### PR TITLE
content: how-it-works — raw text + pain → customer needs

### DIFF
--- a/components/sections/HowItWorksSection.tsx
+++ b/components/sections/HowItWorksSection.tsx
@@ -9,7 +9,7 @@ export function HowItWorksSection() {
           </h2>
         </div>
         <p className="lede">
-          Every transcript, <em>AI notetaker</em> or raw .vtt, runs through the
+          Every transcript, <em>AI notetaker</em> or raw text, runs through the
           same pipeline. The output is{' '}
           <em>structured, cited, and queryable</em> before your next stand-up.
         </p>
@@ -21,16 +21,16 @@ export function HowItWorksSection() {
             <em>Extract</em>
           </h3>
           <p className="desc">
-            Every call is parsed into five structured signal types: pains,
-            objections, competitors, requirements, next steps. Enumerated,
-            not summarised. Every signal carries the verbatim quote, the
-            speaker, and the timestamp.
+            Every call is parsed into five structured signal types: customer
+            needs, objections, competitors, requirements, next steps.
+            Enumerated, not summarised. Every signal carries the verbatim
+            quote, the speaker, and the timestamp.
           </p>
           <div className="ex">
             <div className="el">Example extraction</div>
             <div className="eq">
-              <strong>Pain</strong> · CS director inherits accounts blind at
-              renewal · Priya Shah, VP Sales · 18:02
+              <strong>Customer need</strong> · Account visibility at renewal
+              handoff · Priya Shah, VP Sales · 18:02
             </div>
           </div>
         </div>
@@ -40,16 +40,16 @@ export function HowItWorksSection() {
             <em>Map</em>
           </h3>
           <p className="desc">
-            Each pain maps to a line in your product catalog, ranked by
-            confidence. Every new call is compared against prior calls on the
-            same account, and contradictions get flagged. The graph keeps
-            growing: pains, products, stakeholders, and how the story has
+            Each customer need maps to a line in your product catalog, ranked
+            by confidence. Every new call is compared against prior calls on
+            the same account, and contradictions get flagged. The graph keeps
+            growing: needs, products, stakeholders, and how the story has
             changed over time.
           </p>
           <div className="ex">
             <div className="el">Example mapping</div>
             <div className="eq">
-              Pain <em>&ldquo;handoff loses context&rdquo;</em>{' '}
+              Need <em>&ldquo;context across handoffs&rdquo;</em>{' '}
               <strong>→ 3 products ranked</strong>, contradictions flagged
             </div>
           </div>
@@ -61,9 +61,9 @@ export function HowItWorksSection() {
           </h3>
           <p className="desc">
             The next AE inherits a Day-1 brief. The CS director picks up
-            mid-story, not from zero. Pipeline review sees every pain across
-            every account without replaying a single call. The memory
-            outlasts any rep.
+            mid-story, not from zero. Pipeline review sees every customer
+            need across every account without replaying a single call. The
+            memory outlasts any rep.
           </p>
           <div className="ex">
             <div className="el">Example surface</div>


### PR DESCRIPTION
## Summary
Two content changes on the how-it-works section.

1. **\`raw .vtt\` → \`raw text\`** in the lede. Broader compatibility signal, natural prose flow, editorial voice over file-extension voice on a landing page. Matches the notdo-card change in PR #30.

2. **\`pain\` / \`pains\` → \`customer needs\` / \`needs\`** — 6 occurrences replaced. Two example tags required semantic rewrites because \"pain\" (problem statement) and \"need\" (forward-looking want) describe different things:

| Location | Before | After |
|---|---|---|
| Step 01 signal types | \`pains, objections, competitors, requirements, next steps\` | \`customer needs, objections, competitors, requirements, next steps\` |
| Step 01 example tag | \`Pain · CS director inherits accounts blind at renewal\` | \`Customer need · Account visibility at renewal handoff\` |
| Step 02 desc | \`Each pain maps to a line in your product catalog\` | \`Each customer need maps to a line in your product catalog\` |
| Step 02 example | \`Pain \"handoff loses context\"\` | \`Need \"context across handoffs\"\` |
| Step 02 graph list | \`pains, products, stakeholders\` | \`needs, products, stakeholders\` |
| Step 03 | \`every pain across every account\` | \`every customer need across every account\` |

## Site-wide consistency (NOT in scope — flagging for next PR)

\`pain\` also appears in the following files and is NOT changed by this PR:

- \`components/sections/HeroSection.tsx\` — \"pains, objections, competitors\" in hero copy
- \`components/sections/GongSection.tsx\` — \"pain, promise, stakeholder, across every call\"
- \`components/sections/HubSection.tsx\` — \"Pain-to-product mappings already cited\" + \"Pains and objections across every deal\"
- \`components/sections/ProblemSection.tsx\` — \"the pains, the unprompted pain at minute 42\"
- \`components/sections/InvestorsSection.tsx\` — \"extraction and pain-to-product mapping engine\"

The landing page now diverges from \`company-context.md\` (§5 signal types, §6 pain-product mapping, §8 moat, §200 anti-hype), the pitch deck, and internal sales vocabulary until a site-wide sweep + ground-truth update lands. Next conversation decides: site-wide sweep, partial, or revert.

## Brand consistency flag
Company-context §5 locks the 5 signal types with **pains** as #1. Company-context §6 names \"pain-product mapping\" as the **money slide** for the wedge. The backend schema table is \`pain_product_mappings\`. This PR changes the landing page without changing those downstream artifacts, creating a known divergence the user will address in a follow-up.

## Verified
- \`npm run build\` clean (Next.js 16.1.4 + Turbopack)
- All 12 routes prerender
- Zero \`pain\` occurrences remain in \`HowItWorksSection.tsx\`

## Test plan
- [ ] Vercel preview renders \`/#how-it-works\` with \"customer needs\" in Step 01 signal list
- [ ] Step 01 example tag reads \"Customer need · Account visibility at renewal handoff\"
- [ ] Step 02 example reads \"Need 'context across handoffs' → 3 products ranked\"
- [ ] Step 03 desc reads \"every customer need across every account\"
- [ ] Lede says \"raw text\", not \"raw .vtt\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)