### PR TITLE
Design polish: how-it-works HIGH-1/2/3 + MEDIUM-1/4 (issue #15)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -842,10 +842,10 @@ html {
   }
   .how-head h2 em{font-style:italic;color:var(--copper)}
   .how-head .lede{
-    font-family:var(--font-body), 'Geist', sans-serif;font-weight:300;font-size:17px;line-height:1.65;
-    color:var(--ink-2);max-width:48ch;
+    font-family:var(--font-body), 'Geist', sans-serif;font-weight:300;font-size:19px;line-height:1.55;
+    color:var(--ink-2);max-width:42ch;
   }
-  .how-head .lede em{font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;color:var(--ink);font-size:18px;font-weight:400}
+  .how-head .lede em{font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;color:var(--ink);font-size:20px;font-weight:400}
   .how-steps{display:grid;grid-template-columns:repeat(3,1fr);gap:0;border-top:1px solid var(--hair-2)}
   .how-step{padding:36px 32px 36px 0;border-right:1px solid var(--hair);position:relative}
   .how-step:nth-child(n+2){padding-left:32px}

--- a/app/globals.css
+++ b/app/globals.css
@@ -850,6 +850,12 @@ html {
   .how-step{padding:36px 32px 36px 0;border-right:1px solid var(--hair);position:relative}
   .how-step:nth-child(n+2){padding-left:32px}
   .how-step:last-child{border-right:0}
+  .how-step:not(:last-child)::before{
+    content:"→";position:absolute;right:-10px;top:34px;
+    width:20px;height:20px;display:flex;align-items:center;justify-content:center;
+    background:var(--bg);color:var(--copper);font-size:14px;font-weight:400;
+    font-family:'Geist Mono',monospace;z-index:1;
+  }
   .how-step .idx{
     font-family:'Geist Mono',monospace;font-size:11px;font-weight:500;
     letter-spacing:.2em;text-transform:uppercase;color:var(--copper);

--- a/components/sections/HowItWorksSection.tsx
+++ b/components/sections/HowItWorksSection.tsx
@@ -51,8 +51,7 @@ export function HowItWorksSection() {
             <div className="el">Example mapping</div>
             <div className="eq">
               Pain <em>&ldquo;handoff loses context&rdquo;</em>{' '}
-              <strong>→ 3 products ranked</strong> · Contradiction flagged vs
-              Disco call, Dec 12
+              <strong>→ 3 products ranked</strong>, contradictions flagged
             </div>
           </div>
         </div>

--- a/components/sections/HowItWorksSection.tsx
+++ b/components/sections/HowItWorksSection.tsx
@@ -9,9 +9,8 @@ export function HowItWorksSection() {
           </h2>
         </div>
         <p className="lede">
-          Drop in any transcript: <em>AI notetaker</em>, Zoom, Meet, or a raw
-          .vtt. Salency runs every call through the same pipeline, and the
-          output is{' '}
+          Every transcript, <em>AI notetaker</em> or raw .vtt, runs through the
+          same pipeline. The output is{' '}
           <em>structured, cited, and queryable</em> before your next stand-up.
         </p>
       </div>

--- a/components/sections/HowItWorksSection.tsx
+++ b/components/sections/HowItWorksSection.tsx
@@ -80,7 +80,6 @@ export function HowItWorksSection() {
           Works with any transcript.<span className="sep">·</span>
           Citations and confidence scores on every extraction.
         </span>
-        <span>Runs alongside your AI notetaker</span>
       </div>
     </section>
   );

--- a/components/sections/HowItWorksSection.tsx
+++ b/components/sections/HowItWorksSection.tsx
@@ -78,7 +78,7 @@ export function HowItWorksSection() {
       <div className="how-foot">
         <span>
           Works with any transcript.<span className="sep">·</span>
-          <em>Citations + confidence scores</em> on every extraction.
+          Citations and confidence scores on every extraction.
         </span>
         <span>Runs alongside your AI notetaker</span>
       </div>


### PR DESCRIPTION
## Summary
Ship the three HIGH findings from issue #15 plus two MEDIUMs that cluster cleanly with them. Five commits, one per finding. Scope limited to `components/sections/HowItWorksSection.tsx` and the `.how*` rules in `app/globals.css`.

## Changes

| # | Finding | Type | Files |
|---|---------|------|-------|
| 1 | HIGH-2 — trim Step 02 example to one line | JSX | `HowItWorksSection.tsx` |
| 2 | MEDIUM-1 — reduce copper-emphasis density | JSX | `HowItWorksSection.tsx` |
| 3 | MEDIUM-4 — drop orphan footer span | JSX | `HowItWorksSection.tsx` |
| 4 | HIGH-3 — lede hierarchy match (also lands POLISH-3) | JSX + CSS | both |
| 5 | HIGH-1 — directional arrows between pipeline steps | CSS | `globals.css` |

## Taste calls made (per issue #15 options)
- **HIGH-1:** chose copper → chevron glyphs between columns over horizontal connecting line. Arrows are explicit directional signal, don't require pixel-perfect y-offset math. Line version was fiddly for marginal gain.
- **HIGH-3:** tightened both sides (strip "Drop in any transcript:" prefix, bump lede to 19px / em to 20px, max-width 48ch → 42ch) instead of dropping the right column or rewriting entirely.
- **MEDIUM-1:** dropped italic-copper only from the footer "Citations + confidence scores" phrase and swapped "+" for "and". Kept the 3 pipeline verbs + "Every call," headline emphasis. Net 7 → 6 copper emphases, all pointing at the pipeline.

## Not in scope (deferred from issue #15)
- MEDIUM-2 — example-box eyebrow 9.5px → 11px
- MEDIUM-3 — desc `max-width:34ch` → column fill
- POLISH-1 — drop idx `::after` hairline noise
- POLISH-2 — drop `.how-foot` top border

These are lower-priority, don't cluster with the HIGHs, and can ship in a follow-up polish pass before YC if time allows.

## Verified
- `npm run build` clean (Next.js 16.1.4 + Turbopack)
- All 12 routes prerender: `/`, `/investors`, `/memory`, `/pricing`, `/why-salency`, `/privacy`, `/terms`, etc.
- No TypeScript errors

## Test plan
- [ ] Vercel preview renders `/#how-it-works` with → arrows between Step 01→02 and 02→03
- [ ] Step 02 example now fits one line ("Pain 'handoff loses context' → 3 products ranked, contradictions flagged")
- [ ] Lede reads "Every transcript, AI notetaker or raw .vtt, runs through the same pipeline..." at 19px
- [ ] Footer reads one line: "Works with any transcript. · Citations and confidence scores on every extraction."
- [ ] Middle column no longer overhangs (grid symmetric)

## Sequence
Branched off test-revamp after PR #18 (content restore) merged. If test-revamp → main sync happens next, these polish changes forward with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)