### PR TITLE
Refine how-it-works: Extract / Map / Remember

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -186,9 +186,9 @@ export default function Home() {
             </h2>
           </div>
           <p className="lede">
-            Drop in any transcript — <em>AI notetaker</em>, Zoom, Meet, or a raw
-            .vtt. Salency runs every call through the same three-step pipeline,
-            and the output is{' '}
+            Drop in any transcript: <em>AI notetaker</em>, Zoom, Meet, or a raw
+            .vtt. Salency runs every call through the same pipeline, and the
+            output is{' '}
             <em>structured, cited, and queryable</em> before your next stand-up.
           </p>
         </div>
@@ -199,15 +199,16 @@ export default function Home() {
               <em>Extract</em>
             </h3>
             <p className="desc">
-              Every call is parsed into structured signals: pains, objections,
-              competitors, commitments, timelines, next steps. Not summarised —
-              enumerated. Each one keeps its verbatim quote and timestamp.
+              Every call is parsed into five structured signal types: pains,
+              objections, competitors, requirements, next steps. Enumerated,
+              not summarised. Every signal carries the verbatim quote, the
+              speaker, and the timestamp.
             </p>
             <div className="ex">
-              <div className="el">Example output</div>
+              <div className="el">Example extraction</div>
               <div className="eq">
-                &ldquo;We need to cut AE ramp from 9 months to 4 by Q3.&rdquo;{' '}
-                <strong>→ Commitment</strong> · Priya Shah · Disco 31:08
+                <strong>Pain</strong> · CS director inherits accounts blind at
+                renewal · Priya Shah, VP Sales · 18:02
               </div>
             </div>
           </div>
@@ -217,36 +218,37 @@ export default function Home() {
               <em>Map</em>
             </h3>
             <p className="desc">
-              Each pain is mapped to a line item in your product catalog. Each
-              stakeholder is linked to their role, their account, and every prior
-              quote. The graph grows with every call.
+              Each pain maps to a line in your product catalog, ranked by
+              confidence. Every new call is compared against prior calls on the
+              same account, and contradictions get flagged. The graph keeps
+              growing: pains, products, stakeholders, and how the story has
+              changed over time.
             </p>
             <div className="ex">
               <div className="el">Example mapping</div>
               <div className="eq">
-                Pain:{' '}
-                <em style={{ fontStyle: 'italic' }}>
-                  &ldquo;handoff loses context&rdquo;
-                </em>{' '}
-                <strong>→ Memory Graph + Stakeholder View</strong>
+                Pain <em>&ldquo;handoff loses context&rdquo;</em>{' '}
+                <strong>→ 3 products ranked</strong> · Contradiction flagged vs
+                Disco call, Dec 12
               </div>
             </div>
           </div>
           <div className="how-step">
             <div className="idx">Step 03</div>
             <h3 className="verb">
-              <em>Cite</em>
+              <em>Remember</em>
             </h3>
             <p className="desc">
-              Every field carries the source — transcript, timestamp, speaker,
-              confidence score. The next rep, the next quarter, the next pipeline
-              review can all audit the trail without replaying the call.
+              The next AE inherits a Day-1 brief. The CS director picks up
+              mid-story, not from zero. Pipeline review sees every pain across
+              every account without replaying a single call. The memory
+              outlasts any rep.
             </p>
             <div className="ex">
-              <div className="el">Every extraction</div>
+              <div className="el">Example surface</div>
               <div className="eq">
-                <strong>Cited</strong> to a transcript + timestamp, with a
-                confidence score you can filter on.
+                <strong>Next steps</strong> · Renewal conversation by Mar 15 ·
+                Open commitments: 3
               </div>
             </div>
           </div>
@@ -256,7 +258,7 @@ export default function Home() {
             Works with any transcript.<span className="sep">·</span>
             <em>Citations + confidence scores</em> on every extraction.
           </span>
-          <span>Deploys in 48 hours · alongside your AI notetaker</span>
+          <span>Runs alongside your AI notetaker</span>
         </div>
       </section>
 


### PR DESCRIPTION
CEO-lens copy pass on the how-it-works three-step section.

Source of truth: `company-context.md` §5 (actual pipeline) + §6 (pain-product mapping as money slide).

## Why the old copy missed

| Step | Problem |
|---|---|
| Extract | Signal list said `commitments, timelines`. Real schema per §5 is 5 types: **pains, objections, competitors, requirements, next steps**. Any buyer hitting the demo would catch the mismatch. |
| Map | Buried pain-product mapping (the money slide per §6) under "line item in catalog". **Contradiction detection — half of the uncopyable moat pair per §8 — was missing entirely.** Conflated pain-mapping and stakeholder graph into one vague card. |
| Cite | Weak third card. Citation is an *attribute* of Extract + Map, not its own stage. Wasted the slot that should close the category loop. |
| Footer | Still said "Deploys in 48 hours" — lie per §25 that slipped past the earlier strip. |

## Changes

**Step 01 · Extract**
- Signal list fixed to the real 5 types.
- Example uses a Pain signal (not a fictional Commitment type).

**Step 02 · Map**
- Leads with pain → product, ranked by confidence. Money slide first.
- Names contradiction detection explicitly.
- Describes the compounding graph honestly.

**Step 03 · Remember** *(was: Cite)*
- Closes the category loop. Names the surfaces that outlive rep turnover: Day-1 brief, mid-story CS pickup, cross-account pipeline view.
- "The memory outlasts any rep" echoes the locked hero.

**Lede:** em-dash → colon (§2 bans em-dashes).

**Footer:** dropped "Deploys in 48 hours". Kept "Runs alongside your AI notetaker".

## NOT in scope
- Em-dash sweep across the rest of the page (separate pass).
- Example-text consent check (Priya Shah is a synthetic placeholder matching the existing hub-mock persona).

## Verification
- `npm run build` green.
- Diff: 27 lines in / 25 out, one file.