### PR TITLE
YC lie-strip: remove fabricated proof from landing + investor pages

### DIFF
--- a/app/investor/page.tsx
+++ b/app/investor/page.tsx
@@ -26,7 +26,7 @@ export default function Investor() {
           <div className="inv-intro-meta">
             <span>Pre-seed · Q2 2026</span>
             <span className="sep">·</span>
-            <span>4 of 10 pilot spots open</span>
+            <span>Early access opening Q2 2026</span>
             <span className="sep">·</span>
             <span>Private deck available on request</span>
           </div>
@@ -194,7 +194,7 @@ export default function Investor() {
           <a href="#">Deck (on request)</a>
           <a href="#">Security</a>
         </nav>
-        <span>© 2026 Salency, Inc. · SOC 2 Type II · Pre-seed</span>
+        <span>© 2026 Salency · Toronto · Pre-seed</span>
       </footer>
     </div>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,13 +28,10 @@ export default function Home() {
 
         <div className="hero-meta">
           <span>
-            <span className="dot">●</span> SOC 2 Type II
-          </span>
-          <span>
-            <span className="dot">●</span> Deploys in 48 hrs
-          </span>
-          <span>
             <span className="dot">●</span> Works alongside your notetaker
+          </span>
+          <span>
+            <span className="dot">●</span> Early access · Q2 2026
           </span>
         </div>
       </section>
@@ -174,55 +171,9 @@ export default function Home() {
           <div className="hub-foot">
             <span>One pipeline · every role · zero handoff loss</span>
             <span>
-              <em>4 of 10</em> pilot spots open · Q2 2026
+              <em>Early access</em> · Q2 2026
             </span>
           </div>
-        </div>
-      </section>
-
-      <section className="stats">
-        <div>
-          <div className="n">
-            <em>4</em>
-            <span className="u">hrs</span>
-          </div>
-          <div className="lbl">Per rep, per week — back from status-update busywork</div>
-          <div className="src">Pilot cohort · n=42</div>
-        </div>
-        <div>
-          <div className="n">
-            <em>68</em>
-            <span className="u">%</span>
-          </div>
-          <div className="lbl">Faster AE ramp-to-quota for reps inheriting Salency accounts</div>
-          <div className="src">90-day window</div>
-        </div>
-        <div>
-          <div className="n">
-            <em>3</em>
-            <span className="u">×</span>
-          </div>
-          <div className="lbl">Lower post-handoff churn versus unstructured transition</div>
-          <div className="src">YoY, matched cohort</div>
-        </div>
-        <div>
-          <div className="n">
-            <em>0</em>
-          </div>
-          <div className="lbl">New tabs, new dashboards, new logins for your reps</div>
-          <div className="src">Lives inside your notetaker + CRM</div>
-        </div>
-      </section>
-
-      <section className="logo-bar">
-        <div className="label">In pilot with revenue teams at</div>
-        <div className="logos">
-          <span className="logo-item">Northwind</span>
-          <span className="logo-item sans">PATINA HEALTH</span>
-          <span className="logo-item">Meridian &amp; Co.</span>
-          <span className="logo-item mono">Orbital/Labs</span>
-          <span className="logo-item">Latchkey</span>
-          <span className="logo-item sans">ARGENT</span>
         </div>
       </section>
 
@@ -391,9 +342,8 @@ export default function Home() {
               — the unprompted pain at minute 42 — stays locked in the audio.
             </p>
             <div className="cost">
-              <span className="num">0%</span>
               <span className="lbl">
-                of call transcripts are read past the first listen
+                Transcripts are the artifact no one scrubs after the handoff.
               </span>
             </div>
           </div>
@@ -410,9 +360,10 @@ export default function Home() {
               asking again.
             </p>
             <div className="cost">
-              <span className="num">3×</span>
+              <span className="num">40–50%</span>
               <span className="lbl">
-                higher churn on accounts after an unstructured handoff
+                of customers visibly frustrated when asked to repeat themselves ·
+                Customer interview, Jan 2026
               </span>
             </div>
           </div>
@@ -428,9 +379,8 @@ export default function Home() {
               re-encoding information the system already has.
             </p>
             <div className="cost">
-              <span className="num">4hrs</span>
               <span className="lbl">
-                per rep, per week, lost to manual context transfer
+                Hours spent re-encoding what the recording already captured.
               </span>
             </div>
           </div>
@@ -556,21 +506,21 @@ export default function Home() {
 
       <section className="cta-section">
         <div className="cta-card">
-          <div className="eb">Limited pilot · Q1 2026</div>
+          <div className="eb">Early access · Q2 2026</div>
           <h2>
             Stop paying the <em>ramp-time tax.</em>
           </h2>
           <p className="sub">
-            Twelve revenue teams. Ninety days. A memory layer that outlasts any
-            rep. Request a pilot slot — we&apos;re onboarding four more teams
-            this quarter.
+            A memory layer that outlasts any rep. We&apos;re opening early access
+            to a small group of revenue teams this quarter. Request a slot and
+            we&apos;ll scope a fit together.
           </p>
           <div className="btns">
-            <button className="btn btn-primary">Request a pilot →</button>
+            <button className="btn btn-primary">Request early access →</button>
             <button className="btn btn-ghost">Read the memo</button>
           </div>
           <div className="fine">
-            No card required · 30-minute scoping call · Deploys alongside your AI
+            No card required · 30-minute scoping call · Works alongside your AI
             notetaker
           </div>
         </div>
@@ -585,7 +535,7 @@ export default function Home() {
           <a href="/investor">Investors</a>
           <a href="#">Careers</a>
         </nav>
-        <span>© 2026 Salency, Inc. · SOC 2 Type II</span>
+        <span>© 2026 Salency · Toronto</span>
       </footer>
     </div>
   );


### PR DESCRIPTION
Content-hygiene pass ahead of YC W26 application (due 2026-05-04). Source of truth: `/Users/howard/Documents/Salency/company-context.md` §17 (landing page state), §21 (execution risks), §25 (what NOT to include).

Every edit maps to a fabrication flagged in that doc.

## Stripped (product page)

| Claim | Why false | Replacement |
|---|---|---|
| Hero meta: `SOC 2 Type II` | Not audited (§25, §24) | Removed |
| Hero meta: `Deploys in 48 hrs` | No real deploys shipped (§25) | Replaced with `Early access · Q2 2026` |
| Hub footer: `4 of 10 pilot spots open` | Zero active pilots (§12) | `Early access · Q2 2026` |
| Problem card i: `0% of transcripts read` | Unsourced | Qualitative framing, no number |
| Problem card ii: `3× higher churn` | Unsourced | Replaced with sourced stat: `40–50% of customers visibly frustrated when asked to repeat themselves · Customer interview, Jan 2026` (Erica, §3) |
| Problem card iii: `4hrs per rep per week` | Unsourced | Qualitative framing, no number |
| Stats strip (entire section) | All 4 numbers fabricated — `n=42 pilot cohort`, `68% ramp lift`, `3x churn`, `0 new tabs` | **Section removed** |
| Logo bar: `In pilot with revenue teams at` + 6 logos | Zero customers (§12, §21) | **Section removed** |
| CTA: `Twelve revenue teams. Ninety days.`, `four more teams this quarter`, `Limited pilot · Q1 2026` | Invented + stale | Rewritten: honest `Early access · Q2 2026` + scoping-call framing |
| Footer: `Salency, Inc. · SOC 2 Type II` | Not incorporated + not audited (§24) | `© 2026 Salency · Toronto` |

## Stripped (investor page)

| Claim | Why false | Replacement |
|---|---|---|
| Intro meta: `4 of 10 pilot spots open` | Zero pilots | `Early access opening Q2 2026` |
| Footer: `Salency, Inc. · SOC 2 Type II · Pre-seed` | Not incorporated + not audited | `Salency · Toronto · Pre-seed` |

## Preserved (verified against context)

- Locked hero — §2 / §20 lock #22. `Institutional memory for revenue teams. Not another call recorder.`
- Platform framing — `investor copy.md` approved verbatim.
- V1.5 roadmap — approved verbatim.
- Team bios (Howard, Nikki, Babajide) — approved verbatim, Babajide correctly titled `Technical Lead` per §1 staged-ladder rule.
- Gong-comparison table — positioning, no fabricated stats.
- "What Salency is NOT" anti-hype strip — honest by design (§5).
- Future-fit thesis — approved verbatim.

## Verification
Build green. Two new screenshots committed to local `.design-review/screenshots/`:
- `lie-strip-product-full.png`
- `lie-strip-investor-full.png`

## What's still TBD
- POLISH-2 SVG mark still pending merge via #8 (independent).
- Hover / active-page indicator from #7 (merged) carries through.

Ready for YC partners to read without finding invented numbers.