### PR TITLE
feat(hub): inline outcome + brand/footer/animation polish

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -314,9 +314,9 @@ html {
     backdrop-filter:blur(6px);box-shadow:0 4px 16px rgba(0,0,0,.3);
     opacity:1;transform:translate(0,-50%);
   }
-  .hub-output:nth-child(1){--out-delay:2.3s}
-  .hub-output:nth-child(2){--out-delay:3.2s}
-  .hub-output:nth-child(3){--out-delay:4.1s}
+  .hub-output:nth-child(1){--out-delay:7.5s}
+  .hub-output:nth-child(2){--out-delay:8.4s}
+  .hub-output:nth-child(3){--out-delay:9.3s}
   .hub-output::before{
     content:'';position:absolute;inset:0;pointer-events:none;z-index:1;
     background:linear-gradient(100deg,
@@ -389,7 +389,7 @@ html {
     opacity:0;transform:translateX(20px);
   }
   .hub-wrap.played .hub-outcome{
-    animation:hub-outcome-pop .8s cubic-bezier(.2,.8,.3,1) 5.4s forwards;
+    animation:hub-outcome-pop .8s cubic-bezier(.2,.8,.3,1) 10.6s forwards;
   }
   .hub-outcome-eb{
     font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
@@ -462,7 +462,7 @@ html {
       display:grid;grid-template-columns:repeat(3,1fr);gap:20px;
     }
     .hub-wrap.played .hub-outcome{
-      animation:hub-outcome-pop-v .8s cubic-bezier(.2,.8,.3,1) 5.4s forwards;
+      animation:hub-outcome-pop-v .8s cubic-bezier(.2,.8,.3,1) 10.6s forwards;
     }
     @keyframes hub-outcome-pop-v{
       0%   {opacity:0;transform:translateY(20px)}
@@ -511,6 +511,11 @@ html {
       0%   {opacity:0;transform:translateY(8px)}
       100% {opacity:1;transform:translateY(0)}
     }
+    /* Compress output + outcome delays for the shorter mobile input fade-in */
+    .hub-output:nth-child(1){--out-delay:.9s}
+    .hub-output:nth-child(2){--out-delay:1.1s}
+    .hub-output:nth-child(3){--out-delay:1.3s}
+    .hub-wrap.played .hub-outcome{animation-delay:2.3s}
   }
 
   /* ═══════════ Header ═══════════ */

--- a/app/globals.css
+++ b/app/globals.css
@@ -314,9 +314,9 @@ html {
     backdrop-filter:blur(6px);box-shadow:0 4px 16px rgba(0,0,0,.3);
     opacity:1;transform:translate(0,-50%);
   }
-  .hub-output:nth-child(1){--out-delay:7.5s}
-  .hub-output:nth-child(2){--out-delay:7.5s}
-  .hub-output:nth-child(3){--out-delay:7.5s}
+  .hub-output:nth-child(1){--out-delay:6.4s}
+  .hub-output:nth-child(2){--out-delay:7.3s}
+  .hub-output:nth-child(3){--out-delay:8.2s}
   .hub-output::before{
     content:'';position:absolute;inset:0;pointer-events:none;z-index:1;
     background:linear-gradient(100deg,
@@ -389,7 +389,7 @@ html {
     opacity:0;transform:translateX(20px);
   }
   .hub-wrap.played .hub-outcome{
-    animation:hub-outcome-pop .8s cubic-bezier(.2,.8,.3,1) 8.8s forwards;
+    animation:hub-outcome-pop .8s cubic-bezier(.2,.8,.3,1) 9.5s forwards;
   }
   .hub-outcome-eb{
     font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
@@ -462,7 +462,7 @@ html {
       display:grid;grid-template-columns:repeat(3,1fr);gap:20px;
     }
     .hub-wrap.played .hub-outcome{
-      animation:hub-outcome-pop-v .8s cubic-bezier(.2,.8,.3,1) 8.8s forwards;
+      animation:hub-outcome-pop-v .8s cubic-bezier(.2,.8,.3,1) 9.5s forwards;
     }
     @keyframes hub-outcome-pop-v{
       0%   {opacity:0;transform:translateY(20px)}
@@ -513,9 +513,9 @@ html {
     }
     /* Compress output + outcome delays for the shorter mobile input fade-in */
     .hub-output:nth-child(1){--out-delay:.9s}
-    .hub-output:nth-child(2){--out-delay:.9s}
-    .hub-output:nth-child(3){--out-delay:.9s}
-    .hub-wrap.played .hub-outcome{animation-delay:2s}
+    .hub-output:nth-child(2){--out-delay:1.5s}
+    .hub-output:nth-child(3){--out-delay:2.1s}
+    .hub-wrap.played .hub-outcome{animation-delay:3s}
   }
 
   /* ═══════════ Header ═══════════ */

--- a/app/globals.css
+++ b/app/globals.css
@@ -244,7 +244,7 @@ html {
   .hub-input{
     position:absolute;
     display:flex;flex-direction:column;align-items:center;gap:8px;
-    width:100px;left:0;
+    width:100px;left:60px;
     --dy:0px;
     transform:translate(0,-50%) scale(1);
     opacity:1;
@@ -274,8 +274,8 @@ html {
   @keyframes hub-throw{
     0%   {transform:translate(0,-50%) scale(1);opacity:1;filter:blur(0)}
     2%   {transform:translate(0,-50%) scale(1);opacity:1;filter:blur(0)}
-    30%  {transform:translate(280px,calc(-50% + var(--dy) * .7)) scale(.55);opacity:.85;filter:blur(.4px)}
-    50%  {transform:translate(420px,calc(-50% + var(--dy))) scale(.12);opacity:0;filter:blur(1.5px)}
+    30%  {transform:translate(200px,calc(-50% + var(--dy) * .7)) scale(.55);opacity:.85;filter:blur(.4px)}
+    50%  {transform:translate(340px,calc(-50% + var(--dy))) scale(.12);opacity:0;filter:blur(1.5px)}
     51%  {transform:translate(0,-50%) scale(1);opacity:0;filter:blur(0)}
     75%  {transform:translate(0,-50%) scale(1);opacity:1;filter:blur(0)}
     100% {transform:translate(0,-50%) scale(1);opacity:1;filter:blur(0)}
@@ -314,9 +314,9 @@ html {
     backdrop-filter:blur(6px);box-shadow:0 4px 16px rgba(0,0,0,.3);
     opacity:1;transform:translate(0,-50%);
   }
-  .hub-output:nth-child(1){--out-delay:6.4s}
-  .hub-output:nth-child(2){--out-delay:7.3s}
-  .hub-output:nth-child(3){--out-delay:8.2s}
+  .hub-output:nth-child(1){--out-delay:2s}
+  .hub-output:nth-child(2){--out-delay:2.9s}
+  .hub-output:nth-child(3){--out-delay:3.8s}
   .hub-output::before{
     content:'';position:absolute;inset:0;pointer-events:none;z-index:1;
     background:linear-gradient(100deg,
@@ -389,7 +389,7 @@ html {
     opacity:0;transform:translateX(20px);
   }
   .hub-wrap.played .hub-outcome{
-    animation:hub-outcome-pop .8s cubic-bezier(.2,.8,.3,1) 9.5s forwards;
+    animation:hub-outcome-pop .8s cubic-bezier(.2,.8,.3,1) 5.1s forwards;
   }
   .hub-outcome-eb{
     font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
@@ -441,7 +441,7 @@ html {
   /* ═══════════ Hub responsive ═══════════ */
   @media (max-width:1024px){
     .hub-inputs{width:200px}
-    .hub-input{width:90px;left:0}
+    .hub-input{width:90px;left:55px}
     .hub-outputs{width:200px}
     .hub-core-name{font-size:28px}
     .hub-core-mark{width:36px;height:36px}
@@ -462,7 +462,7 @@ html {
       display:grid;grid-template-columns:repeat(3,1fr);gap:20px;
     }
     .hub-wrap.played .hub-outcome{
-      animation:hub-outcome-pop-v .8s cubic-bezier(.2,.8,.3,1) 9.5s forwards;
+      animation:hub-outcome-pop-v .8s cubic-bezier(.2,.8,.3,1) 5.1s forwards;
     }
     @keyframes hub-outcome-pop-v{
       0%   {opacity:0;transform:translateY(20px)}

--- a/app/globals.css
+++ b/app/globals.css
@@ -286,9 +286,16 @@ html {
     display:flex;flex-direction:column;align-items:center;gap:16px;
     text-align:center;
   }
+  .hub-core-brand{
+    display:flex;align-items:center;gap:12px;
+  }
   .hub-core-mark{
     width:44px;height:44px;object-fit:contain;
     filter:drop-shadow(0 4px 14px rgba(254,133,49,.32));
+  }
+  .hub-core-name{
+    font-family:var(--font-outfit), 'Outfit', sans-serif;font-weight:800;font-size:34px;
+    letter-spacing:-.02em;color:var(--ink);line-height:1;
   }
   .hub-core-ttl{
     font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;font-size:30px;
@@ -442,8 +449,8 @@ html {
   .brand{display:flex;align-items:center;gap:11px;min-height:44px;padding:4px 6px;margin-left:-6px;border-radius:6px}
   .brand img{width:26px;height:26px;display:block}
   .brand .name{
-    font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;font-size:24px;
-    letter-spacing:-.01em;color:var(--ink);
+    font-family:var(--font-outfit), 'Outfit', sans-serif;font-weight:800;font-size:22px;
+    letter-spacing:-.02em;color:var(--ink);
   }
   nav.links{display:flex;gap:24px;justify-self:center}
   nav.links a{
@@ -1293,7 +1300,7 @@ html {
     font-family:'Geist Mono',monospace;font-size:11px;color:var(--ink-4);
     letter-spacing:.04em;
   }
-  footer .brand{font-family:var(--font-display), 'Instrument Serif', serif;font-size:18px;color:var(--ink-2);letter-spacing:-.01em}
+  footer .brand{font-family:var(--font-outfit), 'Outfit', sans-serif;font-weight:800;font-size:17px;color:var(--ink-2);letter-spacing:-.02em}
   footer nav{display:flex;gap:24px}
   footer nav a{color:var(--ink-3)}
   footer nav a:hover{color:var(--ink)}
@@ -1356,8 +1363,8 @@ html {
     letter-spacing:.08em;text-transform:uppercase;
   }
   .inv-footer .brand{
-    font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;font-size:18px;
-    color:#E8E6E3;letter-spacing:-.01em;text-transform:none;
+    font-family:var(--font-outfit), 'Outfit', sans-serif;font-weight:800;font-size:17px;
+    color:#E8E6E3;letter-spacing:-.02em;text-transform:none;
   }
   .inv-footer nav{display:flex;gap:28px}
   .inv-footer nav a{color:var(--ink-3);transition:color .18s}

--- a/app/globals.css
+++ b/app/globals.css
@@ -391,7 +391,12 @@ html {
     font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
     letter-spacing:.2em;text-transform:uppercase;color:var(--copper);
   }
-  .hub-outcome-eb .dot{color:var(--copper);margin-right:6px}
+  .hub-outcome-eb .dot{
+    display:inline-block;width:6px;height:6px;border-radius:50%;
+    background:var(--copper);margin-right:8px;
+    vertical-align:middle;font-size:0;line-height:0;
+    position:relative;top:-1px;
+  }
   .hub-outcome-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:28px}
   .hub-outcome-row{
     display:flex;flex-direction:column;gap:3px;

--- a/app/globals.css
+++ b/app/globals.css
@@ -384,12 +384,7 @@ html {
   .hub-outcome{
     position:relative;min-width:0;
     border-top:1px solid var(--hair-2);
-    padding:22px 28px 24px;
-    display:flex;flex-direction:column;gap:14px;
-  }
-  .hub-outcome-eb{
-    font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
-    letter-spacing:.2em;text-transform:uppercase;color:var(--copper);
+    padding:18px 28px 20px;
   }
   .hub-outcome-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:28px}
   .hub-outcome-row{

--- a/app/globals.css
+++ b/app/globals.css
@@ -315,8 +315,8 @@ html {
     opacity:1;transform:translate(0,-50%);
   }
   .hub-output:nth-child(1){--out-delay:7.5s}
-  .hub-output:nth-child(2){--out-delay:8.4s}
-  .hub-output:nth-child(3){--out-delay:9.3s}
+  .hub-output:nth-child(2){--out-delay:7.5s}
+  .hub-output:nth-child(3){--out-delay:7.5s}
   .hub-output::before{
     content:'';position:absolute;inset:0;pointer-events:none;z-index:1;
     background:linear-gradient(100deg,
@@ -389,7 +389,7 @@ html {
     opacity:0;transform:translateX(20px);
   }
   .hub-wrap.played .hub-outcome{
-    animation:hub-outcome-pop .8s cubic-bezier(.2,.8,.3,1) 10.6s forwards;
+    animation:hub-outcome-pop .8s cubic-bezier(.2,.8,.3,1) 8.8s forwards;
   }
   .hub-outcome-eb{
     font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
@@ -462,7 +462,7 @@ html {
       display:grid;grid-template-columns:repeat(3,1fr);gap:20px;
     }
     .hub-wrap.played .hub-outcome{
-      animation:hub-outcome-pop-v .8s cubic-bezier(.2,.8,.3,1) 10.6s forwards;
+      animation:hub-outcome-pop-v .8s cubic-bezier(.2,.8,.3,1) 8.8s forwards;
     }
     @keyframes hub-outcome-pop-v{
       0%   {opacity:0;transform:translateY(20px)}
@@ -513,9 +513,9 @@ html {
     }
     /* Compress output + outcome delays for the shorter mobile input fade-in */
     .hub-output:nth-child(1){--out-delay:.9s}
-    .hub-output:nth-child(2){--out-delay:1.1s}
-    .hub-output:nth-child(3){--out-delay:1.3s}
-    .hub-wrap.played .hub-outcome{animation-delay:2.3s}
+    .hub-output:nth-child(2){--out-delay:.9s}
+    .hub-output:nth-child(3){--out-delay:.9s}
+    .hub-wrap.played .hub-outcome{animation-delay:2s}
   }
 
   /* ═══════════ Header ═══════════ */

--- a/app/globals.css
+++ b/app/globals.css
@@ -391,12 +391,6 @@ html {
     font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
     letter-spacing:.2em;text-transform:uppercase;color:var(--copper);
   }
-  .hub-outcome-eb .dot{
-    display:inline-block;width:6px;height:6px;border-radius:50%;
-    background:var(--copper);margin-right:8px;
-    vertical-align:middle;font-size:0;line-height:0;
-    position:relative;top:-1px;
-  }
   .hub-outcome-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:28px}
   .hub-outcome-row{
     display:flex;flex-direction:column;gap:3px;

--- a/app/globals.css
+++ b/app/globals.css
@@ -225,10 +225,12 @@ html {
   .hub-wrap{max-width:1280px;margin:72px auto 0;padding:0 40px}
   .hub{
     position:relative;height:560px;
+    display:grid;grid-template-columns:3fr 1fr;
     background:linear-gradient(180deg,#141119 0%,#0F0D13 100%);
     border:1px solid var(--hair-2);border-radius:16px;overflow:hidden;
     box-shadow:0 40px 80px -30px rgba(0,0,0,.6), inset 0 1px 0 rgba(255,255,255,.03);
   }
+  .hub-main{position:relative;height:100%;min-width:0}
   .hub-head{
     position:absolute;top:22px;left:28px;right:28px;display:flex;justify-content:space-between;
     font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
@@ -272,8 +274,8 @@ html {
   @keyframes hub-throw{
     0%   {transform:translate(0,-50%) scale(1);opacity:1;filter:blur(0)}
     2%   {transform:translate(0,-50%) scale(1);opacity:1;filter:blur(0)}
-    30%  {transform:translate(300px,calc(-50% + var(--dy) * .7)) scale(.55);opacity:.85;filter:blur(.4px)}
-    50%  {transform:translate(460px,calc(-50% + var(--dy))) scale(.12);opacity:0;filter:blur(1.5px)}
+    30%  {transform:translate(200px,calc(-50% + var(--dy) * .7)) scale(.55);opacity:.85;filter:blur(.4px)}
+    50%  {transform:translate(310px,calc(-50% + var(--dy))) scale(.12);opacity:0;filter:blur(1.5px)}
     51%  {transform:translate(0,-50%) scale(1);opacity:0;filter:blur(0)}
     75%  {transform:translate(0,-50%) scale(1);opacity:1;filter:blur(0)}
     100% {transform:translate(0,-50%) scale(1);opacity:1;filter:blur(0)}
@@ -380,39 +382,41 @@ html {
   }
 
   .hub-outcome{
-    margin-top:24px;
-    background:linear-gradient(180deg,#1A171E 0%,#141119 100%);
-    border:1px solid rgba(254,133,49,.22);border-radius:14px;
-    padding:22px 28px;
-    box-shadow:0 20px 60px rgba(0,0,0,.5), inset 0 1px 0 rgba(255,255,255,.03);
-    opacity:0;transform:translateY(20px) scale(.985);
+    position:relative;min-width:0;
+    border-left:1px solid var(--hair-2);
+    padding:24px 22px;
+    display:flex;flex-direction:column;gap:18px;
+    opacity:0;transform:translateX(20px);
   }
   .hub-wrap.played .hub-outcome{
     animation:hub-outcome-pop .8s cubic-bezier(.2,.8,.3,1) 5.4s forwards;
   }
   .hub-outcome-eb{
     font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
-    letter-spacing:.2em;text-transform:uppercase;color:var(--copper);margin-bottom:16px;
+    letter-spacing:.2em;text-transform:uppercase;color:var(--copper);
   }
   .hub-outcome-eb .dot{color:var(--copper);margin-right:6px}
-  .hub-outcome-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:28px}
-  .hub-outcome-row{display:flex;flex-direction:column;gap:4px}
+  .hub-outcome-grid{display:flex;flex-direction:column;gap:18px}
+  .hub-outcome-row{
+    display:flex;flex-direction:column;gap:3px;
+    padding-left:12px;border-left:2px solid rgba(254,133,49,.35);
+  }
   .hub-outcome-rk{
     font-family:'Geist Mono',monospace;font-size:10px;font-weight:500;
     letter-spacing:.2em;text-transform:uppercase;color:var(--copper);
   }
   .hub-outcome-rt{
     font-family:var(--font-display), 'Instrument Serif', serif;
-    font-weight:400;font-size:22px;line-height:1.15;color:var(--ink);
+    font-weight:400;font-size:18px;line-height:1.2;color:var(--ink);
   }
   .hub-outcome-rs{
     font-family:var(--font-body), 'Geist', sans-serif;font-weight:300;
-    font-size:12.5px;color:var(--ink-3);line-height:1.45;
+    font-size:12px;color:var(--ink-3);line-height:1.4;
   }
   @keyframes hub-outcome-pop{
-    0%   {opacity:0;transform:translateY(20px) scale(.985)}
-    60%  {opacity:1;transform:translateY(-2px) scale(1.005)}
-    100% {opacity:1;transform:translateY(0) scale(1)}
+    0%   {opacity:0;transform:translateX(20px)}
+    60%  {opacity:1;transform:translateX(-2px)}
+    100% {opacity:1;transform:translateX(0)}
   }
 
   @media (prefers-reduced-motion: reduce){

--- a/app/globals.css
+++ b/app/globals.css
@@ -385,6 +385,11 @@ html {
     position:relative;min-width:0;
     border-top:1px solid var(--hair-2);
     padding:18px 28px 20px;
+    display:flex;flex-direction:column;gap:12px;
+  }
+  .hub-outcome-eb{
+    font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
+    letter-spacing:.18em;text-transform:uppercase;color:var(--copper);
   }
   .hub-outcome-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:28px}
   .hub-outcome-row{
@@ -1183,9 +1188,9 @@ html {
 
   /* ═══════════ Register divider ═══════════ */
   .reg-div{
-    position:relative;margin-top:120px;
+    position:relative;margin-top:0;
     background:#0C0A10;
-    height:220px;display:flex;align-items:center;justify-content:center;
+    height:96px;display:flex;align-items:center;justify-content:center;
     overflow:hidden;
   }
   .reg-div::before{
@@ -1389,7 +1394,7 @@ html {
   .investors-register > *{position:relative;z-index:1}
 
   .inv-intro{
-    max-width:1280px;margin:0 auto;padding:100px 40px 80px;
+    max-width:1280px;margin:0 auto;padding:48px 40px 80px;
     border-bottom:1px solid var(--hair);position:relative;
   }
   .inv-intro::after{

--- a/app/globals.css
+++ b/app/globals.css
@@ -224,13 +224,13 @@ html {
   /* ═══════════ Hub diagram (replaces product mock) ═══════════ */
   .hub-wrap{max-width:1280px;margin:72px auto 0;padding:0 40px}
   .hub{
-    position:relative;height:560px;
-    display:grid;grid-template-columns:3fr 1fr;
+    position:relative;height:auto;
+    display:flex;flex-direction:column;
     background:linear-gradient(180deg,#141119 0%,#0F0D13 100%);
     border:1px solid var(--hair-2);border-radius:16px;overflow:hidden;
     box-shadow:0 40px 80px -30px rgba(0,0,0,.6), inset 0 1px 0 rgba(255,255,255,.03);
   }
-  .hub-main{position:relative;height:100%;min-width:0}
+  .hub-main{position:relative;height:560px;min-width:0;flex-shrink:0}
   .hub-head{
     position:absolute;top:22px;left:28px;right:28px;display:flex;justify-content:space-between;
     font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
@@ -383,23 +383,20 @@ html {
 
   .hub-outcome{
     position:relative;min-width:0;
-    border-left:1px solid var(--hair-2);
-    padding:24px 22px;
-    display:flex;flex-direction:column;gap:18px;
-    opacity:0;transform:translateX(20px);
-  }
-  .hub-wrap.played .hub-outcome{
-    animation:hub-outcome-pop .8s cubic-bezier(.2,.8,.3,1) 7.1s forwards;
+    border-top:1px solid var(--hair-2);
+    padding:22px 28px 24px;
+    display:flex;flex-direction:column;gap:14px;
   }
   .hub-outcome-eb{
     font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
     letter-spacing:.2em;text-transform:uppercase;color:var(--copper);
   }
   .hub-outcome-eb .dot{color:var(--copper);margin-right:6px}
-  .hub-outcome-grid{display:flex;flex-direction:column;gap:18px}
+  .hub-outcome-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:28px}
   .hub-outcome-row{
     display:flex;flex-direction:column;gap:3px;
     padding-left:12px;border-left:2px solid rgba(254,133,49,.35);
+    transition:transform .2s ease;
   }
   .hub-outcome-rk{
     font-family:'Geist Mono',monospace;font-size:10px;font-weight:500;
@@ -407,16 +404,23 @@ html {
   }
   .hub-outcome-rt{
     font-family:var(--font-display), 'Instrument Serif', serif;
-    font-weight:400;font-size:18px;line-height:1.2;color:var(--ink);
+    font-weight:400;font-size:20px;line-height:1.2;color:var(--ink);
   }
   .hub-outcome-rs{
     font-family:var(--font-body), 'Geist', sans-serif;font-weight:300;
-    font-size:12px;color:var(--ink-3);line-height:1.4;
+    font-size:12.5px;color:var(--ink-3);line-height:1.45;
   }
-  @keyframes hub-outcome-pop{
-    0%   {opacity:0;transform:translateX(20px)}
-    60%  {opacity:1;transform:translateX(-2px)}
-    100% {opacity:1;transform:translateX(0)}
+  .hub-wrap.played .hub-outcome-row{
+    animation:hub-outcome-pulse 1.1s cubic-bezier(.3,.8,.3,1) both;
+  }
+  .hub-wrap.played .hub-outcome-row:nth-child(1){animation-delay:7.1s}
+  .hub-wrap.played .hub-outcome-row:nth-child(2){animation-delay:7.3s}
+  .hub-wrap.played .hub-outcome-row:nth-child(3){animation-delay:7.5s}
+  @keyframes hub-outcome-pulse{
+    0%   {border-left-color:rgba(254,133,49,.35);box-shadow:0 0 0 0 rgba(254,133,49,0)}
+    30%  {border-left-color:rgba(254,133,49,1);box-shadow:-4px 0 18px -2px rgba(254,133,49,.5), inset 3px 0 0 rgba(254,133,49,.4)}
+    60%  {border-left-color:rgba(254,133,49,.85);box-shadow:-3px 0 12px -2px rgba(254,133,49,.3)}
+    100% {border-left-color:rgba(254,133,49,.55);box-shadow:0 0 0 0 rgba(254,133,49,0)}
   }
 
   @media (prefers-reduced-motion: reduce){
@@ -428,13 +432,13 @@ html {
     .hub-output::before{display:none}
     .hub-output-ic{opacity:1;transform:scale(1)}
     .hub-output-body{clip-path:none}
-    .hub-outcome{animation:none;opacity:1;transform:none}
+    .hub-outcome-row{animation:none;transition:none;box-shadow:none}
   }
   .hub-foot{
-    position:absolute;left:28px;right:28px;bottom:22px;display:flex;justify-content:space-between;
-    padding-top:18px;border-top:1px solid var(--hair);
+    display:flex;justify-content:space-between;
+    padding:16px 28px;border-top:1px solid var(--hair);
     font-family:'Geist Mono',monospace;font-size:11px;color:var(--ink-3);
-    letter-spacing:.04em;z-index:3;
+    letter-spacing:.04em;
   }
   .hub-foot em{font-style:normal;color:var(--copper);font-weight:600}
 
@@ -449,26 +453,10 @@ html {
     .hub-outcome-rt{font-size:17px}
   }
 
-  /* Tablet: outcome stacks below the main diagram */
+  /* Tablet: tighter main diagram */
   @media (max-width:900px){
-    .hub{grid-template-columns:1fr;height:auto}
     .hub-main{height:500px}
-    .hub-outcome{
-      border-left:none;border-top:1px solid var(--hair-2);
-      padding:22px 28px;
-      opacity:0;transform:translateY(20px);
-    }
-    .hub-outcome-grid{
-      display:grid;grid-template-columns:repeat(3,1fr);gap:20px;
-    }
-    .hub-wrap.played .hub-outcome{
-      animation:hub-outcome-pop-v .8s cubic-bezier(.2,.8,.3,1) 7.1s forwards;
-    }
-    @keyframes hub-outcome-pop-v{
-      0%   {opacity:0;transform:translateY(20px)}
-      60%  {opacity:1;transform:translateY(-2px)}
-      100% {opacity:1;transform:translateY(0)}
-    }
+    .hub-outcome-grid{gap:20px}
   }
 
   /* Phone: vertical flow inside the main diagram, simplified motion */
@@ -511,11 +499,13 @@ html {
       0%   {opacity:0;transform:translateY(8px)}
       100% {opacity:1;transform:translateY(0)}
     }
-    /* Compress output + outcome delays for the shorter mobile input fade-in */
+    /* Compress output + outcome pulse delays for the shorter mobile input fade-in */
     .hub-output:nth-child(1){--out-delay:.9s}
     .hub-output:nth-child(2){--out-delay:1.5s}
     .hub-output:nth-child(3){--out-delay:2.1s}
-    .hub-wrap.played .hub-outcome{animation-delay:3s}
+    .hub-wrap.played .hub-outcome-row:nth-child(1){animation-delay:3.3s}
+    .hub-wrap.played .hub-outcome-row:nth-child(2){animation-delay:3.5s}
+    .hub-wrap.played .hub-outcome-row:nth-child(3){animation-delay:3.7s}
   }
 
   /* ═══════════ Header ═══════════ */

--- a/app/globals.css
+++ b/app/globals.css
@@ -244,7 +244,7 @@ html {
   .hub-input{
     position:absolute;
     display:flex;flex-direction:column;align-items:center;gap:8px;
-    width:100px;left:60px;
+    width:100px;left:0;
     --dy:0px;
     transform:translate(0,-50%) scale(1);
     opacity:1;
@@ -274,8 +274,8 @@ html {
   @keyframes hub-throw{
     0%   {transform:translate(0,-50%) scale(1);opacity:1;filter:blur(0)}
     2%   {transform:translate(0,-50%) scale(1);opacity:1;filter:blur(0)}
-    30%  {transform:translate(200px,calc(-50% + var(--dy) * .7)) scale(.55);opacity:.85;filter:blur(.4px)}
-    50%  {transform:translate(310px,calc(-50% + var(--dy))) scale(.12);opacity:0;filter:blur(1.5px)}
+    30%  {transform:translate(280px,calc(-50% + var(--dy) * .7)) scale(.55);opacity:.85;filter:blur(.4px)}
+    50%  {transform:translate(420px,calc(-50% + var(--dy))) scale(.12);opacity:0;filter:blur(1.5px)}
     51%  {transform:translate(0,-50%) scale(1);opacity:0;filter:blur(0)}
     75%  {transform:translate(0,-50%) scale(1);opacity:1;filter:blur(0)}
     100% {transform:translate(0,-50%) scale(1);opacity:1;filter:blur(0)}
@@ -304,7 +304,7 @@ html {
     line-height:1.1;letter-spacing:-.015em;color:var(--ink);white-space:nowrap;
   }
   .hub-core-ttl em{font-style:italic;color:var(--copper)}
-  .hub-outputs{position:absolute;right:28px;top:0;bottom:0;width:280px;z-index:2}
+  .hub-outputs{position:absolute;right:28px;top:0;bottom:0;width:220px;z-index:2}
   .hub-output{
     --out-delay:0s;
     position:absolute;left:0;right:0;overflow:hidden;
@@ -437,6 +437,81 @@ html {
     letter-spacing:.04em;z-index:3;
   }
   .hub-foot em{font-style:normal;color:var(--copper);font-weight:600}
+
+  /* ═══════════ Hub responsive ═══════════ */
+  @media (max-width:1024px){
+    .hub-inputs{width:200px}
+    .hub-input{width:90px;left:0}
+    .hub-outputs{width:200px}
+    .hub-core-name{font-size:28px}
+    .hub-core-mark{width:36px;height:36px}
+    .hub-outcome{padding:20px 22px}
+    .hub-outcome-rt{font-size:17px}
+  }
+
+  /* Tablet: outcome stacks below the main diagram */
+  @media (max-width:900px){
+    .hub{grid-template-columns:1fr;height:auto}
+    .hub-main{height:500px}
+    .hub-outcome{
+      border-left:none;border-top:1px solid var(--hair-2);
+      padding:22px 28px;
+      opacity:0;transform:translateY(20px);
+    }
+    .hub-outcome-grid{
+      display:grid;grid-template-columns:repeat(3,1fr);gap:20px;
+    }
+    .hub-wrap.played .hub-outcome{
+      animation:hub-outcome-pop-v .8s cubic-bezier(.2,.8,.3,1) 5.4s forwards;
+    }
+    @keyframes hub-outcome-pop-v{
+      0%   {opacity:0;transform:translateY(20px)}
+      60%  {opacity:1;transform:translateY(-2px)}
+      100% {opacity:1;transform:translateY(0)}
+    }
+  }
+
+  /* Phone: vertical flow inside the main diagram, simplified motion */
+  @media (max-width:640px){
+    .hub-wrap{margin-top:48px;padding:0 20px}
+    .hub-main{
+      height:auto;
+      display:flex;flex-direction:column;align-items:center;
+      padding:48px 18px 32px;gap:28px;
+    }
+    .hub-head{position:static;display:flex;justify-content:center;gap:12px}
+    .hub-lines{display:none}
+    .hub-inputs,.hub-core,.hub-outputs{
+      position:static;width:100%;height:auto;transform:none;left:auto;right:auto;top:auto;bottom:auto;
+    }
+    .hub-inputs{
+      display:grid;grid-template-columns:repeat(4,1fr);gap:10px;justify-items:center;
+    }
+    .hub-input{position:static;left:auto;top:auto!important;width:auto;transform:none}
+    .hub-input-ic{width:40px;height:40px}
+    .hub-input-lbl{font-size:11px}
+    .hub-core{padding:8px 0}
+    .hub-core-name{font-size:26px}
+    .hub-core-ttl{font-size:22px;white-space:normal}
+    .hub-outputs{display:flex;flex-direction:column;gap:10px}
+    .hub-output{position:static;left:auto;top:auto!important;transform:none}
+    .hub-foot{
+      position:static;display:flex;flex-direction:column;gap:6px;text-align:center;
+      padding-top:14px;margin-top:8px;
+    }
+    .hub-outcome{padding:20px}
+    .hub-outcome-grid{grid-template-columns:1fr;gap:16px}
+    /* Skip the throw animation on phones — elements render in place */
+    .hub-wrap.played .hub-input{animation:hub-in-mobile .5s ease-out both}
+    .hub-wrap.played .hub-input:nth-child(1){animation-delay:0s}
+    .hub-wrap.played .hub-input:nth-child(2){animation-delay:.1s}
+    .hub-wrap.played .hub-input:nth-child(3){animation-delay:.2s}
+    .hub-wrap.played .hub-input:nth-child(4){animation-delay:.3s}
+    @keyframes hub-in-mobile{
+      0%   {opacity:0;transform:translateY(8px)}
+      100% {opacity:1;transform:translateY(0)}
+    }
+  }
 
   /* ═══════════ Header ═══════════ */
   header{

--- a/app/globals.css
+++ b/app/globals.css
@@ -314,9 +314,9 @@ html {
     backdrop-filter:blur(6px);box-shadow:0 4px 16px rgba(0,0,0,.3);
     opacity:1;transform:translate(0,-50%);
   }
-  .hub-output:nth-child(1){--out-delay:2s}
-  .hub-output:nth-child(2){--out-delay:2.9s}
-  .hub-output:nth-child(3){--out-delay:3.8s}
+  .hub-output:nth-child(1){--out-delay:4s}
+  .hub-output:nth-child(2){--out-delay:4.9s}
+  .hub-output:nth-child(3){--out-delay:5.8s}
   .hub-output::before{
     content:'';position:absolute;inset:0;pointer-events:none;z-index:1;
     background:linear-gradient(100deg,
@@ -389,7 +389,7 @@ html {
     opacity:0;transform:translateX(20px);
   }
   .hub-wrap.played .hub-outcome{
-    animation:hub-outcome-pop .8s cubic-bezier(.2,.8,.3,1) 5.1s forwards;
+    animation:hub-outcome-pop .8s cubic-bezier(.2,.8,.3,1) 7.1s forwards;
   }
   .hub-outcome-eb{
     font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
@@ -462,7 +462,7 @@ html {
       display:grid;grid-template-columns:repeat(3,1fr);gap:20px;
     }
     .hub-wrap.played .hub-outcome{
-      animation:hub-outcome-pop-v .8s cubic-bezier(.2,.8,.3,1) 5.1s forwards;
+      animation:hub-outcome-pop-v .8s cubic-bezier(.2,.8,.3,1) 7.1s forwards;
     }
     @keyframes hub-outcome-pop-v{
       0%   {opacity:0;transform:translateY(20px)}

--- a/components/sections/HubSection.tsx
+++ b/components/sections/HubSection.tsx
@@ -178,7 +178,10 @@ export function HubSection() {
         </div>
 
         <div className="hub-core">
-          <img className="hub-core-mark" src="/salency-mark.svg" alt="Salency" />
+          <div className="hub-core-brand">
+            <img className="hub-core-mark" src="/salency-mark.svg" alt="" />
+            <span className="hub-core-name">Salency</span>
+          </div>
           <div className="hub-core-ttl">
             Extract · <em>Map</em> · Remember
           </div>

--- a/components/sections/HubSection.tsx
+++ b/components/sections/HubSection.tsx
@@ -245,12 +245,6 @@ export function HubSection() {
           </div>
         </div>
 
-        <div className="hub-foot">
-          <span>One pipeline · every role · zero handoff loss</span>
-          <span>
-            <em>Early access</em> · Q2 2026
-          </span>
-        </div>
         </div>
 
         <div className="hub-outcome" role="complementary">
@@ -274,6 +268,13 @@ export function HubSection() {
               <div className="hub-outcome-rs">Pains and objections across every deal</div>
             </div>
           </div>
+        </div>
+
+        <div className="hub-foot">
+          <span>One pipeline · every role · zero handoff loss</span>
+          <span>
+            <em>Early access</em> · Q2 2026
+          </span>
         </div>
       </div>
     </section>

--- a/components/sections/HubSection.tsx
+++ b/components/sections/HubSection.tsx
@@ -9,6 +9,7 @@ export function HubSection() {
   return (
     <section className={`hub-wrap${played ? ' played' : ''}`}>
       <div className="hub">
+        <div className="hub-main">
         <div className="hub-head">
           <span className="eb">
             Inputs <span className="arr">→</span>
@@ -250,27 +251,28 @@ export function HubSection() {
             <em>Early access</em> · Q2 2026
           </span>
         </div>
-      </div>
-
-      <div className="hub-outcome" role="complementary">
-        <div className="hub-outcome-eb">
-          <span className="dot">●</span> Outcome · every role inherits it
         </div>
-        <div className="hub-outcome-grid">
-          <div className="hub-outcome-row">
-            <div className="hub-outcome-rk">New AE</div>
-            <div className="hub-outcome-rt">Inherits context</div>
-            <div className="hub-outcome-rs">Full account state before the next call</div>
+
+        <div className="hub-outcome" role="complementary">
+          <div className="hub-outcome-eb">
+            <span className="dot">●</span> Outcome
           </div>
-          <div className="hub-outcome-row">
-            <div className="hub-outcome-rk">CSM</div>
-            <div className="hub-outcome-rt">Picks up handoff</div>
-            <div className="hub-outcome-rs">Pain-to-product mappings already cited</div>
-          </div>
-          <div className="hub-outcome-row">
-            <div className="hub-outcome-rk">Director</div>
-            <div className="hub-outcome-rt">Sees the pattern</div>
-            <div className="hub-outcome-rs">Pains and objections across every deal</div>
+          <div className="hub-outcome-grid">
+            <div className="hub-outcome-row">
+              <div className="hub-outcome-rk">New AE</div>
+              <div className="hub-outcome-rt">Inherits context</div>
+              <div className="hub-outcome-rs">Full account state before the next call</div>
+            </div>
+            <div className="hub-outcome-row">
+              <div className="hub-outcome-rk">CSM</div>
+              <div className="hub-outcome-rt">Picks up handoff</div>
+              <div className="hub-outcome-rs">Pain-to-product mappings already cited</div>
+            </div>
+            <div className="hub-outcome-row">
+              <div className="hub-outcome-rk">Director</div>
+              <div className="hub-outcome-rt">Sees the pattern</div>
+              <div className="hub-outcome-rs">Pains and objections across every deal</div>
+            </div>
           </div>
         </div>
       </div>

--- a/components/sections/HubSection.tsx
+++ b/components/sections/HubSection.tsx
@@ -248,9 +248,7 @@ export function HubSection() {
         </div>
 
         <div className="hub-outcome" role="complementary">
-          <div className="hub-outcome-eb">
-            <span className="dot">●</span> Outcome
-          </div>
+          <div className="hub-outcome-eb">Outcome</div>
           <div className="hub-outcome-grid">
             <div className="hub-outcome-row">
               <div className="hub-outcome-rk">New AE</div>

--- a/components/sections/HubSection.tsx
+++ b/components/sections/HubSection.tsx
@@ -248,7 +248,6 @@ export function HubSection() {
         </div>
 
         <div className="hub-outcome" role="complementary">
-          <div className="hub-outcome-eb">Outcome</div>
           <div className="hub-outcome-grid">
             <div className="hub-outcome-row">
               <div className="hub-outcome-rk">New AE</div>

--- a/components/sections/HubSection.tsx
+++ b/components/sections/HubSection.tsx
@@ -248,6 +248,7 @@ export function HubSection() {
         </div>
 
         <div className="hub-outcome" role="complementary">
+          <div className="hub-outcome-eb">Outcome</div>
           <div className="hub-outcome-grid">
             <div className="hub-outcome-row">
               <div className="hub-outcome-rk">New AE</div>

--- a/components/sections/InvestorsSection.tsx
+++ b/components/sections/InvestorsSection.tsx
@@ -5,9 +5,6 @@ export function InvestorsSection() {
         <span className="hair" />
         <div className="wrap">
           <span className="kicker">What we&apos;re building</span>
-          <h2>
-            For <em>investors</em>
-          </h2>
         </div>
       </div>
 

--- a/components/sections/SiteFooter.tsx
+++ b/components/sections/SiteFooter.tsx
@@ -3,13 +3,20 @@ import Link from 'next/link';
 export function SiteFooter() {
   return (
     <footer>
-      <span className="brand">Salency</span>
+      <Link href="/" className="brand">Salency</Link>
       <nav>
-        <button type="button" className="footer-link">Product</button>
+        <Link href="/why-salency" className="footer-link">Why Salency</Link>
+        <Link href="/memory" className="footer-link">Memory</Link>
         <Link href="/pricing" className="footer-link">Pricing</Link>
-        <button type="button" className="footer-link">Security</button>
         <Link href="/investors" className="footer-link">Investors</Link>
-        <button type="button" className="footer-link">Careers</button>
+        <a
+          href="mailto:founders@salency.ai?subject=Careers"
+          className="footer-link"
+        >
+          Careers
+        </a>
+        <Link href="/privacy" className="footer-link">Privacy</Link>
+        <Link href="/terms" className="footer-link">Terms</Link>
       </nav>
       <span>© 2026 Salency · Toronto</span>
     </footer>


### PR DESCRIPTION
Closes #24

## Summary

Originally scoped as a 3:1 right-side outcome column — landed on a cleaner layout after iteration: outcome as a full-width bottom strip, visible by default, with a post-outputs pulse. Hub-foot follows below it.

### Hub structure
- **Outcome moved to bottom strip.** `.hub` is now a flex column: `.hub-main` (560px diagram) → `.hub-outcome` (3-column row with top divider) → `.hub-foot`.
- **Outcome visible by default** (no entrance fade). After outputs finish (~6.9s), each outcome row plays a staggered copper pulse — border-left brightens, soft copper glow blooms outward, fades back.
- **`hub-foot` moved** from inside `.hub-main` (previously `position:absolute`) to a flow sibling below the outcome. Now renders as the card's last row with top hair-divider.

### Brand + wordmark
- Header + footer wordmark: `Instrument Serif` → `Outfit 800` (extra-bold sans)
- Add `Salency` wordmark next to the logo mark inside `hub-core` as a 34px brand lockup

### Footer
- Previously `Product` / `Security` / `Careers` were non-functional `<button>` elements. All items now work:
  - Why Salency → `/why-salency`
  - Memory → `/memory`
  - Pricing → `/pricing`
  - Investors → `/investors`
  - Careers → `mailto:founders@salency.ai?subject=Careers`
  - Privacy → `/privacy`
  - Terms → `/terms`
- Brand wordmark in footer is also a link back to `/`.

### Animation timing (user-tuned)
- Inputs: throw into core, staggered `0 / 1 / 2 / 3s`, each 4.5s duration
- Outputs: start at `4s`, staggered `0.9s` apart → `4.0s / 4.9s / 5.8s`
- Outcome row pulses: `7.1s / 7.3s / 7.5s` (0.2s stagger)
- Input horizontal travel: `200px / 340px` (at 30% / 50% keyframes) — lands in core from centered starting position
- Inputs centered in their 220px container (`left: 60px`)

### Responsive
- **≤1024px:** tighter widths (`.hub-inputs` / `.hub-outputs` both 200px, input centered in 200 with `left: 55px`), hub-core mark 36px, wordmark 28px
- **≤900px:** small diagram compression (500px height, tighter outcome gap)
- **≤640px:** `.hub-main` collapses to a vertical flex stack — head, 4-col inputs grid, core, outputs column, foot. Throw animation replaced with a staggered fade-up (`hub-in-mobile`). Output + outcome pulse delays compressed (`.9s / 1.5s / 2.1s` outputs, `3.3s / 3.5s / 3.7s` outcome rows).

`prefers-reduced-motion`: all hub animations disabled; elements render at their final static state.

## Test plan
- [ ] Desktop: hub renders as one bordered card — diagram on top, outcome strip (3 roles) below, hub-foot at bottom
- [ ] Outcome is **visible** when the page loads (no fade-in required)
- [ ] Hover over the `.hub-lines` SVG (empty lines space, not input icons) — animation plays once, input icons throw toward core, outputs generate one-by-one starting at 4s
- [ ] After outputs finish (~6.9s), each outcome row pulses copper (border-left + glow) in sequence 0.2s apart
- [ ] Hub-core lockup reads `[mark] Salency` above `Extract · Map · Remember`
- [ ] Header and footer wordmarks render in Outfit 800
- [ ] Footer: every nav item navigates to its route (or opens mail client for Careers). Brand wordmark links home.
- [ ] No `●` unicode bullet anywhere in the hub (previously rendered weirdly in some browsers)
- [ ] Reduced-motion: hub renders fully static in final positions
- [ ] Narrow viewport (<640px): hub stacks vertically, outputs rendered as a column, foot centered below outcome

🤖 Generated with [Claude Code](https://claude.com/claude-code)