### PR TITLE
Header polish: stronger hover, active-page state, nav separator

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -314,18 +314,32 @@ html {
   }
   nav.links{display:flex;gap:24px;justify-self:center}
   nav.links a{
+    position:relative;
     font-family:var(--font-body), 'Geist', sans-serif;font-weight:400;font-size:14px;
     color:var(--ink-2);display:inline-flex;align-items:center;gap:6px;
     padding:11px 8px;border-radius:6px;
     transition:color .16s, background-color .16s;
   }
-  nav.links a:hover{color:var(--ink);background:rgba(232,230,227,0.04)}
+  nav.links a::after{
+    content:"";position:absolute;left:8px;right:8px;bottom:6px;height:1px;
+    background:var(--copper);
+    transform:scaleX(0);transform-origin:left center;
+    transition:transform .2s ease;
+  }
+  nav.links a:hover{color:var(--ink);background:rgba(232,230,227,0.06)}
+  nav.links a:hover::after{transform:scaleX(1)}
+  nav.links a.is-active{color:var(--ink)}
+  nav.links a.is-active::after{transform:scaleX(1)}
   nav.links .new{
     font-family:'Geist Mono',monospace;font-size:9px;font-weight:500;
     letter-spacing:.16em;text-transform:uppercase;color:var(--copper);
     padding:2px 6px;border:1px solid rgba(254,133,49,.3);border-radius:3px;
   }
-  .nav-cta{display:flex;gap:10px;align-items:center}
+  .nav-cta{display:flex;gap:10px;align-items:center;padding-left:16px;position:relative}
+  .nav-cta::before{
+    content:"";position:absolute;left:0;top:50%;transform:translateY(-50%);
+    width:1px;height:20px;background:var(--hair-2);
+  }
   .nav-cta a.sign{font-size:14px;color:var(--ink-2);padding:11px 14px;border-radius:6px;min-height:44px;display:inline-flex;align-items:center;transition:color .16s, background-color .16s}
   .nav-cta a.sign:hover{color:var(--ink);background:rgba(232,230,227,0.04)}
   .btn{
@@ -1246,6 +1260,7 @@ html {
   transition:color .16s, background-color .16s;
 }
 .nav-panel-links a:hover,.nav-panel-links a:active{color:var(--ink);background:rgba(232,230,227,0.05)}
+.nav-panel-links a.is-active{color:var(--ink);box-shadow:inset 2px 0 0 var(--copper);background:rgba(254,133,49,0.04)}
 .nav-panel-links .new{
   font-family:'Geist Mono',monospace;font-size:9px;font-weight:500;
   letter-spacing:.16em;text-transform:uppercase;color:var(--copper);

--- a/components/MarketingHeader.tsx
+++ b/components/MarketingHeader.tsx
@@ -1,8 +1,16 @@
 'use client';
 
+import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 type Variant = 'product' | 'investor';
+
+function isActive(href: string, pathname: string): boolean {
+  if (!href || href === '#' || href.startsWith('mailto:')) return false;
+  if (href.startsWith('#')) return false;
+  if (href === '/') return pathname === '/';
+  return pathname === href || pathname.startsWith(href + '/');
+}
 
 interface MarketingHeaderProps {
   variant?: Variant;
@@ -10,6 +18,7 @@ interface MarketingHeaderProps {
 
 export function MarketingHeader({ variant = 'product' }: MarketingHeaderProps) {
   const [open, setOpen] = useState(false);
+  const pathname = usePathname() ?? '/';
 
   useEffect(() => {
     if (!open) return;
@@ -48,12 +57,20 @@ export function MarketingHeader({ variant = 'product' }: MarketingHeaderProps) {
         </a>
 
         <nav className="links">
-          {links.map((l) => (
-            <a key={l.label} href={l.href}>
-              {l.label}
-              {'badge' in l && l.badge && <span className="new">{l.badge}</span>}
-            </a>
-          ))}
+          {links.map((l) => {
+            const active = isActive(l.href, pathname);
+            return (
+              <a
+                key={l.label}
+                href={l.href}
+                className={active ? 'is-active' : undefined}
+                aria-current={active ? 'page' : undefined}
+              >
+                {l.label}
+                {'badge' in l && l.badge && <span className="new">{l.badge}</span>}
+              </a>
+            );
+          })}
         </nav>
 
         <div className="nav-cta">
@@ -99,12 +116,21 @@ export function MarketingHeader({ variant = 'product' }: MarketingHeaderProps) {
         hidden={!open}
       >
         <nav className="nav-panel-links">
-          {links.map((l) => (
-            <a key={l.label} href={l.href} onClick={() => setOpen(false)}>
-              {l.label}
-              {'badge' in l && l.badge && <span className="new">{l.badge}</span>}
-            </a>
-          ))}
+          {links.map((l) => {
+            const active = isActive(l.href, pathname);
+            return (
+              <a
+                key={l.label}
+                href={l.href}
+                className={active ? 'is-active' : undefined}
+                aria-current={active ? 'page' : undefined}
+                onClick={() => setOpen(false)}
+              >
+                {l.label}
+                {'badge' in l && l.badge && <span className="new">{l.badge}</span>}
+              </a>
+            );
+          })}
         </nav>
         <div className="nav-panel-cta">
           {isInvestor ? (


### PR DESCRIPTION
Addresses **MEDIUM-2**, **MEDIUM-3**, and **POLISH-1** from issue #4.

## What changed

### MEDIUM-2 · Nav hover reads as clickable
Each nav link gets a `::after` pseudo-element that draws a 1px copper underline on hover via `transform: scaleX` transition, plus a denser 6%-white pill background (up from 4%). Visible at reading distance on the dark bar.

### MEDIUM-3 · Active-page indicator
`MarketingHeader` imports `usePathname` and computes `isActive` per link — handles `/`, hash anchors, mailto, and nested routes. Matched links get `.is-active` + `aria-current="page"`. Active state reuses the copper underline + ink color so hover and active feel like the same system. Mobile panel version uses an inset-left copper bar.

**Note:** currently dormant because neither variant's link set cross-references the other page (product nav has `/investor`; investor nav has `/`, but user is on `/` when product nav shows and on `/investor` when investor nav shows). Lights up automatically when nav content is later unified.

### POLISH-1 · Separator between nav and CTA
Thin 1px × 20px hair rule inserted via `.nav-cta::before` at 16px left-padding. CTA group now reads as a distinct region from the primary nav.

## Verification
Screenshots at `.design-review/screenshots/polish-{product,investor,hover3}.png`. Build green. Hover test via `browse hover` shows copper underline + pill on "vs AI notetakers".

## Still open (tracked in #4)
- HIGH-4 variant unify → **merged** in #6
- POLISH-2 inline SVG brand mark → deferred (existing logo.svg is 87KB, needs simpler mark asset)

Closes MEDIUM-2, MEDIUM-3, POLISH-1 portion of #4.