### PR TITLE
Header quick wins: sticky, focus ring, touch targets, mobile menu

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1208,6 +1208,76 @@ html {
   --font-display: var(--font-instrument-sans), 'Instrument Sans', system-ui, sans-serif;
 }
 
+/* Mobile hamburger + slide-down panel */
+.nav-burger{
+  display:none;
+  width:44px;height:44px;
+  align-items:center;justify-content:center;
+  flex-direction:column;gap:4px;
+  background:transparent;border:1px solid var(--hair-2);border-radius:8px;
+  cursor:pointer;padding:0;
+  transition:background-color .18s, border-color .18s;
+}
+.nav-burger:hover{background:rgba(232,230,227,0.04);border-color:rgba(232,230,227,0.22)}
+.nav-burger .bar{
+  display:block;width:18px;height:1.5px;background:var(--ink);border-radius:2px;
+  transition:transform .22s ease, opacity .18s ease;transform-origin:center;
+}
+.nav-burger .bar-1.is-open{transform:translateY(5.5px) rotate(45deg)}
+.nav-burger .bar-2.is-open{opacity:0}
+.nav-burger .bar-3.is-open{transform:translateY(-5.5px) rotate(-45deg)}
+
+.nav-panel{
+  display:none;
+  position:absolute;left:0;right:0;top:100%;z-index:39;
+  background:var(--bg);
+  border-bottom:1px solid var(--hair);
+  box-shadow:0 20px 40px -20px rgba(0,0,0,.6);
+  padding:16px 24px 24px;
+  flex-direction:column;gap:12px;
+  animation:nav-panel-in .2s ease-out;
+}
+.nav-panel.is-open{display:flex}
+@keyframes nav-panel-in{
+  from{opacity:0;transform:translateY(-8px)}
+  to{opacity:1;transform:translateY(0)}
+}
+.nav-panel-links{display:flex;flex-direction:column;gap:2px}
+.nav-panel-links a{
+  font-family:var(--font-body), 'Geist', sans-serif;font-weight:400;font-size:16px;
+  color:var(--ink-2);
+  padding:14px 12px;border-radius:8px;min-height:48px;
+  display:inline-flex;align-items:center;gap:8px;
+  transition:color .16s, background-color .16s;
+}
+.nav-panel-links a:hover,.nav-panel-links a:active{color:var(--ink);background:rgba(232,230,227,0.05)}
+.nav-panel-links .new{
+  font-family:'Geist Mono',monospace;font-size:9px;font-weight:500;
+  letter-spacing:.16em;text-transform:uppercase;color:var(--copper);
+  padding:2px 6px;border:1px solid rgba(254,133,49,.3);border-radius:3px;
+}
+.nav-panel-cta{
+  display:flex;flex-direction:column;gap:8px;
+  padding-top:12px;margin-top:4px;
+  border-top:1px solid var(--hair);
+}
+.nav-panel-cta .sign{
+  font-size:15px;color:var(--ink-2);
+  padding:14px 12px;border-radius:8px;min-height:48px;
+  display:inline-flex;align-items:center;
+}
+.nav-panel-cta .btn{justify-content:center;padding:14px 18px;font-size:15px}
+
+/* Collapse desktop nav below 900px */
+@media (max-width:900px){
+  .nav{grid-template-columns:1fr auto auto;gap:12px;padding:12px 20px}
+  nav.links{display:none}
+  .nav-cta{display:none}
+  .nav-burger{display:inline-flex}
+  .brand .name{font-size:22px}
+  .inv-header{padding:12px 20px}
+}
+
 /* Header focus-visible — copper ring for keyboard users, nothing for mouse */
 header a:focus-visible,
 header button:focus-visible,

--- a/app/globals.css
+++ b/app/globals.css
@@ -306,27 +306,28 @@ html {
     padding:16px 40px;
     display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:48px;
   }
-  .brand{display:flex;align-items:center;gap:11px}
+  .brand{display:flex;align-items:center;gap:11px;min-height:44px;padding:4px 6px;margin-left:-6px;border-radius:6px}
   .brand img{width:26px;height:26px;display:block}
   .brand .name{
     font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;font-size:24px;
     letter-spacing:-.01em;color:var(--ink);
   }
-  nav.links{display:flex;gap:36px;justify-self:center}
+  nav.links{display:flex;gap:24px;justify-self:center}
   nav.links a{
     font-family:var(--font-body), 'Geist', sans-serif;font-weight:400;font-size:14px;
     color:var(--ink-2);display:inline-flex;align-items:center;gap:6px;
-    transition:color .16s;
+    padding:11px 8px;border-radius:6px;
+    transition:color .16s, background-color .16s;
   }
