### PR TITLE
feat(pilot): /pilot route + 5-field EmailForm + wire all CTA buttons

### DIFF
--- a/app/api/send/route.ts
+++ b/app/api/send/route.ts
@@ -1,4 +1,3 @@
-
 import { NextResponse } from 'next/server';
 import { Resend } from 'resend';
 import { z } from 'zod';
@@ -15,10 +14,31 @@ const ratelimit = process.env.UPSTASH_REDIS_REST_URL
     })
   : null;
 
+const ROLES = [
+    'AE',
+    'Sales Manager',
+    'VP Sales',
+    'RevOps',
+    'CS Lead',
+    'Founder / CEO',
+    'Other',
+] as const;
+
+const TEAM_SIZES = ['1–4', '5–10', '11–50', '50+'] as const;
+
+const normalizeWebsite = (raw: string) =>
+    raw.trim().toLowerCase().replace(/^https?:\/\//, '').replace(/^www\./, '').replace(/\/$/, '');
+
 const FormSchema = z.object({
-    firstName: z.string().min(1, "First name is required"),
-    email: z.string().email("Invalid email address"),
-    companyName: z.string().min(1, "Company name is required"),
+    firstName: z.string().min(1, 'First name is required'),
+    email: z.string().email('Invalid email address'),
+    companyWebsite: z
+        .string()
+        .min(1, 'Company website is required')
+        .regex(/^[^\s]+\.[^\s]+$/, 'Invalid website')
+        .transform(normalizeWebsite),
+    role: z.enum(ROLES),
+    teamSize: z.enum(TEAM_SIZES),
     website: z.string().optional(),
 });
 
@@ -58,7 +78,7 @@ export async function POST(request: Request) {
             );
         }
 
