### PR TITLE
fix(coming-soon): align eyebrow + meta dots with main page

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1615,7 +1615,10 @@ header button:focus:not(:focus-visible){
 .coming-soon .eb{
   font-family:'Geist Mono',monospace;font-size:10px;font-weight:500;
   letter-spacing:.16em;text-transform:uppercase;color:var(--copper);
-  display:inline-block;margin-bottom:24px;
+  display:inline-flex;align-items:center;gap:10px;margin-bottom:24px;
+}
+.coming-soon .eb::before{
+  content:"";width:28px;height:1px;background:var(--copper);display:inline-block;
 }
 .coming-soon h1{
   font-family:var(--font-display), 'Instrument Sans', system-ui, sans-serif;
@@ -1630,13 +1633,7 @@ header button:focus:not(:focus-visible){
   font-size:18px;line-height:1.55;color:var(--ink-2);
   text-wrap:pretty;
 }
-.coming-soon-meta{
-  margin-top:32px;
-  font-family:'Geist Mono',monospace;font-size:11px;
-  letter-spacing:.1em;text-transform:uppercase;color:var(--ink-3);
-  display:flex;gap:24px;flex-wrap:wrap;
-}
-.coming-soon-meta .dot{color:var(--copper);margin-right:6px}
+.coming-soon-meta{margin-top:32px}
 
 /* ═══════════ Loading UI ═══════════ */
 .sr-only{

--- a/components/sections/ComingSoon.tsx
+++ b/components/sections/ComingSoon.tsx
@@ -13,13 +13,9 @@ export function ComingSoon({ eyebrow, title, description }: Props) {
           {title} <em>coming soon.</em>
         </h1>
         <p>{description}</p>
-        <div className="coming-soon-meta">
-          <span>
-            <span className="dot">●</span> Early access · Q2 2026
-          </span>
-          <span>
-            <span className="dot">●</span> Private preview on request
-          </span>
+        <div className="coming-soon-meta hero-meta">
+          <span className="hero-meta-item">Early access · Q2 2026</span>
+          <span className="hero-meta-item">Private preview on request</span>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Adds the missing `.coming-soon .eb::before` 28×1px copper dash so the Pricing/Memory eyebrows match `.prob-head`, `.how-head`, `.gong-head`, `.platform`.
- Replaces `<span class="dot">●</span>` meta dots with `.hero-meta` + `.hero-meta-item`, reusing the 6px `::before` circle already used on the hero. Drops redundant `.coming-soon-meta` font/layout rules now inherited from `.hero-meta`.

Closes #34

## Test plan
- [ ] Visit `/pricing` — eyebrow shows leading copper dash; two meta items show evenly-sized 6px copper dots aligned with the uppercase mono text.
- [ ] Visit `/memory` — same verification.
- [ ] Compare visually against the main page hero meta strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)