### PR TITLE
Unify header chrome across product + investor variants

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -219,7 +219,7 @@ html {
 
   /* ambient glow removed — Anthropic-style clean hero */
   .page{position:relative;overflow-x:clip}
-  .page > *:not(header):not(.inv-header){position:relative;z-index:1}
+  .page > *:not(header){position:relative;z-index:1}
 
   /* ═══════════ Hub diagram (replaces product mock) ═══════════ */
   .hub-wrap{max-width:1280px;margin:72px auto 0;padding:0 40px}
@@ -1147,11 +1147,6 @@ html {
   }
   .inv-page > *{position:relative;z-index:1}
 
-  .inv-header{
-    max-width:1280px;margin:0 auto;padding:24px 40px;
-    border-bottom:1px solid var(--hair);
-  }
-
   .inv-intro{
     max-width:1280px;margin:0 auto;padding:100px 40px 80px;
     border-bottom:1px solid var(--hair);position:relative;
@@ -1275,21 +1270,16 @@ html {
   .nav-cta{display:none}
   .nav-burger{display:inline-flex}
   .brand .name{font-size:22px}
-  .inv-header{padding:12px 20px}
 }
 
 /* Header focus-visible — copper ring for keyboard users, nothing for mouse */
 header a:focus-visible,
-header button:focus-visible,
-.inv-header a:focus-visible,
-.inv-header button:focus-visible{
+header button:focus-visible{
   outline:2px solid var(--copper);
   outline-offset:3px;
   border-radius:4px;
 }
 header a:focus:not(:focus-visible),
-header button:focus:not(:focus-visible),
-.inv-header a:focus:not(:focus-visible),
-.inv-header button:focus:not(:focus-visible){
+header button:focus:not(:focus-visible){
   outline:none;
 }

--- a/components/MarketingHeader.tsx
+++ b/components/MarketingHeader.tsx
@@ -40,7 +40,7 @@ export function MarketingHeader({ variant = 'product' }: MarketingHeaderProps) {
       ];
 
   return (
-    <header className={isInvestor ? 'inv-header' : undefined}>
+    <header>
       <div className="nav">
         <a className="brand" href="/">
           <img src="/salency-mark.png" alt="" />


### PR DESCRIPTION
Addresses **HIGH-4** from issue #4: two header variants silently forked the visual chrome (different padding, different height, no blur/sticky on investor), which broke wayfinding between pages.

## What changed
- `components/MarketingHeader.tsx` — drop the `inv-header` class; `<header>` renders plain on both variants.
- `app/globals.css` — remove `.inv-header` rule (the padding override), its mobile breakpoint override, its focus-visible selectors, and the `:not(.inv-header)` exclusion on `.page > *`.

## What stays different per variant
Content only. Links and the right-side CTA swap by prop:
- product: How it works / Memory / vs AI notetakers / Investors / Pricing + pilot CTA
- investor: Product / Platform / Team / Thesis + Contact Howard / Back to product

## Verification
Both pages now report identical chrome:
- height: **78px** · padding: **16px 40px** · className: empty
- same sticky+blur background, same border-bottom, same z-index
- mobile hamburger + slide-down panel work for both

Screenshots: `.design-review/screenshots/after-header-{product,investor}.png`.

Closes HIGH-4 portion of #4.