### PR TITLE
Hotfix: apply mixed pain/need register rule to production

### DIFF
--- a/components/sections/HowItWorksSection.tsx
+++ b/components/sections/HowItWorksSection.tsx
@@ -21,16 +21,16 @@ export function HowItWorksSection() {
             <em>Extract</em>
           </h3>
           <p className="desc">
-            Every call is parsed into five structured signal types: customer
-            needs, objections, competitors, requirements, next steps.
-            Enumerated, not summarised. Every signal carries the verbatim
-            quote, the speaker, and the timestamp.
+            Every call is parsed into five structured signal types: pains,
+            objections, competitors, requirements, next steps. Enumerated,
+            not summarised. Every signal carries the verbatim quote, the
+            speaker, and the timestamp.
           </p>
           <div className="ex">
             <div className="el">Example extraction</div>
             <div className="eq">
-              <strong>Customer need</strong> · Account visibility at renewal
-              handoff · Priya Shah, VP Sales · 18:02
+              <strong>Pain</strong> · CS director inherits accounts blind at
+              renewal · Priya Shah, VP Sales · 18:02
             </div>
           </div>
         </div>
@@ -40,16 +40,16 @@ export function HowItWorksSection() {
             <em>Map</em>
           </h3>
           <p className="desc">
-            Each customer need maps to a line in your product catalog, ranked
-            by confidence. Every new call is compared against prior calls on
-            the same account, and contradictions get flagged. The graph keeps
-            growing: needs, products, stakeholders, and how the story has
+            Each pain maps to a line in your product catalog, ranked by
+            confidence. Every new call is compared against prior calls on the
+            same account, and contradictions get flagged. The graph keeps
+            growing: pains, products, stakeholders, and how the story has
             changed over time.
           </p>
           <div className="ex">
             <div className="el">Example mapping</div>
             <div className="eq">
-              Need <em>&ldquo;context across handoffs&rdquo;</em>{' '}
+              Pain <em>&ldquo;handoff loses context&rdquo;</em>{' '}
               <strong>→ 3 products ranked</strong>, contradictions flagged
             </div>
           </div>


### PR DESCRIPTION
## Summary
PR #36 shipped to production before PR #37 landed. Production now has the full \`pain\` → \`customer needs\` swap in how-it-works, which is the wrong call — that swap was rolled back in PR #37 with a mixed-register rule.

This PR carries PR #37's partial revert to main.

## What production currently has (wrong)
- Step 01 signal types: \"customer needs, objections, competitors, requirements, next steps\" ← should be \"pains\"
- Step 01 example tag: \"Customer need · Account visibility at renewal handoff\" ← should be \"Pain · CS director inherits accounts blind at renewal\"
- Step 02 desc: \"Each customer need maps...\" ← should be \"Each pain maps...\" (pain-product mapping = money-slide locked term per §6)
- Step 02 graph list + example: swapped to \"needs\" ← should be \"pains\"

## What this PR fixes (from PR #37)
Mixed register per \`company-context.md\` rule:

| Register | Word |
|----------|------|
| Diagnostic (bad current state) | Pain |
| Technical artifact names (schema, §5 taxonomy, §6 money slide) | Pain |
| Outcome (forward-looking value) | Customer need |

## Kept on main (from PR #36)
- Step 03 outcome: \"every customer need across every account\" (outcome register, correct)
- Lede: \"raw text\" (compatibility signal, correct)
- All other PR #36 content (design polish, notdo positioning, main's loading UI, CSS refactor, route fixes)

## Net diff: 2 commits
\`\`\`
8655ec1 Merge pull request #37 from howardhwt/content/how-it-works-mixed-register
b5d858b content: apply mixed pain/need register rule to how-it-works
\`\`\`

## Why this matters (YC risk)
Prod reads \"Each customer need maps to a line in your product catalog\" — but the backend schema table is literally called \`pain_product_mappings\`. If a YC partner asks a technical follow-up or pokes the API, landing-page copy and product schema diverge. The mixed register restores alignment.

## Verified
- \`npm run build\` clean on test-revamp
- Backend schema unchanged

## Test plan
- [ ] Vercel prod preview renders \"pains\" in Step 01 signal list
- [ ] Step 02 reads \"Each pain maps to a line in your product catalog\"
- [ ] Step 03 still reads \"every customer need across every account\" (outcome register kept)
- [ ] Lede still says \"raw text\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)