-  nav.links a:hover{color:var(--ink)}
+  nav.links a:hover{color:var(--ink);background:rgba(232,230,227,0.04)}
   nav.links .new{
     font-family:'Geist Mono',monospace;font-size:9px;font-weight:500;
     letter-spacing:.16em;text-transform:uppercase;color:var(--copper);
     padding:2px 6px;border:1px solid rgba(254,133,49,.3);border-radius:3px;
   }
   .nav-cta{display:flex;gap:10px;align-items:center}
-  .nav-cta a.sign{font-size:14px;color:var(--ink-2);padding:8px 12px}
-  .nav-cta a.sign:hover{color:var(--ink)}
+  .nav-cta a.sign{font-size:14px;color:var(--ink-2);padding:11px 14px;border-radius:6px;min-height:44px;display:inline-flex;align-items:center;transition:color .16s, background-color .16s}
+  .nav-cta a.sign:hover{color:var(--ink);background:rgba(232,230,227,0.04)}
   .btn{
     display:inline-flex;align-items:center;gap:8px;cursor:pointer;
     font-family:var(--font-body), 'Geist', sans-serif;font-weight:500;font-size:14px;

--- a/app/globals.css
+++ b/app/globals.css
@@ -1206,3 +1206,19 @@ html {
   --font-body: var(--font-instrument-sans), 'Instrument Sans', system-ui, sans-serif;
   --font-display: var(--font-instrument-sans), 'Instrument Sans', system-ui, sans-serif;
 }
+
+/* Header focus-visible — copper ring for keyboard users, nothing for mouse */
+header a:focus-visible,
+header button:focus-visible,
+.inv-header a:focus-visible,
+.inv-header button:focus-visible{
+  outline:2px solid var(--copper);
+  outline-offset:3px;
+  border-radius:4px;
+}
+header a:focus:not(:focus-visible),
+header button:focus:not(:focus-visible),
+.inv-header a:focus:not(:focus-visible),
+.inv-header button:focus:not(:focus-visible){
+  outline:none;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -218,8 +218,8 @@ html {
   a{color:inherit;text-decoration:none}
 
   /* ambient glow removed — Anthropic-style clean hero */
-  .page{position:relative;overflow:hidden}
-  .page > *{position:relative;z-index:1}
+  .page{position:relative;overflow-x:clip}
+  .page > *:not(header):not(.inv-header){position:relative;z-index:1}
 
   /* ═══════════ Hub diagram (replaces product mock) ═══════════ */
   .hub-wrap{max-width:1280px;margin:72px auto 0;padding:0 40px}

--- a/components/MarketingHeader.tsx
+++ b/components/MarketingHeader.tsx
@@ -1,3 +1,7 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
 type Variant = 'product' | 'investor';
 
 interface MarketingHeaderProps {
@@ -5,54 +9,134 @@ interface MarketingHeaderProps {
 }
 
 export function MarketingHeader({ variant = 'product' }: MarketingHeaderProps) {
-  if (variant === 'investor') {
-    return (
-      <header className="inv-header">
-        <div className="nav">
-          <a className="brand" href="/">
-            <img src="/salency-mark.png" alt="" />
-            <span className="name">Salency</span>
-          </a>
-          <nav className="links">
-            <a href="/">Product</a>
-            <a href="#platform">Platform</a>
-            <a href="#team">Team</a>
-            <a href="#thesis">Thesis</a>
-          </nav>
-          <div className="nav-cta">
-            <a href="mailto:howard@salency.com" className="sign">
-              Contact Howard
-            </a>
-            <a href="/" className="btn btn-ghost">
-              ← Back to product
-            </a>
-          </div>
-        </div>
-      </header>
-    );
-  }
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => e.key === 'Escape' && setOpen(false);
+    document.addEventListener('keydown', onKey);
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.body.style.overflow = '';
+    };
+  }, [open]);
+
+  const isInvestor = variant === 'investor';
+
+  const links = isInvestor
+    ? [
+        { href: '/', label: 'Product' },
+        { href: '#platform', label: 'Platform' },
+        { href: '#team', label: 'Team' },
+        { href: '#thesis', label: 'Thesis' },
+      ]
+    : [
+        { href: '#how-it-works', label: 'How it works' },
+        { href: '#', label: 'Memory', badge: 'New' },
+        { href: '#', label: 'vs AI notetakers' },
+        { href: '/investor', label: 'Investors' },
+        { href: '#', label: 'Pricing' },
+      ];
 
   return (
-    <header>
+    <header className={isInvestor ? 'inv-header' : undefined}>
       <div className="nav">
         <a className="brand" href="/">
           <img src="/salency-mark.png" alt="" />
           <span className="name">Salency</span>
         </a>
+
         <nav className="links">
-          <a href="#how-it-works">How it works</a>
-          <a href="#">
-            Memory <span className="new">New</span>
-          </a>
-          <a href="#">vs AI notetakers</a>
-          <a href="/investor">Investors</a>
-          <a href="#">Pricing</a>
+          {links.map((l) => (
+            <a key={l.label} href={l.href}>
+              {l.label}
+              {'badge' in l && l.badge && <span className="new">{l.badge}</span>}
+            </a>
+          ))}
         </nav>
+
         <div className="nav-cta">
-          <a href="#" className="sign">
-            Sign in
-          </a>
-          <button className="btn btn-primary">Request a pilot →</button>
+          {isInvestor ? (
+            <>
+              <a href="mailto:howard@salency.com" className="sign">
+                Contact Howard
+              </a>
+              <a href="/" className="btn btn-ghost">
+                ← Back to product
+              </a>
+            </>
+          ) : (
+            <>
+              <a href="#" className="sign">
+                Sign in
+              </a>
+              <button className="btn btn-primary">Request a pilot →</button>
+            </>
+          )}
+        </div>
+
+        <button
+          type="button"
+          className="nav-burger"
+          aria-label={open ? 'Close menu' : 'Open menu'}
+          aria-expanded={open}
+          aria-controls="mobile-menu"
+          onClick={() => setOpen((v) => !v)}
+        >
+          <span className={open ? 'bar bar-1 is-open' : 'bar bar-1'} />
+          <span className={open ? 'bar bar-2 is-open' : 'bar bar-2'} />
+          <span className={open ? 'bar bar-3 is-open' : 'bar bar-3'} />
+        </button>
+      </div>
+
+      <div
+        id="mobile-menu"
+        className={open ? 'nav-panel is-open' : 'nav-panel'}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Site navigation"
+        hidden={!open}
+      >
+        <nav className="nav-panel-links">
+          {links.map((l) => (
+            <a key={l.label} href={l.href} onClick={() => setOpen(false)}>
+              {l.label}
+              {'badge' in l && l.badge && <span className="new">{l.badge}</span>}
+            </a>
+          ))}
+        </nav>
+        <div className="nav-panel-cta">
+          {isInvestor ? (
+            <>
+              <a
+                href="mailto:howard@salency.com"
+                className="sign"
+                onClick={() => setOpen(false)}
+              >
+                Contact Howard
+              </a>
+              <a
+                href="/"
+                className="btn btn-ghost"
+                onClick={() => setOpen(false)}
+              >
+                ← Back to product
+              </a>
+            </>
+          ) : (
+            <>
+              <a href="#" className="sign" onClick={() => setOpen(false)}>
+                Sign in
+              </a>
+              <button
+                className="btn btn-primary"
+                onClick={() => setOpen(false)}
+              >
+                Request a pilot →
+              </button>
+            </>
+          )}
         </div>
       </div>
     </header>


### PR DESCRIPTION
Implements the 4 Quick Wins from issue #4.

## Commits
- `bde18e1` **HIGH-2** restore sticky header (`.page > *:not(header)` + `overflow-x:clip`)
- `e172713` **MEDIUM-1** copper `:focus-visible` ring replaces Chrome blue
- `3a791aa` **HIGH-3** touch targets hit 44px (nav links, Sign in, brand wrapper)
- `bd7c07b` **HIGH-1** client-component header with 900px breakpoint, hamburger + slide-down panel, Escape-close, body-scroll lock

## Verification
Screenshots taken at 375 / 768 / 1440 on both `/` and `/investor`. Desktop layout unchanged. Mobile panel opens/closes, locks body scroll, closes on link tap. Sticky confirmed via scroll test (`header.top = 0` at scrollY = 400). Build green.

## Still open (tracked in #4 for follow-up)
- MEDIUM-2 visible hover
- MEDIUM-3 active-page indicator
- HIGH-4 variant fork / wayfinding
- POLISH-1 / POLISH-2

Closes the Quick Wins portion of #4.