### PR TITLE
content(cta): rewrite for buyer register + wire ghost to /investors#thesis

### DIFF
--- a/components/sections/CtaSection.tsx
+++ b/components/sections/CtaSection.tsx
@@ -1,23 +1,27 @@
+import Link from 'next/link';
+
 export function CtaSection() {
   return (
     <section className="cta-section">
       <div className="cta-card">
-        <div className="eb">Early access · Q2 2026</div>
+        <div className="eb">Pilot cohort · Spring 2026</div>
         <h2>
           Stop paying the <em>ramp-time tax.</em>
         </h2>
         <p className="sub">
-          A memory layer that outlasts any rep. We&apos;re opening early access
-          to a small group of revenue teams this quarter. Request a slot and
-          we&apos;ll scope a fit together.
+          Most AEs take months to ramp. Every week of that is revenue on the
+          floor. A memory layer that outlasts any rep, so the next hire
+          inherits a Day-1 brief instead of starting from zero.
         </p>
         <div className="btns">
-          <button className="btn btn-primary">Request early access →</button>
-          <button className="btn btn-ghost">Read the memo</button>
+          <button className="btn btn-primary">Request pilot access →</button>
+          <Link href="/investors#thesis" className="btn btn-ghost">
+            Read our thesis
+          </Link>
         </div>
         <div className="fine">
-          No card required · 30-minute scoping call · Works alongside your AI
-          notetaker
+          Works with Gong, Fathom, Fireflies, or raw text · 1–2 week setup
+          · 30-minute scoping call
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary

CTA section rewrite grounded in company-context.md §4 (ramp-time math), §15 (Stripe/Linear voice), §17 (buyer register), §25 (anti-hype traps), §200 (register rule = CTA either works).

## Changes

- **Eyebrow:** \`Early access · Q2 2026\` → \`Pilot cohort · Spring 2026\` (less brittle than calendar quarter; survives June 30)
- **H2:** unchanged — \`Stop paying the ramp-time tax.\` earned, CFO language lock per §4
- **Sub:** rewritten. Opens with ramp-time framing in plain English ("Most AEs take months to ramp. Every week of that is revenue on the floor."), closes with platform callback to Day-1 brief (ties to how-it-works Step 03). No unsourced "5.7 months" or "\$3.5M ARR" numbers — §15 "don't promise outcomes we don't control" + §25 anti-stat-trap
- **Primary:** \`Request early access →\` → \`Request pilot access →\` (semantic echo with eyebrow "Pilot cohort")
- **Ghost:** \`Read the memo\` → \`Read our thesis\`, wired via \`next/link\` to \`/investors#thesis\`. Was dead \`<button>\`. Survives future move of investor content off main page
- **Fine print:** \`No card required · 30-minute scoping call · Works alongside your AI notetaker\` → \`Works with Gong, Fathom, Fireflies, or raw text · 1–2 week setup · 30-minute scoping call\`. Drops consumer-SaaS tell ("No card required"), names integrations per §14, surfaces implementation time

## Out of scope (follow-up)

- **Primary button still dead** — no \`onClick\` handler. Matches site-wide pattern on Hero + MarketingHeader. Wiring all three to the pilot form (or routing logic) is its own PR per user confirmation.

## Test plan

- [ ] Preview URL renders: eyebrow reads "Pilot cohort · Spring 2026", primary = "Request pilot access →", ghost = "Read our thesis"
- [ ] Ghost button navigates to \`/investors#thesis\` and scrolls to the Future-fit thesis card
- [ ] Ghost button keeps \`btn-ghost\` styling (no accidental underline / color drift from \`<Link>\` vs \`<button>\`)
- [ ] Fine print line reads cleanly on mobile (no awkward break on "1–2 week setup")
- [ ] No em-dashes introduced (en-dash in "1–2" is typography-correct per §87)

🤖 Generated with [Claude Code](https://claude.com/claude-code)