### PR TITLE
feat(hub): interactive pipeline animation triggered on hover

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -239,52 +239,185 @@ html {
   .hub-head .eb.r .arr{color:var(--ink-4)}
   .hub-lines{position:absolute;inset:0;width:100%;height:100%;z-index:1}
   .hub-inputs{position:absolute;left:28px;top:0;bottom:0;width:220px;z-index:2}
-  .hub-pill{
-    position:absolute;transform:translateY(-50%);
-    display:inline-flex;align-items:center;gap:10px;
-    background:rgba(26,23,30,.92);border:1px solid var(--hair-2);border-radius:8px;
-    padding:10px 14px;font-family:var(--font-body), 'Geist', sans-serif;font-size:13px;color:var(--ink);
-    backdrop-filter:blur(6px);box-shadow:0 2px 10px rgba(0,0,0,.25);
+  .hub-input{
+    position:absolute;
+    display:flex;flex-direction:column;align-items:center;gap:8px;
+    width:100px;left:60px;
+    --dy:0px;
+    transform:translate(0,-50%) scale(1);
+    opacity:1;
+    filter:blur(0);
+    will-change:transform,opacity,filter;
   }
-  .hub-pill .ic{font-size:14px}
+  .hub-input:nth-child(1){--dy:157px}
+  .hub-input:nth-child(2){--dy:62px}
+  .hub-input:nth-child(3){--dy:-50px}
+  .hub-input:nth-child(4){--dy:-146px}
+  .hub-wrap.played .hub-input{
+    animation:hub-throw 4.5s cubic-bezier(.55,.08,.3,1) both;
+  }
+  .hub-wrap.played .hub-input:nth-child(1){animation-delay:0s}
+  .hub-wrap.played .hub-input:nth-child(2){animation-delay:1s}
+  .hub-wrap.played .hub-input:nth-child(3){animation-delay:2s}
+  .hub-wrap.played .hub-input:nth-child(4){animation-delay:3s}
+  .hub-input-ic{
+    width:48px;height:48px;display:flex;align-items:center;justify-content:center;
+    border-radius:10px;
+    filter:drop-shadow(0 4px 10px rgba(0,0,0,.35));
+  }
+  .hub-input-lbl{
+    font-family:var(--font-body), 'Geist', sans-serif;font-size:12px;color:var(--ink);
+    letter-spacing:.01em;text-align:center;line-height:1.25;
+  }
+  @keyframes hub-throw{
+    0%   {transform:translate(0,-50%) scale(1);opacity:1;filter:blur(0)}
+    2%   {transform:translate(0,-50%) scale(1);opacity:1;filter:blur(0)}
+    30%  {transform:translate(300px,calc(-50% + var(--dy) * .7)) scale(.55);opacity:.85;filter:blur(.4px)}
+    50%  {transform:translate(460px,calc(-50% + var(--dy))) scale(.12);opacity:0;filter:blur(1.5px)}
+    51%  {transform:translate(0,-50%) scale(1);opacity:0;filter:blur(0)}
+    75%  {transform:translate(0,-50%) scale(1);opacity:1;filter:blur(0)}
+    100% {transform:translate(0,-50%) scale(1);opacity:1;filter:blur(0)}
+  }
+  @media (prefers-reduced-motion: reduce){
+    .hub-input{animation:none;transform:translateY(-50%)}
+  }
   .hub-core{
     position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:2;
-    background:linear-gradient(180deg,#221E28 0%,#181520 100%);
-    border:1px solid rgba(254,133,49,.22);border-radius:14px;
-    padding:28px 44px;text-align:center;min-width:360px;
-    box-shadow:0 20px 60px rgba(0,0,0,.5), 0 0 0 1px rgba(254,133,49,.06), inset 0 1px 0 rgba(255,255,255,.04);
+    display:flex;flex-direction:column;align-items:center;gap:16px;
+    text-align:center;
   }
-  .hub-core-eb{
-    font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
-    letter-spacing:.2em;text-transform:uppercase;color:var(--copper);margin-bottom:12px;
+  .hub-core-mark{
+    width:44px;height:44px;object-fit:contain;
+    filter:drop-shadow(0 4px 14px rgba(254,133,49,.32));
   }
-  .hub-core-eb .dot{color:var(--copper);margin-right:6px}
   .hub-core-ttl{
     font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;font-size:30px;
     line-height:1.1;letter-spacing:-.015em;color:var(--ink);white-space:nowrap;
   }
   .hub-core-ttl em{font-style:italic;color:var(--copper)}
-  .hub-core-sub{
-    margin-top:10px;font-family:'Geist Mono',monospace;font-size:11.5px;
-    color:var(--ink-3);letter-spacing:.02em;
+  .hub-outputs{position:absolute;right:28px;top:0;bottom:0;width:280px;z-index:2}
+  .hub-output{
+    --out-delay:0s;
+    position:absolute;left:0;right:0;overflow:hidden;
+    display:flex;align-items:flex-start;gap:12px;
+    background:rgba(26,23,30,.92);border:1px solid rgba(254,133,49,.22);
+    border-radius:8px;padding:12px 14px;
+    backdrop-filter:blur(6px);box-shadow:0 4px 16px rgba(0,0,0,.3);
+    opacity:1;transform:translate(0,-50%);
   }
-  .hub-roles{position:absolute;right:28px;top:0;bottom:0;width:280px;z-index:2}
-  .hub-role{
-    position:absolute;left:0;right:0;transform:translateY(-50%);
-    background:rgba(26,23,30,.92);border:1px solid var(--hair-2);
-    border-left:2px solid var(--copper);border-radius:4px;padding:12px 16px;
-    backdrop-filter:blur(6px);box-shadow:0 2px 10px rgba(0,0,0,.25);
+  .hub-output:nth-child(1){--out-delay:2.3s}
+  .hub-output:nth-child(2){--out-delay:3.2s}
+  .hub-output:nth-child(3){--out-delay:4.1s}
+  .hub-output::before{
+    content:'';position:absolute;inset:0;pointer-events:none;z-index:1;
+    background:linear-gradient(100deg,
+      transparent 30%,
+      rgba(254,133,49,.32) 48%,
+      rgba(254,220,190,.55) 50%,
+      rgba(254,133,49,.32) 52%,
+      transparent 70%);
+    transform:translateX(-100%);
   }
-  .hub-role .rk{
+  .hub-output-ic{
+    width:22px;height:22px;flex-shrink:0;border-radius:50%;
+    background:rgba(254,133,49,.18);color:var(--copper);
+    display:flex;align-items:center;justify-content:center;margin-top:1px;
+    opacity:1;transform:scale(1);
+  }
+  .hub-output-body{
+    display:flex;flex-direction:column;gap:3px;min-width:0;
+  }
+  .hub-wrap.played .hub-output{
+    animation:
+      hub-output-in .35s cubic-bezier(.2,.8,.3,1) var(--out-delay) forwards,
+      hub-output-glow 1.1s ease-out var(--out-delay) forwards;
+  }
+  .hub-wrap.played .hub-output::before{
+    animation:hub-output-sweep .9s cubic-bezier(.3,.7,.3,1) var(--out-delay) forwards;
+  }
+  .hub-wrap.played .hub-output-ic{
+    animation:hub-output-ic-pop .3s cubic-bezier(.3,1.5,.5,1) calc(var(--out-delay) + .6s) forwards;
+  }
+  .hub-wrap.played .hub-output-body{
+    animation:hub-output-reveal .7s cubic-bezier(.3,.7,.3,1) calc(var(--out-delay) + .1s) forwards;
+  }
+  .hub-output-ttl{
+    font-family:var(--font-body), 'Geist', sans-serif;
+    font-size:13.5px;font-weight:600;color:var(--ink);line-height:1.2;
+  }
+  .hub-output-sub{
+    font-family:var(--font-body), 'Geist', sans-serif;
+    font-size:11.5px;color:var(--ink-3);line-height:1.35;
+  }
+  @keyframes hub-output-in{
+    0%   {opacity:0;transform:translate(-10px,-50%)}
+    100% {opacity:1;transform:translate(0,-50%)}
+  }
+  @keyframes hub-output-sweep{
+    0%   {transform:translateX(-100%)}
+    100% {transform:translateX(100%)}
+  }
+  @keyframes hub-output-reveal{
+    0%   {clip-path:inset(0 100% 0 0)}
+    100% {clip-path:inset(0 0 0 0)}
+  }
+  @keyframes hub-output-ic-pop{
+    0%   {opacity:0;transform:scale(.4)}
+    60%  {opacity:1;transform:scale(1.2)}
+    100% {opacity:1;transform:scale(1)}
+  }
+  @keyframes hub-output-glow{
+    0%   {box-shadow:0 4px 16px rgba(0,0,0,.3), 0 0 0 0 rgba(254,133,49,0)}
+    30%  {box-shadow:0 4px 16px rgba(0,0,0,.3), 0 0 28px 2px rgba(254,133,49,.3)}
+    100% {box-shadow:0 4px 16px rgba(0,0,0,.3), 0 0 0 0 rgba(254,133,49,0)}
+  }
+
+  .hub-outcome{
+    margin-top:24px;
+    background:linear-gradient(180deg,#1A171E 0%,#141119 100%);
+    border:1px solid rgba(254,133,49,.22);border-radius:14px;
+    padding:22px 28px;
+    box-shadow:0 20px 60px rgba(0,0,0,.5), inset 0 1px 0 rgba(255,255,255,.03);
+    opacity:0;transform:translateY(20px) scale(.985);
+  }
+  .hub-wrap.played .hub-outcome{
+    animation:hub-outcome-pop .8s cubic-bezier(.2,.8,.3,1) 5.4s forwards;
+  }
+  .hub-outcome-eb{
+    font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
+    letter-spacing:.2em;text-transform:uppercase;color:var(--copper);margin-bottom:16px;
+  }
+  .hub-outcome-eb .dot{color:var(--copper);margin-right:6px}
+  .hub-outcome-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:28px}
+  .hub-outcome-row{display:flex;flex-direction:column;gap:4px}
+  .hub-outcome-rk{
     font-family:'Geist Mono',monospace;font-size:10px;font-weight:500;
-    letter-spacing:.2em;text-transform:uppercase;color:var(--copper);margin-bottom:4px;
+    letter-spacing:.2em;text-transform:uppercase;color:var(--copper);
   }
-  .hub-role .rt{
-    font-family:var(--font-body), 'Geist', sans-serif;font-size:14px;font-weight:600;color:var(--ink);
+  .hub-outcome-rt{
+    font-family:var(--font-display), 'Instrument Serif', serif;
+    font-weight:400;font-size:22px;line-height:1.15;color:var(--ink);
   }
-  .hub-role .rs{
-    margin-top:3px;font-family:var(--font-body), 'Geist', sans-serif;font-weight:300;
-    font-size:12px;color:var(--ink-3);line-height:1.4;
+  .hub-outcome-rs{
+    font-family:var(--font-body), 'Geist', sans-serif;font-weight:300;
+    font-size:12.5px;color:var(--ink-3);line-height:1.45;
+  }
+  @keyframes hub-outcome-pop{
+    0%   {opacity:0;transform:translateY(20px) scale(.985)}
+    60%  {opacity:1;transform:translateY(-2px) scale(1.005)}
+    100% {opacity:1;transform:translateY(0) scale(1)}
+  }
+
+  @media (prefers-reduced-motion: reduce){
+    .hub-output,
+    .hub-output::before,
+    .hub-output-ic,
+    .hub-output-body{animation:none}
+    .hub-output{opacity:1;transform:translate(0,-50%)}
+    .hub-output::before{display:none}
+    .hub-output-ic{opacity:1;transform:scale(1)}
+    .hub-output-body{clip-path:none}
+    .hub-outcome{animation:none;opacity:1;transform:none}
   }
   .hub-foot{
     position:absolute;left:28px;right:28px;bottom:22px;display:flex;justify-content:space-between;

--- a/components/sections/HubSection.tsx
+++ b/components/sections/HubSection.tsx
@@ -1,13 +1,20 @@
+'use client';
+
+import { useState } from 'react';
+
 export function HubSection() {
+  const [played, setPlayed] = useState(false);
+  const trigger = () => setPlayed(true);
+
   return (
-    <section className="hub-wrap">
+    <section className={`hub-wrap${played ? ' played' : ''}`}>
       <div className="hub">
         <div className="hub-head">
           <span className="eb">
-            Inputs <span className="arr">→</span> transcripts + catalog
+            Inputs <span className="arr">→</span>
           </span>
           <span className="eb r">
-            <span className="arr">←</span> consumed by roles
+            <span className="arr">→</span> Outputs
           </span>
         </div>
 
@@ -15,7 +22,12 @@ export function HubSection() {
           className="hub-lines"
           viewBox="0 0 1000 560"
           preserveAspectRatio="none"
-          aria-hidden="true"
+          role="img"
+          aria-label="Hover to play the pipeline animation"
+          tabIndex={0}
+          onMouseEnter={trigger}
+          onPointerEnter={trigger}
+          onFocus={trigger}
         >
           <defs>
             <radialGradient id="hubGlow" cx="50%" cy="50%" r="50%">
@@ -24,6 +36,14 @@ export function HubSection() {
               <stop offset="100%" stopColor="rgba(254,133,49,0)" />
             </radialGradient>
           </defs>
+          <rect
+            x="0"
+            y="0"
+            width="1000"
+            height="560"
+            fill="transparent"
+            pointerEvents="all"
+          />
           <ellipse cx="500" cy="280" rx="340" ry="200" fill="url(#hubGlow)" />
           <ellipse
             cx="500"
@@ -43,90 +63,181 @@ export function HubSection() {
             stroke="rgba(254,133,49,0.14)"
             strokeDasharray="2 8"
           />
-          <path
-            d="M 210 140 Q 360 160, 500 280"
-            fill="none"
-            stroke="rgba(254,133,49,0.55)"
-            strokeWidth="1.1"
-          />
-          <path
-            d="M 210 230 Q 360 250, 500 280"
-            fill="none"
-            stroke="rgba(254,133,49,0.55)"
-            strokeWidth="1.1"
-          />
-          <path
-            d="M 210 330 Q 360 320, 500 280"
-            fill="none"
-            stroke="rgba(254,133,49,0.55)"
-            strokeWidth="1.1"
-          />
-          <path
-            d="M 210 420 Q 360 390, 500 280"
-            fill="none"
-            stroke="rgba(254,133,49,0.55)"
-            strokeWidth="1.1"
-          />
-          <path
-            d="M 500 280 Q 640 180, 790 150"
-            fill="none"
-            stroke="rgba(254,133,49,0.55)"
-            strokeWidth="1.1"
-          />
-          <path
-            d="M 500 280 Q 640 280, 790 280"
-            fill="none"
-            stroke="rgba(254,133,49,0.55)"
-            strokeWidth="1.1"
-          />
-          <path
-            d="M 500 280 Q 640 380, 790 410"
-            fill="none"
-            stroke="rgba(254,133,49,0.55)"
-            strokeWidth="1.1"
-          />
         </svg>
 
         <div className="hub-inputs">
-          <div className="hub-pill" style={{ top: '22%' }}>
-            <span className="ic">🎤</span>Call recording
+          <div className="hub-input" style={{ top: '22%' }}>
+            <div className="hub-input-ic">
+              <svg viewBox="0 0 48 48" width="44" height="44" aria-hidden="true">
+                <path
+                  d="M11 4 H29 L39 14 V42 C39 43.1 38.1 44 37 44 H11 C9.9 44 9 43.1 9 42 V6 C9 4.9 9.9 4 11 4 Z"
+                  fill="#22202A"
+                  stroke="rgba(254,133,49,0.55)"
+                  strokeWidth="1"
+                />
+                <path
+                  d="M29 4 V14 H39"
+                  fill="none"
+                  stroke="rgba(254,133,49,0.55)"
+                  strokeWidth="1"
+                />
+                <text
+                  x="24"
+                  y="32"
+                  fontSize="8"
+                  fontWeight="600"
+                  fill="#E8925A"
+                  textAnchor="middle"
+                  fontFamily="'Geist Mono', monospace"
+                  letterSpacing="0.5"
+                >
+                  .TXT
+                </text>
+              </svg>
+            </div>
+            <div className="hub-input-lbl">Transcript</div>
           </div>
-          <div className="hub-pill" style={{ top: '39%' }}>
-            <span className="ic">📄</span>.vtt transcript
+
+          <div className="hub-input" style={{ top: '39%' }}>
+            <div className="hub-input-ic">
+              <svg viewBox="0 0 48 48" width="44" height="44" aria-hidden="true">
+                <circle
+                  cx="24"
+                  cy="24"
+                  r="16"
+                  fill="#22202A"
+                  stroke="rgba(254,133,49,0.55)"
+                  strokeWidth="1"
+                />
+                <ellipse
+                  cx="24"
+                  cy="24"
+                  rx="6"
+                  ry="16"
+                  fill="none"
+                  stroke="rgba(254,133,49,0.55)"
+                  strokeWidth="1"
+                />
+                <line
+                  x1="8"
+                  y1="24"
+                  x2="40"
+                  y2="24"
+                  stroke="rgba(254,133,49,0.55)"
+                  strokeWidth="1"
+                />
+                <path
+                  d="M11 16 Q24 20, 37 16"
+                  fill="none"
+                  stroke="rgba(254,133,49,0.55)"
+                  strokeWidth="1"
+                />
+                <path
+                  d="M11 32 Q24 28, 37 32"
+                  fill="none"
+                  stroke="rgba(254,133,49,0.55)"
+                  strokeWidth="1"
+                />
+              </svg>
+            </div>
+            <div className="hub-input-lbl">Product Catalog</div>
           </div>
-          <div className="hub-pill" style={{ top: '59%' }}>
-            <span className="ic">📦</span>Product catalog
+
+          <div className="hub-input" style={{ top: '59%' }}>
+            <div className="hub-input-ic">
+              <svg viewBox="0 0 48 48" width="44" height="44" aria-hidden="true">
+                <rect x="4" y="4" width="40" height="40" rx="7" fill="#0052CC" />
+                <path
+                  d="M8 34 C14 28, 20 28, 26 30 C32 32, 38 32, 42 28"
+                  stroke="#FFFFFF"
+                  strokeWidth="4"
+                  fill="none"
+                  strokeLinecap="round"
+                />
+                <path
+                  d="M8 20 C14 14, 20 14, 26 16 C32 18, 38 18, 42 14"
+                  stroke="#FFFFFF"
+                  strokeWidth="4"
+                  fill="none"
+                  strokeLinecap="round"
+                />
+              </svg>
+            </div>
+            <div className="hub-input-lbl">Product Details</div>
           </div>
-          <div className="hub-pill" style={{ top: '76%' }}>
-            <span className="ic">💬</span>Zoom transcript
+
+          <div className="hub-input" style={{ top: '76%' }}>
+            <div className="hub-input-ic">
+              <svg viewBox="0 0 48 48" width="44" height="44" aria-hidden="true">
+                <rect x="4" y="4" width="40" height="40" rx="8" fill="#2D8CFF" />
+                <path d="M18 17 L32 24 L18 31 Z" fill="#FFFFFF" />
+              </svg>
+            </div>
+            <div className="hub-input-lbl">Call Recording</div>
           </div>
         </div>
 
         <div className="hub-core">
-          <div className="hub-core-eb">
-            <span className="dot">●</span> Salency
-          </div>
+          <img className="hub-core-mark" src="/salency-mark.svg" alt="Salency" />
           <div className="hub-core-ttl">
             Extract · <em>Map</em> · Remember
           </div>
-          <div className="hub-core-sub">one queryable memory layer</div>
         </div>
 
-        <div className="hub-roles">
-          <div className="hub-role" style={{ top: '18%' }}>
-            <div className="rk">New AE</div>
-            <div className="rt">Inherits context</div>
-            <div className="rs">Full account state before the next call</div>
+        <div className="hub-outputs">
+          <div className="hub-output" style={{ top: '26%' }}>
+            <div className="hub-output-ic" aria-hidden="true">
+              <svg viewBox="0 0 14 14" width="12" height="12">
+                <path
+                  d="M2 7.5 L5.5 11 L12 3.5"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+            <div className="hub-output-body">
+              <div className="hub-output-ttl">Products mapped</div>
+              <div className="hub-output-sub">pain → feature, cited to transcript</div>
+            </div>
           </div>
-          <div className="hub-role" style={{ top: '44%' }}>
-            <div className="rk">CSM</div>
-            <div className="rt">Picks up handoff</div>
-            <div className="rs">Pain-to-product mappings already cited</div>
+          <div className="hub-output" style={{ top: '50%' }}>
+            <div className="hub-output-ic" aria-hidden="true">
+              <svg viewBox="0 0 14 14" width="12" height="12">
+                <path
+                  d="M2 7.5 L5.5 11 L12 3.5"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+            <div className="hub-output-body">
+              <div className="hub-output-ttl">Customer needs</div>
+              <div className="hub-output-sub">pains, objections, asks</div>
+            </div>
           </div>
-          <div className="hub-role" style={{ top: '70%' }}>
-            <div className="rk">Director</div>
-            <div className="rt">Sees the pattern</div>
-            <div className="rs">Pains and objections across every deal</div>
+          <div className="hub-output" style={{ top: '74%' }}>
+            <div className="hub-output-ic" aria-hidden="true">
+              <svg viewBox="0 0 14 14" width="12" height="12">
+                <path
+                  d="M2 7.5 L5.5 11 L12 3.5"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+            <div className="hub-output-body">
+              <div className="hub-output-ttl">Account context</div>
+              <div className="hub-output-sub">state carried across every call</div>
+            </div>
           </div>
         </div>
 
@@ -135,6 +246,29 @@ export function HubSection() {
           <span>
             <em>Early access</em> · Q2 2026
           </span>
+        </div>
+      </div>
+
+      <div className="hub-outcome" role="complementary">
+        <div className="hub-outcome-eb">
+          <span className="dot">●</span> Outcome · every role inherits it
+        </div>
+        <div className="hub-outcome-grid">
+          <div className="hub-outcome-row">
+            <div className="hub-outcome-rk">New AE</div>
+            <div className="hub-outcome-rt">Inherits context</div>
+            <div className="hub-outcome-rs">Full account state before the next call</div>
+          </div>
+          <div className="hub-outcome-row">
+            <div className="hub-outcome-rk">CSM</div>
+            <div className="hub-outcome-rt">Picks up handoff</div>
+            <div className="hub-outcome-rs">Pain-to-product mappings already cited</div>
+          </div>
+          <div className="hub-outcome-row">
+            <div className="hub-outcome-rk">Director</div>
+            <div className="hub-outcome-rt">Sees the pattern</div>
+            <div className="hub-outcome-rs">Pains and objections across every deal</div>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Closes #21

## Summary
- Replace static hub diagram with a hover-triggered narrative: inputs throw into core → outputs generate one-by-one → outcome panel pops up below
- Rework inputs into app-icon + label stacks (`.txt` Transcript / Globe Product Catalog / Confluence Product Details / Zoom Call Recording)
- Simplify hub-core: drop the bordered card, show the Salency logo mark + `Extract · Map · Remember`
- Add three outputs (Products mapped / Customer needs / Account context) with shimmer + typewriter + check-icon-pop "generate" effect
- Move the existing role cards (New AE / CSM / Director) into an outcome panel below the hub
- Animation gates on hover of the `.hub-lines` SVG, plays exactly once via a `played` React state latch, and ends with every element visible and static
- Respects `prefers-reduced-motion`

## Test plan
- [ ] `npm run dev` and load the landing page
- [ ] Scroll to the hub section — inputs + outputs visible by default, outcome hidden
- [ ] Hover over the SVG (empty lines area, not the input icons) — animation plays once
- [ ] Input 1 starts flying within ~90ms of hover (no perceptible lag)
- [ ] Outputs 1 → 2 → 3 generate sequentially with shimmer sweep + typewriter reveal
- [ ] Outcome panel pops up from below after outputs complete (~5.4s)
- [ ] Move mouse away mid-animation — animation continues to completion and holds final state
- [ ] Hover again after completion — nothing re-triggers (class already latched)
- [ ] Hovering the input icons themselves does NOT trigger (only the SVG hit area does)
- [ ] Toggle macOS Reduce Motion → reload → everything renders static in final positions, no animation
- [ ] Tab into the SVG via keyboard (`tabIndex={0}`) — focus also triggers the animation
- [ ] `npm run lint` — no new errors (pre-existing ProblemCard errors and `<img>` warning unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)