### PR TITLE
Session pass: how-it-works content + design polish + notdo-card refactor

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -983,6 +983,12 @@ html {
   .how-step{padding:36px 32px 36px 0;border-right:1px solid var(--hair);position:relative}
   .how-step:nth-child(n+2){padding-left:32px}
   .how-step:last-child{border-right:0}
+  .how-step:not(:last-child)::before{
+    content:"→";position:absolute;right:-10px;top:34px;
+    width:20px;height:20px;display:flex;align-items:center;justify-content:center;
+    background:var(--bg);color:var(--copper);font-size:14px;font-weight:400;
+    font-family:'Geist Mono',monospace;z-index:1;
+  }
   .how-step .idx{
     font-family:'Geist Mono',monospace;font-size:11px;font-weight:500;
     letter-spacing:.2em;text-transform:uppercase;color:var(--copper);

--- a/app/globals.css
+++ b/app/globals.css
@@ -975,10 +975,10 @@ html {
   }
   .how-head h2 em{font-style:italic;color:var(--copper)}
   .how-head .lede{
-    font-family:var(--font-body), 'Geist', sans-serif;font-weight:300;font-size:17px;line-height:1.65;
-    color:var(--ink-2);max-width:48ch;
+    font-family:var(--font-body), 'Geist', sans-serif;font-weight:300;font-size:19px;line-height:1.55;
+    color:var(--ink-2);max-width:42ch;
   }
-  .how-head .lede em{font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;color:var(--ink);font-size:18px;font-weight:400}
+  .how-head .lede em{font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;color:var(--ink);font-size:20px;font-weight:400}
   .how-steps{display:grid;grid-template-columns:repeat(3,1fr);gap:0;border-top:1px solid var(--hair-2)}
   .how-step{padding:36px 32px 36px 0;border-right:1px solid var(--hair);position:relative}
   .how-step:nth-child(n+2){padding-left:32px}

--- a/components/sections/HowItWorksSection.tsx
+++ b/components/sections/HowItWorksSection.tsx
@@ -9,10 +9,10 @@ export function HowItWorksSection() {
           </h2>
         </div>
         <p className="lede">
-          Transcript from any source: <em>AI notetaker</em>, Zoom, Meet, or a
-          raw .vtt. Three steps turn it into <em>structured memory</em>: every
-          pain, commitment, and stakeholder cited, queryable, and still useful
-          after the rep who took the call has moved on.
+          Drop in any transcript: <em>AI notetaker</em>, Zoom, Meet, or a raw
+          .vtt. Salency runs every call through the same pipeline, and the
+          output is{' '}
+          <em>structured, cited, and queryable</em> before your next stand-up.
         </p>
       </div>
       <div className="how-steps">
@@ -22,15 +22,16 @@ export function HowItWorksSection() {
             <em>Extract</em>
           </h3>
           <p className="desc">
-            Every call is parsed into structured signals: pains, objections,
-            competitors, commitments, timelines, next steps. Not summarised —
-            enumerated. Each one keeps its verbatim quote and timestamp.
+            Every call is parsed into five structured signal types: pains,
+            objections, competitors, requirements, next steps. Enumerated,
+            not summarised. Every signal carries the verbatim quote, the
+            speaker, and the timestamp.
           </p>
           <div className="ex">
-            <div className="el">Example output</div>
+            <div className="el">Example extraction</div>
             <div className="eq">
-              &ldquo;We need to cut AE ramp from 9 months to 4 by Q3.&rdquo;{' '}
-              <strong>→ Commitment</strong> · Priya Shah · Disco 31:08
+              <strong>Pain</strong> · CS director inherits accounts blind at
+              renewal · Priya Shah, VP Sales · 18:02
             </div>
           </div>
         </div>
@@ -40,18 +41,18 @@ export function HowItWorksSection() {
             <em>Map</em>
           </h3>
           <p className="desc">
-            Each pain is mapped to a line item in your product catalog. Each
-            stakeholder is linked to their role, their account, and every prior
-            quote. The graph grows with every call.
+            Each pain maps to a line in your product catalog, ranked by
+            confidence. Every new call is compared against prior calls on the
+            same account, and contradictions get flagged. The graph keeps
+            growing: pains, products, stakeholders, and how the story has
+            changed over time.
           </p>
           <div className="ex">
             <div className="el">Example mapping</div>
             <div className="eq">
-              Pain:{' '}
-              <em style={{ fontStyle: 'italic' }}>
-                &ldquo;handoff loses context&rdquo;
-              </em>{' '}
-              <strong>→ Memory Graph + Stakeholder View</strong>
+              Pain <em>&ldquo;handoff loses context&rdquo;</em>{' '}
+              <strong>→ 3 products ranked</strong> · Contradiction flagged vs
+              Disco call, Dec 12
             </div>
           </div>
         </div>
@@ -61,16 +62,16 @@ export function HowItWorksSection() {
             <em>Remember</em>
           </h3>
           <p className="desc">
-            The graph keeps every extraction alive long after the call ends.
-            When a rep rotates or the quarter turns, the account&apos;s memory
-            travels with it — still linked to source, still queryable, still
-            current.
+            The next AE inherits a Day-1 brief. The CS director picks up
+            mid-story, not from zero. Pipeline review sees every pain across
+            every account without replaying a single call. The memory
+            outlasts any rep.
           </p>
           <div className="ex">
-            <div className="el">Example recall</div>
+            <div className="el">Example surface</div>
             <div className="eq">
-              New AE opens <strong>Acme</strong> → inherits 47 extractions
-              across 9 calls, each cited and stakeholder-mapped.
+              <strong>Next steps</strong> · Renewal conversation by Mar 15 ·
+              Open commitments: 3
             </div>
           </div>
         </div>
@@ -80,7 +81,7 @@ export function HowItWorksSection() {
           Works with any transcript.<span className="sep">·</span>
           <em>Citations + confidence scores</em> on every extraction.
         </span>
-        <span>Deploys in 48 hours · alongside your AI notetaker</span>
+        <span>Runs alongside your AI notetaker</span>
       </div>
     </section>
   );

--- a/components/sections/HowItWorksSection.tsx
+++ b/components/sections/HowItWorksSection.tsx
@@ -51,8 +51,7 @@ export function HowItWorksSection() {
             <div className="el">Example mapping</div>
             <div className="eq">
               Pain <em>&ldquo;handoff loses context&rdquo;</em>{' '}
-              <strong>→ 3 products ranked</strong> · Contradiction flagged vs
-              Disco call, Dec 12
+              <strong>→ 3 products ranked</strong>, contradictions flagged
             </div>
           </div>
         </div>

--- a/components/sections/HowItWorksSection.tsx
+++ b/components/sections/HowItWorksSection.tsx
@@ -9,9 +9,8 @@ export function HowItWorksSection() {
           </h2>
         </div>
         <p className="lede">
-          Drop in any transcript: <em>AI notetaker</em>, Zoom, Meet, or a raw
-          .vtt. Salency runs every call through the same pipeline, and the
-          output is{' '}
+          Every transcript, <em>AI notetaker</em> or raw .vtt, runs through the
+          same pipeline. The output is{' '}
           <em>structured, cited, and queryable</em> before your next stand-up.
         </p>
       </div>

--- a/components/sections/HowItWorksSection.tsx
+++ b/components/sections/HowItWorksSection.tsx
@@ -80,7 +80,6 @@ export function HowItWorksSection() {
           Works with any transcript.<span className="sep">·</span>
           Citations and confidence scores on every extraction.
         </span>
-        <span>Runs alongside your AI notetaker</span>
       </div>
     </section>
   );

--- a/components/sections/HowItWorksSection.tsx
+++ b/components/sections/HowItWorksSection.tsx
@@ -78,7 +78,7 @@ export function HowItWorksSection() {
       <div className="how-foot">
         <span>
           Works with any transcript.<span className="sep">·</span>
-          <em>Citations + confidence scores</em> on every extraction.
+          Citations and confidence scores on every extraction.
         </span>
         <span>Runs alongside your AI notetaker</span>
       </div>

--- a/components/sections/NotDoSection.tsx
+++ b/components/sections/NotDoSection.tsx
@@ -12,10 +12,9 @@ export function NotDoSection() {
             <div className="t">Not a CRM replacement</div>
             <span className="check" aria-label="What it does">✓</span>
             <div className="s">
-              Reads every call transcript, extracts the pains, stakeholders,
-              and commitments, and writes them back into Salesforce, HubSpot,
-              or Attio as structured fields — so your CRM finally reflects
-              what was actually said.
+              Salesforce, HubSpot, Attio stay. Salency is the memory layer
+              alongside them: pain graph, contradictions, account-level
+              brief. Flat fields export when leadership wants them in CRM.
             </div>
           </div>
           <div className="notdo-item">
@@ -23,10 +22,9 @@ export function NotDoSection() {
             <div className="t">Not an in-call coach</div>
             <span className="check" aria-label="What it does">✓</span>
             <div className="s">
-              Works between calls. After each conversation, Salency updates
-              the account&apos;s memory — pain history, objection log,
-              stakeholder map — so the rep walks into the next call already
-              briefed.
+              That&apos;s Gong&apos;s turf. Salency works between calls.
+              After each conversation it updates the account&apos;s memory,
+              so the rep walks into the next call already briefed.
             </div>
           </div>
           <div className="notdo-item">
@@ -34,9 +32,10 @@ export function NotDoSection() {
             <div className="t">Not a magic close button</div>
             <span className="check" aria-label="What it does">✓</span>
             <div className="s">
-              Removes the context tax. Reps stop re-reading transcripts,
-              re-asking customers, and reconstructing deals from Slack threads
-              — so the hour before every call goes back to selling.
+              We don&apos;t claim to close more deals. We capture what gets
+              lost: the pain a buyer named, the contradiction from last
+              week&apos;s call, the next step nobody wrote down. The hour
+              before every call goes back to selling.
             </div>
           </div>
           <div className="notdo-item">
@@ -44,10 +43,9 @@ export function NotDoSection() {
             <div className="t">Not another call recorder</div>
             <span className="check" aria-label="What it does">✓</span>
             <div className="s">
-              Sits <em>on top of</em> your notetaker. Gong, Fathom, Fireflies,
-              or raw .vtt — Salency takes the transcript they produce and
-              turns it into a cited, queryable memory layer that survives rep
-              rotation.
+              Salency sits <em>on top of</em> your notetaker. Gong, Fathom,
+              Fireflies, raw .vtt go in. A cited, queryable memory layer
+              comes out. Survives rep rotation.
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Consolidates 7 commits from this session's design + content work into one PR for `main`. Cherry-picked onto latest `main` (which includes team's PR #22 hub animation, `aa6496a`). No conflicts; auto-merged on `globals.css` (different rule blocks: hub vs how-it-works).

## What's included (chronological)

| # | SHA | Type | Finding | Files |
|---|-----|------|---------|-------|
| 1 | `a4882d4` | content | Restore how-it-works refinements lost in PR #17 split (5-signal-types, contradiction detection, lie-stripped footer) | HowItWorksSection.tsx |
| 2 | `2c2b2cc` | design | HIGH-2 — trim Step 02 example to one line (grid rhythm) | HowItWorksSection.tsx |
| 3 | `0a70ae4` | design | MEDIUM-1 — reduce copper-emphasis density (7 → 6, dropped from footer) | HowItWorksSection.tsx |
| 4 | `14750a5` | design | MEDIUM-4 — drop orphan footer span ("Runs alongside your AI notetaker") | HowItWorksSection.tsx |
| 5 | `f4ee0de` | design | HIGH-3 — lede hierarchy match (strip "Drop in any transcript:", bump 17px → 19px, em 18px → 20px, max-width 48ch → 42ch) | HowItWorksSection.tsx + globals.css |
| 6 | `f1163d1` | design | HIGH-1 — directional cue between pipeline steps (copper chevron arrows via `::before` on `.how-step:not(:last-child)`) | globals.css |
| 7 | `39f4f21` | content | Refactor notdo-card: lie-strip CRM write-back claim, bake in §203 close-more-deals disclosure, name Gong's turf, drop em-dashes, ~30% shorter | NotDoSection.tsx |

## Source-of-truth refs
All content changes calibrated against `~/Documents/Salency/company-context.md`:
- §5 — 5 real signal types (pains, objections, competitors, requirements, next steps)
- §6 — institutional memory category framing
- §8 — moat = pain-product mapping + contradiction detection
- §17 — landing page state, two-register design
- §25 — what NOT to include
- §87 — em-dash ban
- §200 — anti-hype strip
- §202 — "that's Gong's turf" (verbatim)
- §203 — mandatory "does NOT close more deals" disclosure
- §206 — no V1 CRM integrations

## Strategic positioning shift (notdo-card item 1)
Reframed CRM stance from "writes back to Salesforce/HubSpot/Attio" (false claim — V1 has zero integrations) to "Salency is the memory layer alongside them: pain graph, contradictions, account-level brief. Flat fields export when leadership wants them in CRM."

This positions CRM as complementary, not competitive. Memory layer (the moat per §8) stays on Salency; flat fields export when needed. Honors V1 reality without losing the selling point. Linear/Notion/Superhuman pattern: be your own layer, not a feature of the incumbent.

## Why these were grouped
All 7 commits ship together as coherent design + content pass on the buyer-facing landing. Bisectable order preserved (HIGH-2 → MEDIUM-1 → MEDIUM-4 → HIGH-3 → HIGH-1 → notdo refactor). Each commit verified individually + together.

## Conflict check
Team's PR #22 (`aa6496a` interactive hub animation) touched `HubSection.tsx` + `globals.css`. Session work touched `HowItWorksSection.tsx`, `NotDoSection.tsx`, `globals.css`. Cherry-pick auto-merged twice on `globals.css` (different rule blocks). Zero manual conflict resolution needed.

## Verified
- `npm run build` clean (Next.js 16.1.4 + Turbopack)
- All 12 routes prerender: `/`, `/investors`, `/memory`, `/pricing`, `/why-salency`, `/privacy`, `/terms`
- Linear history: 7 commits ahead of main, 0 behind
- No TypeScript errors

## Test plan
- [ ] Vercel preview renders `/#how-it-works` with 5-signal-type list, → arrows between steps, 19px lede, one-line Step 02 example, single-span footer
- [ ] Vercel preview renders `/#what-isnt-it` (or wherever notdo anchors) with new copy: "Salesforce, HubSpot, Attio stay..." (no "writes them back"), "That's Gong's turf.", "We don't claim to close more deals."
- [ ] Hub animation from PR #22 still works (no regression on hover-triggered narrative)
- [ ] No em-dashes in either how-it-works or notdo sections
- [ ] Mobile breakpoint still collapses cleanly

## Not in scope
- Em-dash sweep across the rest of the page (separate pass)
- MEDIUM-2 / MEDIUM-3 / POLISH-1 / POLISH-2 from issue #15 (lower priority, can ship pre-YC if time)
- Any structural changes
- Other sections (hub, gong, problem, hero) untouched

## Replaces / supersedes
- PR #20 (`design/how-it-works-polish` → `test-revamp`) — content same, this PR replaces it for direct main merge
- PR #23 (`content/notdo-card-refactor` → `test-revamp`) — content same, this PR replaces it for direct main merge

After this lands, both can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)