### PR TITLE
refactor(form+pilot): extract .btn-submit + .pilot-app to native-nested CSS

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -646,6 +646,57 @@ html {
   }
   .btn-ghost:hover{background:rgba(232,230,227,0.08);border-color:rgba(232,230,227,0.22)}
 
+  .btn-submit{
+    display:flex;align-items:center;justify-content:center;gap:8px;
+    width:100%;cursor:pointer;
+    font-family:var(--font-body), 'Geist', sans-serif;font-weight:600;font-size:16px;
+    padding:16px 24px;border-radius:8px;border:0;
+    color:#1A0A02;
+    background:linear-gradient(180deg, #FE9544 0%, var(--copper) 50%, var(--copper-deep) 100%);
+    box-shadow:
+      inset 0 1px 0 rgba(255,255,255,.25),
+      inset 0 -1px 0 rgba(0,0,0,.2),
+      0 1px 0 rgba(0,0,0,.3),
+      0 8px 24px -8px rgba(254,133,49,.5);
+    transition:filter .18s ease, opacity .18s ease;
+
+    &:hover{filter:brightness(1.1)}
+    &:disabled{opacity:.5;cursor:not-allowed}
+    &:disabled:hover{filter:none}
+  }
+
+  .pilot-app{
+    .eb{
+      font-family:'Geist Mono','SFMono-Regular',Consolas,monospace;
+      font-size:11px;font-weight:500;letter-spacing:.18em;
+      text-transform:uppercase;color:var(--copper);
+      display:inline-flex;align-items:center;gap:10px;
+
+      &::before{
+        content:"";width:28px;height:1px;background:var(--copper);display:inline-block;
+      }
+    }
+    h1{
+      font-family:var(--font-display), 'Instrument Serif', serif;
+      font-weight:400;line-height:1.04;letter-spacing:-.025em;
+      color:var(--ink);
+
+      em{font-style:italic;color:var(--copper)}
+    }
+    .pilot-lede{
+      font-family:var(--font-body), 'Geist', sans-serif;
+      font-weight:300;line-height:1.55;color:var(--ink-2);
+    }
+    h3{
+      font-family:var(--font-display), 'Instrument Serif', serif;
+      font-weight:400;line-height:1.2;color:var(--ink);
+    }
+    li{
+      font-family:var(--font-body), 'Geist', sans-serif;
+      line-height:1.55;color:var(--ink-2);
+    }
+  }
+
   /* ═══════════ Hero ═══════════ */
   .hero{
     max-width:1280px;margin:0 auto;

--- a/components/EmailForm.tsx
+++ b/components/EmailForm.tsx
@@ -237,7 +237,7 @@ export function EmailForm({ prefillEmail }: { prefillEmail?: string }) {
             <button
                 type="submit"
                 disabled={isSubmitting}
-                className="w-full bg-accent-warm hover:brightness-110 text-background font-bold py-4 rounded-lg active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 text-lg shadow-[0_0_20px_rgba(232,146,90,0.3)] hover:shadow-[0_0_30px_rgba(232,146,90,0.5)] transition-[color,background-color,box-shadow,transform,opacity,filter] duration-200"
+                className="btn-submit"
             >
                 {isSubmitting && <Loader2 className="animate-spin w-5 h-5" />}
                 <span>{isSubmitting ? 'Submitting' : 'Request Pilot'}</span>

--- a/components/sections/PilotApplication.tsx
+++ b/components/sections/PilotApplication.tsx
@@ -15,15 +15,13 @@ const IDEAL = [
 
 export function PilotApplication() {
   return (
-    <main className="max-w-6xl mx-auto px-6 md:px-10 py-16 md:py-24">
+    <main className="pilot-app max-w-6xl mx-auto px-6 md:px-10 py-16 md:py-24">
       <section className="mb-16 md:mb-20 max-w-3xl">
-        <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-accent-warm mb-5">
-          Pilot cohort · Spring 2026
-        </p>
-        <h1 className="font-serif font-normal text-5xl md:text-6xl leading-[1.02] tracking-tight text-white mb-6 text-balance">
-          Join the <em className="italic text-accent-warm">pilot.</em>
+        <p className="eb mb-5">Pilot cohort · Spring 2026</p>
+        <h1 className="text-5xl md:text-6xl mb-6 text-balance">
+          Join the <em>pilot.</em>
         </h1>
-        <p className="text-lg md:text-xl text-gray-300 leading-relaxed font-light max-w-[52ch]">
+        <p className="pilot-lede text-lg md:text-xl max-w-[52ch]">
           A memory layer that outlasts any rep. We&apos;re opening early access to a
           small group of revenue teams this cohort. Tell us about your team and
           we&apos;ll scope the fit together.
@@ -33,13 +31,10 @@ export function PilotApplication() {
       <section className="grid grid-cols-1 lg:grid-cols-[1fr_1.2fr] gap-12 lg:gap-16 items-start">
         <div className="space-y-6 order-2 lg:order-1">
           <div className="bg-white/5 border border-white/10 rounded-xl p-6 md:p-8">
-            <h3 className="font-serif text-xl text-white mb-4">Pilot includes</h3>
+            <h3 className="text-xl mb-4">Pilot includes</h3>
             <ul className="space-y-3">
               {PILOT_INCLUDES.map((item) => (
-                <li
-                  key={item}
-                  className="flex items-start gap-3 text-gray-300 text-sm leading-relaxed"
-                >
+                <li key={item} className="flex items-start gap-3 text-sm">
                   <span className="text-accent-warm mt-[2px] shrink-0">✓</span>
                   <span>{item}</span>
                 </li>
@@ -47,13 +42,10 @@ export function PilotApplication() {
             </ul>
           </div>
           <div className="bg-white/5 border border-white/10 rounded-xl p-6 md:p-8">
-            <h3 className="font-serif text-xl text-white mb-4">Good fit if</h3>
+            <h3 className="text-xl mb-4">Good fit if</h3>
             <ul className="space-y-3">
               {IDEAL.map((item) => (
-                <li
-                  key={item}
-                  className="flex items-start gap-3 text-gray-300 text-sm leading-relaxed"
-                >
+                <li key={item} className="flex items-start gap-3 text-sm">
                   <span className="w-1.5 h-1.5 rounded-full bg-accent-warm mt-[9px] shrink-0" />
                   <span>{item}</span>
                 </li>


### PR DESCRIPTION
## Summary
- **Form submit button** moved from a ~280-char Tailwind arbitrary-value stack in JSX to a single \`.btn-submit\` class in \`globals.css\` using native CSS nesting (\`&:hover\`, \`&:disabled\`, \`&:disabled:hover\`). Visually matches \`.btn .btn-primary\` (copper gradient, inset+drop shadow stack, near-black text, font-semibold) with the form-preferred \`hover:brightness-110\` only (no lift).
- **Pilot/Pricing typography fix** — new \`.pilot-app\` nested block maps descendant \`h1\`/\`h3\`/\`.eb\`/\`.pilot-lede\`/\`li\` to the site's font tokens (Instrument Serif for headings, Geist Mono for eyebrow, Geist for body). Fixes the drift where \`/pricing\` and \`/pilot\` rendered generic system serif from Tailwind's default \`font-serif\` utility instead of the design-system fonts.
- **Convention alignment** — renamed \`.pilot-eb\` → \`.eb\` (scoped inside \`.pilot-app\`) to match \`.prob-head .eb\`, \`.how-head .eb\`, \`.gong-head .eb\`, \`.platform .eb\`, \`.coming-soon .eb\`. Added \`.eb::before\` 28×1px copper dash to match the other section eyebrows.
- **JSX cleanup** — \`PilotApplication.tsx\` drops redundant font/color/tracking/leading Tailwind utilities now owned by the scoped CSS; keeps layout-only utilities.

## Test plan
- [ ] Open the pilot modal (any CTA) and submit the form — button renders with copper gradient, inset/drop/glow shadows, \`hover:brightness-110\` on hover, \`Submitting\` label + spinner centered during submission.
- [ ] Visit \`/pricing\` and \`/pilot\` — h1 "Join the pilot." renders in Instrument Serif (not generic system serif); eyebrow shows the leading 28×1px copper dash before "Pilot cohort · Spring 2026"; body/list text renders in Geist.
- [ ] Compare \`/pricing\` typography against \`/\` hero — same font family, same editorial feel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)