### PR TITLE
docs: lock GitHub Flow as branching convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,3 +67,16 @@ Server by default. Client components (`'use client'`): `PageClient`, `Header`, `
 - `DESIGN.md` — full proposed system with tokens, competitive research, SAFE/RISK classification.
 - `SALENCY_LANDING_PAGE.md`, `TASKS.md` — product/positioning context and outstanding work.
 - `.gstack/design-reports/design-preview.html` — live token preview (open in browser).
+
+## Branching strategy (GitHub Flow)
+
+**Trunk = `main`. Feature branches branch off `main`, PR to `main`, merge to `main`. `main` auto-deploys to production.**
+
+- **Never** branch off `test-revamp`, `test`, or any long-lived non-main branch. They're obsolete for this repo.
+- **Vercel preview URL per PR** is the staging environment — review the preview, then merge. No intermediate staging branch needed.
+- **Branch names:** `content/*` for copy, `design/*` for visual, `feat/*` for features, `fix/*` for bugs, `refactor/*` for restructure.
+- **One PR = one logical change.** Small, reviewable, bisectable.
+
+**Why:** Salency's landing page is small + fast-moving. The earlier `feature → test-revamp → main` flow caused ordering bugs (e.g., PR #36 shipped before PR #37, breaking prod copy) and double-PR overhead with no integration-risk benefit that Vercel previews don't already cover.
+
+**If you see an older PR targeting `test-revamp`:** retarget to `main` with `gh pr edit <N> --base main`.


### PR DESCRIPTION
## Summary
Append \"Branching strategy\" section to \`CLAUDE.md\`. Locks GitHub Flow (trunk = \`main\`, feature branches PR directly to \`main\`) as the convention for this repo.

## Why now
Today's session hit the exact failure mode the old flow was vulnerable to: PR #36 merged \`test-revamp\` → \`main\` before PR #37 (the partial revert) landed on \`test-revamp\`, shipping the wrong copy to production. Had to open PR #38 as a hotfix.

Root cause: \`feature → test-revamp → main\` means every feature requires 2 PRs, merge order matters, and there's no integration-risk benefit Vercel preview URLs don't already cover on a small marketing site.

## What the new convention says
- **Trunk = \`main\`.** Feature branches branch off \`main\`, PR to \`main\`, merge to \`main\`. Main auto-deploys to prod.
- **Vercel preview URL per PR = staging.** Review the preview, then merge.
- **Never branch off \`test-revamp\` / \`test\` / any long-lived non-main branch.**
- **Branch naming:** \`content/*\` \`design/*\` \`feat/*\` \`fix/*\` \`refactor/*\`.
- **One PR = one logical change.**

## Follow-up (not this PR)
Decide fate of \`test-revamp\` branch — delete entirely or keep as throwaway sandbox. User's call.

## Test plan
- [ ] CLAUDE.md renders cleanly on GitHub
- [ ] Section is findable (under \"Branching strategy (GitHub Flow)\")

🤖 Generated with [Claude Code](https://claude.com/claude-code)