### PR TITLE
content: apply mixed pain/need register rule to how-it-works (partial PR #33 revert)

### DIFF
--- a/components/sections/HowItWorksSection.tsx
+++ b/components/sections/HowItWorksSection.tsx
@@ -21,16 +21,16 @@ export function HowItWorksSection() {
             <em>Extract</em>
           </h3>
           <p className="desc">
-            Every call is parsed into five structured signal types: customer
-            needs, objections, competitors, requirements, next steps.
-            Enumerated, not summarised. Every signal carries the verbatim
-            quote, the speaker, and the timestamp.
+            Every call is parsed into five structured signal types: pains,
+            objections, competitors, requirements, next steps. Enumerated,
+            not summarised. Every signal carries the verbatim quote, the
+            speaker, and the timestamp.
           </p>
           <div className="ex">
             <div className="el">Example extraction</div>
             <div className="eq">
-              <strong>Customer need</strong> · Account visibility at renewal
-              handoff · Priya Shah, VP Sales · 18:02
+              <strong>Pain</strong> · CS director inherits accounts blind at
+              renewal · Priya Shah, VP Sales · 18:02
             </div>
           </div>
         </div>
@@ -40,16 +40,16 @@ export function HowItWorksSection() {
             <em>Map</em>
           </h3>
           <p className="desc">
-            Each customer need maps to a line in your product catalog, ranked
-            by confidence. Every new call is compared against prior calls on
-            the same account, and contradictions get flagged. The graph keeps
-            growing: needs, products, stakeholders, and how the story has
+            Each pain maps to a line in your product catalog, ranked by
+            confidence. Every new call is compared against prior calls on the
+            same account, and contradictions get flagged. The graph keeps
+            growing: pains, products, stakeholders, and how the story has
             changed over time.
           </p>
           <div className="ex">
             <div className="el">Example mapping</div>
             <div className="eq">
-              Need <em>&ldquo;context across handoffs&rdquo;</em>{' '}
+              Pain <em>&ldquo;handoff loses context&rdquo;</em>{' '}
               <strong>→ 3 products ranked</strong>, contradictions flagged
             </div>
           </div>


### PR DESCRIPTION
## Summary
Partial revert of PR #33. The site-wide \`pain\` → \`customer needs\` swap was the wrong call. Mixed-register usage is correct. Register rule locked in \`company-context.md\` (new subsection before §200).

## The register rule

| Register | Word | When |
|----------|------|------|
| Diagnostic (naming the bad current state) | **Pain** | Buyer vernacular. Match rep language. |
| Technical artifact names (schema, category framing) | **Pain** | \`pain_product_mappings\` table, \"pain-product mapping = money slide\" per §6. Never rename — propagates to backend, API, pitch. |
| Outcome (forward-looking value) | **Customer need** | Exec-facing, empathy-forward. |
| Product output surfaces | **Customer need** | Buyer-facing. \"Day-1 brief of customer needs\" reads polished. |

## Reverts applied

| Hunk | Before (PR #33) | After (this PR) | Why |
|------|-----------------|-----------------|-----|
| Step 01 signal types | \`customer needs, objections...\` | \`pains, objections...\` | Technical taxonomy from §5; backend uses \`pains\` |
| Step 01 example tag | \`Customer need · Account visibility at renewal handoff\` | \`Pain · CS director inherits accounts blind at renewal\` | Diagnostic; original signal restored |
| Step 02 desc | \`Each customer need maps...\` | \`Each pain maps...\` | Pain-product mapping = money-slide locked category term per §6 |
| Step 02 graph list | \`needs, products, stakeholders\` | \`pains, products, stakeholders\` | Technical taxonomy |
| Step 02 example | \`Need \"context across handoffs\"\` | \`Pain \"handoff loses context\"\` | Diagnostic |

## Kept from PR #33

- **Step 03 outcome:** \`every customer need across every account\` (outcome register; reads executive on leadership skim)
- **Lede:** \`raw text\` vs \`raw .vtt\` (compatibility signal, unrelated to pain/need)

## Net count
5 pain occurrences (diagnostic + technical) + 1 customer need occurrence (outcome). Mixed deliberately.

## Other sections — NO change
Hero, Problem, Gong, Hub, Investors all correctly in diagnostic register (\"pain\"). No sweep needed. Site stays aligned with backend schema, pitch deck, and investor copy.

## Also updated
\`/Users/howard/Documents/Salency/company-context.md\` (out of repo) gained a \"Pain / Need register rule\" subsection before §200 with the per-section guidance table. Future copy decisions land on the right word without re-litigating.

## Verified
- \`npm run build\` clean (Next.js 16.1.4 + Turbopack)
- All 12 routes prerender
- 5 pain lines + 1 customer need line in how-it-works
- Backend schema (pain_product_mappings) unchanged, no divergence risk

## Merge sequence
PR #36 (test-revamp → main) is open and will pick up this change automatically when it merges here first. Order: merge this PR → PR #36 diff updates → ship to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)