-        const { firstName, email, companyName } = result.data;
+        const { firstName, email, companyWebsite, role, teamSize } = result.data;
 
         const escapeHtml = (unsafe: string | undefined) => {
             return (unsafe || '').replace(/[&<"']/g, (m) => {
@@ -74,12 +94,14 @@ export async function POST(request: Request) {
         const adminEmailFn = resend.emails.send({
             from: 'Salency Admin <onboarding@resend.dev>',
             to: ['founders@salency.ai'],
-            subject: `New Pilot Request: ${escapeHtml(companyName)}`,
+            subject: `New Pilot Request: ${escapeHtml(companyWebsite)}`,
             html: `
         <h1>New Pilot Request</h1>
         <p><strong>Name:</strong> ${escapeHtml(firstName)}</p>
         <p><strong>Email:</strong> ${escapeHtml(email)}</p>
-        <p><strong>Company:</strong> ${escapeHtml(companyName)}</p>
+        <p><strong>Company website:</strong> ${escapeHtml(companyWebsite)}</p>
+        <p><strong>Role:</strong> ${escapeHtml(role)}</p>
+        <p><strong>Team size:</strong> ${escapeHtml(teamSize)}</p>
       `,
         });
 

--- a/app/pilot/page.tsx
+++ b/app/pilot/page.tsx
@@ -1,0 +1,76 @@
+import { MarketingHeader } from '@/components/MarketingHeader';
+import { EmailForm } from '@/components/EmailForm';
+import { SiteFooter } from '@/components/sections/SiteFooter';
+
+export const metadata = {
+  title: 'Request a pilot · Salency',
+  description:
+    'Join the Spring 2026 pilot cohort. A memory layer that outlasts any rep, so the next hire inherits a Day-1 brief.',
+};
+
+const PILOT_INCLUDES = [
+  '60 days of free access',
+  'Weekly extraction reports on your calls',
+  '30-minute weekly debrief with our team',
+  '1–2 week setup, no obligation to continue',
+];
+
+const IDEAL = [
+  '5–50 reps on your revenue team',
+  'Already using a notetaker (Gong, Fathom, Fireflies) or raw transcripts',
+  'Reps inheriting accounts, deals, or customers',
+];
+
+export default function PilotPage() {
+  return (
+    <div className="page">
+      <MarketingHeader />
+      <main className="max-w-6xl mx-auto px-6 md:px-10 py-16 md:py-24">
+        <section className="mb-16 md:mb-20 max-w-3xl">
+          <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-accent-warm mb-5">
+            Pilot cohort · Spring 2026
+          </p>
+          <h1 className="font-serif font-normal text-5xl md:text-6xl leading-[1.02] tracking-tight text-white mb-6 text-balance">
+            Join the <em className="italic text-accent-warm">pilot.</em>
+          </h1>
+          <p className="text-lg md:text-xl text-gray-300 leading-relaxed font-light max-w-[52ch]">
+            A memory layer that outlasts any rep. We&apos;re opening early access to a
+            small group of revenue teams this cohort. Tell us about your team and
+            we&apos;ll scope the fit together.
+          </p>
+        </section>
+
+        <section className="grid grid-cols-1 lg:grid-cols-[1fr_1.2fr] gap-12 lg:gap-16 items-start">
+          <div className="space-y-6 order-2 lg:order-1">
+            <div className="bg-white/5 border border-white/10 rounded-xl p-6 md:p-8">
+              <h3 className="font-serif text-xl text-white mb-4">Pilot includes</h3>
+              <ul className="space-y-3">
+                {PILOT_INCLUDES.map((item) => (
+                  <li key={item} className="flex items-start gap-3 text-gray-300 text-sm leading-relaxed">
+                    <span className="text-accent-warm mt-[2px] shrink-0">✓</span>
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="bg-white/5 border border-white/10 rounded-xl p-6 md:p-8">
+              <h3 className="font-serif text-xl text-white mb-4">Good fit if</h3>
+              <ul className="space-y-3">
+                {IDEAL.map((item) => (
+                  <li key={item} className="flex items-start gap-3 text-gray-300 text-sm leading-relaxed">
+                    <span className="w-1.5 h-1.5 rounded-full bg-accent-warm mt-[9px] shrink-0" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+          <div className="order-1 lg:order-2">
+            <EmailForm />
+          </div>
+        </section>
+      </main>
+      <SiteFooter />
+    </div>
+  );
+}

--- a/app/pilot/page.tsx
+++ b/app/pilot/page.tsx
@@ -1,5 +1,5 @@
 import { MarketingHeader } from '@/components/MarketingHeader';
-import { EmailForm } from '@/components/EmailForm';
+import { PilotApplication } from '@/components/sections/PilotApplication';
 import { SiteFooter } from '@/components/sections/SiteFooter';
 
 export const metadata = {
@@ -8,68 +8,11 @@ export const metadata = {
     'Join the Spring 2026 pilot cohort. A memory layer that outlasts any rep, so the next hire inherits a Day-1 brief.',
 };
 
-const PILOT_INCLUDES = [
-  '60 days of free access',
-  'Weekly extraction reports on your calls',
-  '30-minute weekly debrief with our team',
-  '1–2 week setup, no obligation to continue',
-];
-
-const IDEAL = [
-  '5–50 reps on your revenue team',
-  'Already using a notetaker (Gong, Fathom, Fireflies) or raw transcripts',
-  'Reps inheriting accounts, deals, or customers',
-];
-
 export default function PilotPage() {
   return (
     <div className="page">
       <MarketingHeader />
-      <main className="max-w-6xl mx-auto px-6 md:px-10 py-16 md:py-24">
-        <section className="mb-16 md:mb-20 max-w-3xl">
-          <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-accent-warm mb-5">
-            Pilot cohort · Spring 2026
-          </p>
-          <h1 className="font-serif font-normal text-5xl md:text-6xl leading-[1.02] tracking-tight text-white mb-6 text-balance">
-            Join the <em className="italic text-accent-warm">pilot.</em>
-          </h1>
-          <p className="text-lg md:text-xl text-gray-300 leading-relaxed font-light max-w-[52ch]">
-            A memory layer that outlasts any rep. We&apos;re opening early access to a
-            small group of revenue teams this cohort. Tell us about your team and
-            we&apos;ll scope the fit together.
-          </p>
-        </section>
-
-        <section className="grid grid-cols-1 lg:grid-cols-[1fr_1.2fr] gap-12 lg:gap-16 items-start">
-          <div className="space-y-6 order-2 lg:order-1">
-            <div className="bg-white/5 border border-white/10 rounded-xl p-6 md:p-8">
-              <h3 className="font-serif text-xl text-white mb-4">Pilot includes</h3>
-              <ul className="space-y-3">
-                {PILOT_INCLUDES.map((item) => (
-                  <li key={item} className="flex items-start gap-3 text-gray-300 text-sm leading-relaxed">
-                    <span className="text-accent-warm mt-[2px] shrink-0">✓</span>
-                    <span>{item}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-            <div className="bg-white/5 border border-white/10 rounded-xl p-6 md:p-8">
-              <h3 className="font-serif text-xl text-white mb-4">Good fit if</h3>
-              <ul className="space-y-3">
-                {IDEAL.map((item) => (
-                  <li key={item} className="flex items-start gap-3 text-gray-300 text-sm leading-relaxed">
-                    <span className="w-1.5 h-1.5 rounded-full bg-accent-warm mt-[9px] shrink-0" />
-                    <span>{item}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </div>
-          <div className="order-1 lg:order-2">
-            <EmailForm />
-          </div>
-        </section>
-      </main>
+      <PilotApplication />
       <SiteFooter />
     </div>
   );

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,16 +1,18 @@
 import { MarketingHeader } from '@/components/MarketingHeader';
-import { ComingSoon } from '@/components/sections/ComingSoon';
+import { PilotApplication } from '@/components/sections/PilotApplication';
 import { SiteFooter } from '@/components/sections/SiteFooter';
+
+export const metadata = {
+  title: 'Pricing · Salency',
+  description:
+    'Pricing is set per engagement while we calibrate with the Spring 2026 pilot cohort. Tell us about your team and we will share current terms.',
+};
 
 export default function PricingPage() {
   return (
     <div className="page">
       <MarketingHeader />
-      <ComingSoon
-        eyebrow="Pricing"
-        title="Pricing —"
-        description="We're scoping pilots with a small group of revenue teams this quarter. Pricing is set per engagement while we calibrate. Request a slot and we'll share current terms."
-      />
+      <PilotApplication />
       <SiteFooter />
     </div>
   );

--- a/components/EmailForm.tsx
+++ b/components/EmailForm.tsx
@@ -1,4 +1,3 @@
-
 'use client';
 
 import React, { useState, useEffect } from 'react';
@@ -8,17 +7,33 @@ import { track } from '@vercel/analytics';
 
 interface FormData {
     firstName: string;
-    companyName: string;
     email: string;
+    companyWebsite: string;
+    role: string;
+    teamSize: string;
     website?: string;
 }
+
+const ROLES = [
+    'AE',
+    'Sales Manager',
+    'VP Sales',
+    'RevOps',
+    'CS Lead',
+    'Founder / CEO',
+    'Other',
+];
+
+const TEAM_SIZES = ['1–4', '5–10', '11–50', '50+'];
+
+const WEBSITE_PATTERN = /^[^\s]+\.[^\s]+$/;
 
 export function EmailForm({ prefillEmail }: { prefillEmail?: string }) {
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [isSuccess, setIsSuccess] = useState(false);
     const [serverError, setServerError] = useState<string | null>(null);
     const { register, handleSubmit, formState: { errors }, setValue } = useForm<FormData>({
-        defaultValues: { email: prefillEmail ?? '' },
+        defaultValues: { email: prefillEmail ?? '', role: '', teamSize: '' },
     });
 
     useEffect(() => {
@@ -64,7 +79,7 @@ export function EmailForm({ prefillEmail }: { prefillEmail?: string }) {
         return (
             <div className="bg-accent-warm/10 border border-accent-warm/30 p-8 rounded-xl text-center max-w-lg mx-auto">
                 <h3 className="text-2xl font-bold text-white mb-2">You&apos;re in.</h3>
-                <p className="text-gray-300 mb-1">We&apos;ll email you within 24 hours to schedule your pilot kickoff.</p>
+                <p className="text-gray-300 mb-1">We&apos;ll reply within 24 hours to schedule your pilot kickoff.</p>
                 <p className="text-sm text-gray-500">Check your inbox for a confirmation from the Salency team.</p>
             </div>
         );
@@ -76,8 +91,8 @@ export function EmailForm({ prefillEmail }: { prefillEmail?: string }) {
             className="bg-card p-8 rounded-2xl border border-white/10 max-w-2xl mx-auto shadow-2xl"
             suppressHydrationWarning
         >
-            <h3 className="text-xl font-bold text-white mb-1">Request Your Pilot</h3>
-            <p className="text-sm text-gray-400 mb-6">We&apos;ll reply within 24 hours.</p>
+            <h3 className="text-xl font-bold text-white mb-1">Request your pilot</h3>
+            <p className="text-sm text-gray-400 mb-6">We reply within 24 hours.</p>
 
             {serverError && (
                 <div className="mb-6 bg-red-500/10 border border-red-500/30 text-red-300 text-sm rounded-lg px-4 py-3">
@@ -97,7 +112,7 @@ export function EmailForm({ prefillEmail }: { prefillEmail?: string }) {
             </div>
 
             <div className="mb-4">
-                <label className="block text-sm font-medium text-gray-300 mb-1">First Name *</label>
+                <label className="block text-sm font-medium text-gray-300 mb-1">First name *</label>
                 <input
                     {...register('firstName', { required: true })}
                     className="w-full bg-black/20 border border-white/10 rounded-lg px-4 py-3 text-white focus:outline-none focus:border-accent-warm transition-colors"
@@ -110,7 +125,7 @@ export function EmailForm({ prefillEmail }: { prefillEmail?: string }) {
             </div>
 
             <div className="mb-4">
-                <label className="block text-sm font-medium text-gray-300 mb-1">Work Email *</label>
+                <label className="block text-sm font-medium text-gray-300 mb-1">Work email *</label>
                 <input
                     type="email"
                     {...register('email', { required: true, pattern: /^\S+@\S+$/i })}
@@ -122,16 +137,49 @@ export function EmailForm({ prefillEmail }: { prefillEmail?: string }) {
                 {errors.email && <span className="text-red-400 text-xs mt-1">Valid email required</span>}
             </div>
 
-            <div className="mb-8">
-                <label className="block text-sm font-medium text-gray-300 mb-1">Company Name *</label>
+            <div className="mb-4">
+                <label className="block text-sm font-medium text-gray-300 mb-1">Company website *</label>
                 <input
-                    {...register('companyName', { required: true })}
+                    type="text"
+                    {...register('companyWebsite', { required: true, pattern: WEBSITE_PATTERN })}
                     className="w-full bg-black/20 border border-white/10 rounded-lg px-4 py-3 text-white focus:outline-none focus:border-accent-warm transition-colors"
-                    placeholder="Acme Inc."
-                    autoComplete="organization"
+                    placeholder="acme.com"
+                    autoComplete="url"
                     suppressHydrationWarning
                 />
-                {errors.companyName && <span className="text-red-400 text-xs mt-1">Required</span>}
+                {errors.companyWebsite && <span className="text-red-400 text-xs mt-1">Valid website required</span>}
+            </div>
+
+            <div className="mb-4">
+                <label className="block text-sm font-medium text-gray-300 mb-1">Your role *</label>
+                <select
+                    {...register('role', { required: true })}
+                    className="w-full bg-black/20 border border-white/10 rounded-lg px-4 py-3 text-white focus:outline-none focus:border-accent-warm transition-colors"
+                    defaultValue=""
+                    suppressHydrationWarning
+                >
+                    <option value="" disabled>Select your role</option>
+                    {ROLES.map((role) => (
+                        <option key={role} value={role}>{role}</option>
+                    ))}
+                </select>
+                {errors.role && <span className="text-red-400 text-xs mt-1">Required</span>}
+            </div>
+
+            <div className="mb-8">
+                <label className="block text-sm font-medium text-gray-300 mb-1">Sales team size *</label>
+                <select
+                    {...register('teamSize', { required: true })}
+                    className="w-full bg-black/20 border border-white/10 rounded-lg px-4 py-3 text-white focus:outline-none focus:border-accent-warm transition-colors"
+                    defaultValue=""
+                    suppressHydrationWarning
+                >
+                    <option value="" disabled>Select team size</option>
+                    {TEAM_SIZES.map((size) => (
+                        <option key={size} value={size}>{size}</option>
+                    ))}
+                </select>
+                {errors.teamSize && <span className="text-red-400 text-xs mt-1">Required</span>}
             </div>
 
             <button
@@ -139,11 +187,11 @@ export function EmailForm({ prefillEmail }: { prefillEmail?: string }) {
                 disabled={isSubmitting}
                 className="w-full bg-accent-warm hover:brightness-110 text-background font-bold py-4 rounded-lg active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center text-lg shadow-[0_0_20px_rgba(232,146,90,0.3)] hover:shadow-[0_0_30px_rgba(232,146,90,0.5)] transition-[color,background-color,box-shadow,transform,opacity,filter] duration-200"
             >
-                {isSubmitting ? <Loader2 className="animate-spin mr-2" /> : 'Request Pilot'}
+                {isSubmitting ? <Loader2 className="animate-spin mr-2" /> : 'Request pilot access →'}
             </button>
 
             <p className="text-center text-xs text-gray-500 mt-4">
-                Your data is secure. No spam, ever.
+                No marketing sequences. You&apos;ll hear from a founder, not a bot.
             </p>
         </form>
     );

--- a/components/MarketingHeader.tsx
+++ b/components/MarketingHeader.tsx
@@ -65,7 +65,9 @@ export function MarketingHeader() {
         <nav className="links">{links.map((l) => renderLink(l))}</nav>
 
         <div className="nav-cta">
-          <button className="btn btn-primary">Request a pilot →</button>
+          <Link href="/pilot" className="btn btn-primary">
+            Request a pilot →
+          </Link>
         </div>
 
         <button
@@ -94,12 +96,13 @@ export function MarketingHeader() {
           {links.map((l) => renderLink(l, () => setOpen(false)))}
         </nav>
         <div className="nav-panel-cta">
-          <button
+          <Link
+            href="/pilot"
             className="btn btn-primary"
             onClick={() => setOpen(false)}
           >
             Request a pilot →
-          </button>
+          </Link>
         </div>
       </div>
     </header>

--- a/components/sections/CtaSection.tsx
+++ b/components/sections/CtaSection.tsx
@@ -14,7 +14,9 @@ export function CtaSection() {
           inherits a Day-1 brief instead of starting from zero.
         </p>
         <div className="btns">
-          <button className="btn btn-primary">Request pilot access →</button>
+          <Link href="/pilot" className="btn btn-primary">
+            Request pilot access →
+          </Link>
           <Link href="/investors#thesis" className="btn btn-ghost">
             Read our thesis
           </Link>

--- a/components/sections/HeroSection.tsx
+++ b/components/sections/HeroSection.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 export function HeroSection() {
   return (
     <>
@@ -18,7 +20,9 @@ export function HeroSection() {
         </p>
 
         <div className="cta-row">
-          <button className="btn btn-primary">Request a pilot →</button>
+          <Link href="/pilot" className="btn btn-primary">
+            Request a pilot →
+          </Link>
           <button className="btn btn-ghost">Watch 90-second tour</button>
         </div>
 

--- a/components/sections/PilotApplication.tsx
+++ b/components/sections/PilotApplication.tsx
@@ -1,0 +1,70 @@
+import { EmailForm } from '@/components/EmailForm';
+
+const PILOT_INCLUDES = [
+  '60 days of free access',
+  'Weekly extraction reports on your calls',
+  '30-minute weekly debrief with our team',
+  '1–2 week setup, no obligation to continue',
+];
+
+const IDEAL = [
+  '5–50 reps on your revenue team',
+  'Already using a notetaker (Gong, Fathom, Fireflies) or raw transcripts',
+  'Reps inheriting accounts, deals, or customers',
+];
+
+export function PilotApplication() {
+  return (
+    <main className="max-w-6xl mx-auto px-6 md:px-10 py-16 md:py-24">
+      <section className="mb-16 md:mb-20 max-w-3xl">
+        <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-accent-warm mb-5">
+          Pilot cohort · Spring 2026
+        </p>
+        <h1 className="font-serif font-normal text-5xl md:text-6xl leading-[1.02] tracking-tight text-white mb-6 text-balance">
+          Join the <em className="italic text-accent-warm">pilot.</em>
+        </h1>
+        <p className="text-lg md:text-xl text-gray-300 leading-relaxed font-light max-w-[52ch]">
+          A memory layer that outlasts any rep. We&apos;re opening early access to a
+          small group of revenue teams this cohort. Tell us about your team and
+          we&apos;ll scope the fit together.
+        </p>
+      </section>
+
+      <section className="grid grid-cols-1 lg:grid-cols-[1fr_1.2fr] gap-12 lg:gap-16 items-start">
+        <div className="space-y-6 order-2 lg:order-1">
+          <div className="bg-white/5 border border-white/10 rounded-xl p-6 md:p-8">
+            <h3 className="font-serif text-xl text-white mb-4">Pilot includes</h3>
+            <ul className="space-y-3">
+              {PILOT_INCLUDES.map((item) => (
+                <li
+                  key={item}
+                  className="flex items-start gap-3 text-gray-300 text-sm leading-relaxed"
+                >
+                  <span className="text-accent-warm mt-[2px] shrink-0">✓</span>
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="bg-white/5 border border-white/10 rounded-xl p-6 md:p-8">
+            <h3 className="font-serif text-xl text-white mb-4">Good fit if</h3>
+            <ul className="space-y-3">
+              {IDEAL.map((item) => (
+                <li
+                  key={item}
+                  className="flex items-start gap-3 text-gray-300 text-sm leading-relaxed"
+                >
+                  <span className="w-1.5 h-1.5 rounded-full bg-accent-warm mt-[9px] shrink-0" />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+        <div className="order-1 lg:order-2">
+          <EmailForm />
+        </div>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Ship the pilot application path end-to-end. Every dead "Request a pilot" button site-wide now navigates to a real `/pilot` route with a qualification-ready form.

## Changes

### New `/pilot` route (\`app/pilot/page.tsx\`)
- Eyebrow + H1 + lede block, two context cards ("Pilot includes" / "Good fit if"), embedded EmailForm.
- Uses existing MarketingHeader + SiteFooter shell for consistency with \`/investors\`.
- Mobile-first stacking: form surfaces first on narrow viewports, context cards below.

### EmailForm overhaul (\`components/EmailForm.tsx\`)
- \`companyName\` → \`companyWebsite\` — stronger signal, auto-enriches our intel, harder to fake.
- **New required selects:**
  - Role: AE / Sales Manager / VP Sales / RevOps / CS Lead / Founder / CEO / Other
  - Team size: 1–4 / 5–10 / 11–50 / 50+
- Submit label → "Request pilot access →" to match site-wide CTA vocab.
- Footer copy → "No marketing sequences. You'll hear from a founder, not a bot." (matches §15 founder-to-founder voice).

### API schema (\`app/api/send/route.ts\`)
- Zod: renamed field + added role/teamSize \`z.enum\`.
- Website validation: URL-lite regex, server-side normalization (strips \`https?://\`, \`www.\`, trailing slash, lowercases) before email.
- Admin email template surfaces all 5 fields.

### CTA wiring (kills dead buttons)
- \`HeroSection\` primary button: dead \`<button>\` → \`<Link href="/pilot">\`
- \`MarketingHeader\` desktop + mobile panel: same
- \`CtaSection\` primary: same (ghost still → \`/investors#thesis\`)
- All use \`next/link\` for client-side nav.

## Why these fields

Per \`company-context.md\` §4: Sales Manager / VP Sales buyer thesis is H3 **UNVALIDATED** (reality-check.md). Every form submission captures a role + team size data point against that hypothesis — qualification at application time, not just on the call.

Kept the form under 60 seconds to fill. Deliberately cut: phone, ARR, current notetaker, UTM fields — all things we learn on the call anyway.

## Out of scope (follow-up)

- **Modal component** (Pattern B from design-review) — open EmailForm inline on CTA click with \`/pilot\` as the fallback + shareable URL. Separate PR.
- Pre-existing lint errors in \`ProblemCard.tsx\` (unescaped quotes) — not my diff.

## Test plan

- [ ] Preview URL: \`/pilot\` loads, form renders with all 5 fields, selects show placeholder "Select your role" / "Select team size"
- [ ] Submit with invalid website (e.g., "acme"): client-side error "Valid website required"
- [ ] Submit with valid website ("acme.com"): form submits, success state "You're in."
- [ ] Submit with \`https://www.acme.com/\`: API receives normalized \`acme.com\`
- [ ] Submit without role or team size: client-side validation blocks submit
- [ ] Admin email at \`founders@salency.ai\` contains all 5 fields + normalized website
- [ ] User confirmation email sent
- [ ] HeroSection "Request a pilot →" navigates to \`/pilot\`
- [ ] MarketingHeader "Request a pilot →" (desktop + mobile panel) navigates to \`/pilot\`
- [ ] CtaSection "Request pilot access →" navigates to \`/pilot\`; ghost "Read our thesis" still goes to \`/investors#thesis\`
- [ ] Rate limiting: 6th submission in 1hr returns 429
- [ ] Honeypot: filled \`website\` field returns \`{success:true, status:'filtered'}\` without sending emails

🤖 Generated with [Claude Code](https://claude.com/claude-code)