### PR TITLE
refactor(css): unify standalone intro container, canonical eyebrow, rename cryptic classes

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -45,7 +45,7 @@ Both `--font-body` and `--font-display` currently resolve to **Instrument Sans**
 
 | Role | Font | Weight | Used on |
 |---|---|---|---|
-| Hero h1, section h2, card h3, editorial accents | `var(--font-display)` (Instrument Sans) | 400 normal, 400 italic for `em` | `.h1`, `.hero h1`, `.prob-head h2`, `.how-head h2`, `.gong-head h2`, `.platform h2`, `.thesis-card h2`, `.coming-soon h1`, `.pilot-app h1`/`h3`, `.inv-intro h1`, `.founder .name` |
+| Hero h1, section h2, card h3, editorial accents | `var(--font-display)` (Instrument Sans) | 400 normal, 400 italic for `em` | `.h1`, `.hero h1`, `.prob-head h2`, `.how-head h2`, `.notetaker-head h2`, `.platform h2`, `.thesis-card h2`, `.coming-soon h1`, `.pilot-app h1`/`h3`, `.inv-intro h1`, `.founder .name` |
 | Body, ledes, paragraph text, list items | `var(--font-body)` (Instrument Sans) | 300 for ledes, 400 for body | `.sub`, `.how-head .lede`, `.platform p`, `.inv-intro p`, `.pilot-lede`, `.founder .bio`, `.thesis-card p` |
 | Eyebrows, meta strips, labels, pill tags, footer legal | `'Geist Mono', monospace` | 400 or 500 | `.eb`, `.hero-meta`, `.inv-intro-meta`, `.founder .role`, `.roadmap-card .v`, `.sample-label`, `footer`, legal pages |
 | Brand wordmark (header logo) | `var(--font-outfit)` | 800 | `.brand .name`, `.nav-brand` |
@@ -199,7 +199,7 @@ Used on every marketing section to label the content area.
 Shipped copies (all use the same 28×1 dash, copper, `.18em` tracking):
 - `.prob-head .eb` / `::before` — Problem section
 - `.how-head .eb` / `::before` — How it works
-- `.gong-head .eb` / `::before` — Gong comparison
+- `.notetaker-head .eb` / `::before` — Notetaker comparison
 - `.platform .eb` / `::before` — Platform framing (investors)
 - `.coming-soon .eb` / `::before` — Pricing + Memory stubs
 - `.pilot-app .eb` / `::before` — Pilot + Pricing page intro

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -143,14 +143,14 @@ Wider sections (investor) use `max-width: 1100px` with the same padding. Legal p
 - First section on a page: `padding: 48–96px top`.
 - Last section before footer: `padding-bottom: 96–120px`.
 
-### Standalone section container — `max-width:1280px; margin:140px auto 0; padding:0 40px` (canonical)
+### Standalone section container — `max-width:1280px; margin:80px auto 0; padding:20px 40px` (canonical)
 
-Every marketing section that sits at the top of a standalone page (not home) uses the same container: 1280px max-width, `140px` top margin as header-to-content spacing, no vertical padding, `40px` fixed horizontal padding. Selectors:
+Every marketing section that sits at the top of a standalone page (not home) uses the same container: 1280px max-width, `80px` top margin as header-to-content spacing, `20px` vertical padding, `40px` fixed horizontal padding. Selectors:
 
-- `.prob` (the Problem section — shared with home as a mid-page spacer, with the same `140px` acting as section-to-section rhythm there)
+- `.prob` (the Problem section — shared with home as a mid-page spacer, with the same `80px` acting as section-to-section rhythm there)
 - `.coming-soon` (on `/memory`)
 - `.inv-intro` (on `/investors`)
-- `.pilot-app` (on `/pilot` and `/pricing`, applied via `max-w-[1280px] mx-auto px-10 mt-[140px]` in `PilotApplication.tsx`)
+- `.pilot-app` (on `/pilot` and `/pricing`, applied via `max-w-[1280px] mx-auto mt-20 px-10 py-5` in `PilotApplication.tsx`)
 
 Home (`/`) hero uses the tighter `.hero` 96/40/72 variant because it has more above-the-fold content. Legal pages (`/privacy`, `/terms`) use `pt-32` (128px) via Tailwind since they're narrow-measure prose.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -177,9 +177,9 @@ Used on every marketing section to label the content area.
 ```css
 .eb {
   font-family: 'Geist Mono', monospace;
-  font-size: 10–11px;
+  font-size: 11px;
   font-weight: 500;
-  letter-spacing: .16–.18em;
+  letter-spacing: .18em;
   text-transform: uppercase;
   color: var(--copper);
   display: inline-flex;

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -143,15 +143,16 @@ Wider sections (investor) use `max-width: 1100px` with the same padding. Legal p
 - First section on a page: `padding: 48–96px top`.
 - Last section before footer: `padding-bottom: 96–120px`.
 
-### Standalone intro padding — `120px 40px 96px` (canonical)
+### Standalone section container — `max-width:1280px; margin:140px auto 0; padding:0 40px` (canonical)
 
-Every standalone marketing page (pages accessed from the MarketingHeader nav that aren't the home page) uses the same intro padding so header-to-content spacing feels identical across the site. Selectors:
+Every marketing section that sits at the top of a standalone page (not home) uses the same container: 1280px max-width, `140px` top margin as header-to-content spacing, no vertical padding, `40px` fixed horizontal padding. Selectors:
 
+- `.prob` (the Problem section — shared with home as a mid-page spacer, with the same `140px` acting as section-to-section rhythm there)
 - `.coming-soon` (on `/memory`)
 - `.inv-intro` (on `/investors`)
-- `.pilot-app` (on `/pilot` and `/pricing`, applied via `pt-[120px] pb-24 px-6 md:px-10` in `PilotApplication.tsx`)
+- `.pilot-app` (on `/pilot` and `/pricing`, applied via `max-w-[1280px] mx-auto px-10 mt-[140px]` in `PilotApplication.tsx`)
 
-Home (`/`) uses the tighter `.hero` 96/40/72 variant because it has more above-the-fold content. Legal pages (`/privacy`, `/terms`) use `pt-32` (128px) via Tailwind since they're narrow-measure prose.
+Home (`/`) hero uses the tighter `.hero` 96/40/72 variant because it has more above-the-fold content. Legal pages (`/privacy`, `/terms`) use `pt-32` (128px) via Tailwind since they're narrow-measure prose.
 
 ### Card / card-like surfaces
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -276,7 +276,7 @@ html {
       filter:drop-shadow(0 4px 10px rgba(0,0,0,.35));
     }
 
-    .hub-input-lbl{
+    .hub-input-label{
       font-family:var(--font-body), 'Geist', sans-serif;
       font-size:12px;color:var(--ink);
       letter-spacing:.01em;text-align:center;line-height:1.25;
@@ -373,17 +373,17 @@ html {
       transition:transform .2s ease;
     }
 
-    .hub-outcome-rk{
+    .hub-outcome-role{
       font-family:'Geist Mono',monospace;font-size:10px;font-weight:500;
       letter-spacing:.2em;text-transform:uppercase;color:var(--copper);
     }
 
-    .hub-outcome-rt{
+    .hub-outcome-role-title{
       font-family:var(--font-display), 'Instrument Serif', serif;
       font-weight:400;font-size:20px;line-height:1.2;color:var(--ink);
     }
 
-    .hub-outcome-rs{
+    .hub-outcome-role-summary{
       font-family:var(--font-body), 'Geist', sans-serif;font-weight:300;
       font-size:12.5px;color:var(--ink-3);line-height:1.45;
     }
@@ -442,7 +442,7 @@ html {
       .hub-core-name{font-size:28px}
       .hub-core-mark{width:36px;height:36px}
       .hub-outcome{padding:20px 22px}
-      .hub-outcome-rt{font-size:17px}
+      .hub-outcome-role-title{font-size:17px}
     }
 
     @media (max-width:900px){
@@ -473,7 +473,7 @@ html {
 
       .hub-input{position:static;left:auto;top:auto!important;width:auto;transform:none}
       .hub-input-ic{width:40px;height:40px}
-      .hub-input-lbl{font-size:11px}
+      .hub-input-label{font-size:11px}
 
       .hub-core{padding:8px 0}
       .hub-core-name{font-size:26px}
@@ -1024,7 +1024,7 @@ html {
 
   /* ═══════════ Problem section ═══════════ */
   .prob{
-    max-width:1280px;margin:140px auto 0;padding:0 40px;
+    max-width:1280px;margin:80px auto 0;padding:20px 40px;
   }
   .prob-head{
     display:grid;grid-template-columns:1fr 1.1fr;gap:64px;align-items:end;
@@ -1072,12 +1072,12 @@ html {
   .prob-card .idx::after{
     content:"";flex:1;height:1px;background:var(--hair);
   }
-  .prob-card .ttl{
+  .prob-card .title{
     font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;
     font-size:30px;line-height:1.1;letter-spacing:-.02em;color:var(--ink);
     margin:0 0 16px;max-width:14ch;
   }
-  .prob-card .ttl em{font-style:italic;color:var(--copper)}
+  .prob-card .title em{font-style:italic;color:var(--copper)}
   .prob-card .desc{
     font-family:var(--font-body), 'Geist', sans-serif;font-weight:300;font-size:14.5px;
     line-height:1.6;color:var(--ink-2);margin:0 0 24px;max-width:32ch;
@@ -1090,7 +1090,7 @@ html {
     font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;font-weight:400;
     font-size:40px;line-height:1;color:var(--copper);letter-spacing:-.02em;
   }
-  .prob-card .cost .lbl{
+  .prob-card .cost .label{
     font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
     letter-spacing:.12em;text-transform:uppercase;color:var(--ink-3);
     line-height:1.4;max-width:18ch;
@@ -1102,20 +1102,20 @@ html {
     border-left:2px solid var(--copper);border-radius:0 12px 12px 0;
     display:grid;grid-template-columns:auto 1fr auto;gap:28px;align-items:center;
   }
-  .prob-resolve .rlbl{
+  .prob-resolve .label{
     font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
     letter-spacing:.18em;text-transform:uppercase;color:var(--copper);
   }
-  .prob-resolve .rtxt{
+  .prob-resolve .text{
     font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;font-size:22px;
     line-height:1.3;letter-spacing:-.01em;color:var(--ink);max-width:64ch;
   }
-  .prob-resolve .rtxt em{font-style:italic;color:var(--copper)}
-  .prob-resolve .ra{
+  .prob-resolve .text em{font-style:italic;color:var(--copper)}
+  .prob-resolve .link{
     font-family:var(--font-body), 'Geist', sans-serif;font-size:13.5px;color:var(--copper);
     white-space:nowrap;font-weight:500;
   }
-  .prob-resolve .ra:hover{color:#FE9F5B}
+  .prob-resolve .link:hover{color:#FE9F5B}
 
   /* ═══════════ CTA ═══════════ */
   .cta-section{
@@ -1209,14 +1209,14 @@ html {
     padding:14px 16px;background:rgba(254,133,49,.04);
     border:1px solid rgba(254,133,49,.12);border-radius:8px;
   }
-  .how-step .ex .el{
+  .how-step .ex .example-label{
     font-family:'Geist Mono',monospace;font-size:9.5px;font-weight:500;
     letter-spacing:.18em;text-transform:uppercase;color:var(--copper);margin-bottom:6px;
   }
-  .how-step .ex .eq{
+  .how-step .ex .example-quote{
     font-family:var(--font-body), 'Geist', sans-serif;font-size:13px;line-height:1.45;color:var(--ink-2);
   }
-  .how-step .ex .eq strong{color:var(--ink);font-weight:500}
+  .how-step .ex .example-quote strong{color:var(--ink);font-weight:500}
   .how-foot{
     margin-top:28px;padding:18px 24px;
     display:flex;justify-content:space-between;align-items:center;gap:24px;
@@ -1233,12 +1233,12 @@ html {
     padding:32px 40px;
     display:grid;grid-template-columns:auto 1fr;gap:40px;align-items:start;
   }
-  .notdo-card .hdr{
+  .notdo-card .header{
     font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;font-size:26px;
     line-height:1.2;letter-spacing:-.015em;color:var(--ink);max-width:10ch;
   }
-  .notdo-card .hdr em{font-style:italic;color:var(--copper)}
-  .notdo-card .hdr .eb{
+  .notdo-card .header em{font-style:italic;color:var(--copper)}
+  .notdo-card .header .eb{
     display:block;font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
     letter-spacing:.2em;text-transform:uppercase;color:var(--ink-4);margin-bottom:10px;
   }
@@ -1257,8 +1257,8 @@ html {
   }
   .notdo-item .x{color:var(--rust)}
   .notdo-item .check{color:var(--copper)}
-  .notdo-item .t{font-size:14.5px;color:var(--ink);font-weight:400;line-height:1.4;grid-column:2}
-  .notdo-item .s{font-size:13px;color:var(--ink-3);line-height:1.5;grid-column:2}
+  .notdo-item .title{font-size:14.5px;color:var(--ink);font-weight:400;line-height:1.4;grid-column:2}
+  .notdo-item .subtitle{font-size:13px;color:var(--ink-3);line-height:1.5;grid-column:2}
 
   /* ═══════════ Gong comparison table ═══════════ */
   .gong{max-width:1280px;margin:140px auto 0;padding:0 40px}
@@ -1306,12 +1306,12 @@ html {
   .gong-table tbody td.col-s{background:rgba(254,133,49,.03);color:var(--ink)}
   .gong-table tbody td.col-s strong{color:var(--copper);font-weight:500}
   .gong-table tbody td.col-g{color:var(--ink-3)}
-  .gong-table .ic{
+  .gong-table .icon{
     display:inline-block;margin-right:8px;font-family:'Geist Mono',monospace;
     font-size:11px;width:16px;text-align:center;
   }
-  .gong-table .col-s .ic{color:var(--copper)}
-  .gong-table .col-g .ic{color:var(--ink-4)}
+  .gong-table .col-s .icon{color:var(--copper)}
+  .gong-table .col-g .icon{color:var(--ink-4)}
 
   /* ═══════════ Investor register ═══════════ */
   .reg-inv{
@@ -1357,11 +1357,11 @@ html {
       background:rgba(254,133,49,.05);border:1px solid rgba(254,133,49,.18);
       border-radius:12px;display:grid;grid-template-columns:auto 1fr;gap:28px;align-items:center;
 
-      .lbl{
+      .label{
         font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
         letter-spacing:.18em;text-transform:uppercase;color:var(--copper);
       }
-      .tt{
+      .title{
         font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;font-size:22px;
         line-height:1.35;color:var(--ink);max-width:62ch;margin:0;
 
@@ -1379,12 +1379,12 @@ html {
       background:rgba(255,255,255,.02);
       display:grid;grid-template-columns:auto 1fr;gap:24px;align-items:center;
 
-      .v{
+      .pill{
         font-family:'Geist Mono',monospace;font-size:11px;font-weight:500;letter-spacing:.18em;
         text-transform:uppercase;color:var(--copper);padding:6px 12px;
         border:1px solid rgba(254,133,49,.28);border-radius:999px;
       }
-      .t{
+      .body{
         font-family:var(--font-body), 'Geist', sans-serif;font-size:15.5px;color:var(--ink);font-weight:400;
 
         em{font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;color:var(--copper);font-size:16.5px;font-weight:400}
@@ -1450,7 +1450,7 @@ html {
       padding:14px 18px;border-left:2px solid rgba(254,133,49,.4);
       background:rgba(254,133,49,.03);
 
-      .lbl{
+      .label{
         font-family:'Geist Mono',monospace;font-size:10px;font-weight:500;
         letter-spacing:.18em;text-transform:uppercase;color:var(--copper);margin-bottom:4px;
       }
@@ -1539,7 +1539,7 @@ html {
   }
 
   .inv-intro{
-    max-width:1280px;margin:0 auto;padding:120px 40px 96px;
+    max-width:1280px;margin:80px auto 0;padding:20px 40px;
     border-bottom:1px solid var(--hair);position:relative;
 
     &::after{
@@ -1666,8 +1666,7 @@ header button:focus:not(:focus-visible){
 
 /* ═══════════ Coming-soon stub pages ═══════════ */
 .coming-soon{
-  max-width:1280px;margin:0 auto;
-  padding:120px 40px 96px;
+  max-width:1280px;margin:80px auto 0;padding:20px 40px;
 }
 .coming-soon-inner{max-width:780px}
 .coming-soon .eb{

--- a/app/globals.css
+++ b/app/globals.css
@@ -1671,8 +1671,8 @@ header button:focus:not(:focus-visible){
 }
 .coming-soon-inner{max-width:780px}
 .coming-soon .eb{
-  font-family:'Geist Mono',monospace;font-size:10px;font-weight:500;
-  letter-spacing:.16em;text-transform:uppercase;color:var(--copper);
+  font-family:'Geist Mono',monospace;font-size:11px;font-weight:500;
+  letter-spacing:.18em;text-transform:uppercase;color:var(--copper);
   display:inline-flex;align-items:center;gap:10px;margin-bottom:24px;
 }
 .coming-soon .eb::before{

--- a/app/globals.css
+++ b/app/globals.css
@@ -1260,58 +1260,58 @@ html {
   .notdo-item .title{font-size:14.5px;color:var(--ink);font-weight:400;line-height:1.4;grid-column:2}
   .notdo-item .subtitle{font-size:13px;color:var(--ink-3);line-height:1.5;grid-column:2}
 
-  /* ═══════════ Gong comparison table ═══════════ */
-  .gong{max-width:1280px;margin:140px auto 0;padding:0 40px}
-  .gong-head{margin-bottom:48px;max-width:56ch}
-  .gong-head .eb{
+  /* ═══════════ Notetaker comparison table ═══════════ */
+  .notetaker{max-width:1280px;margin:140px auto 0;padding:0 40px}
+  .notetaker-head{margin-bottom:48px;max-width:56ch}
+  .notetaker-head .eb{
     font-family:'Geist Mono',monospace;font-size:11px;font-weight:500;
     letter-spacing:.18em;text-transform:uppercase;color:var(--copper);
     margin-bottom:18px;display:flex;align-items:center;gap:10px;
   }
-  .gong-head .eb::before{content:"";width:28px;height:1px;background:var(--copper);display:inline-block}
-  .gong-head h2{
+  .notetaker-head .eb::before{content:"";width:28px;height:1px;background:var(--copper);display:inline-block}
+  .notetaker-head h2{
     font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;
     font-size:clamp(40px,4.5vw,58px);line-height:1.04;letter-spacing:-.025em;
     margin:0 0 18px;color:var(--ink);text-wrap:balance;
   }
-  .gong-head h2 em{font-style:italic;color:var(--copper)}
-  .gong-head p{font-family:var(--font-body), 'Geist', sans-serif;font-weight:300;font-size:16px;line-height:1.65;color:var(--ink-2);margin:0}
-  .gong-table{
+  .notetaker-head h2 em{font-style:italic;color:var(--copper)}
+  .notetaker-head p{font-family:var(--font-body), 'Geist', sans-serif;font-weight:300;font-size:16px;line-height:1.65;color:var(--ink-2);margin:0}
+  .notetaker-table{
     width:100%;border-collapse:collapse;
     background:#121015;border:1px solid var(--hair-2);border-radius:14px;overflow:hidden;
   }
-  .gong-table thead th{
+  .notetaker-table thead th{
     padding:22px 24px;text-align:left;border-bottom:1px solid var(--hair-2);
     font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
     letter-spacing:.18em;text-transform:uppercase;color:var(--ink-3);
   }
-  .gong-table thead th.col-s{color:var(--copper);background:rgba(254,133,49,.04)}
-  .gong-table thead th.col-s .brand{
+  .notetaker-table thead th.col-s{color:var(--copper);background:rgba(254,133,49,.04)}
+  .notetaker-table thead th.col-s .brand{
     display:block;font-family:var(--font-display), 'Instrument Serif', serif;font-size:22px;font-weight:400;
     letter-spacing:-.01em;color:var(--ink);text-transform:none;margin-top:4px;
   }
-  .gong-table thead th.col-g .brand{
+  .notetaker-table thead th.col-g .brand{
     display:block;font-family:var(--font-body), 'Geist', sans-serif;font-weight:500;font-size:18px;
     color:var(--ink-2);text-transform:none;letter-spacing:-.005em;margin-top:4px;
   }
-  .gong-table tbody td{
+  .notetaker-table tbody td{
     padding:20px 24px;border-bottom:1px solid var(--hair);vertical-align:top;
     font-family:var(--font-body), 'Geist', sans-serif;font-size:14.5px;line-height:1.5;color:var(--ink-2);
   }
-  .gong-table tbody tr:last-child td{border-bottom:0}
-  .gong-table tbody td.dim{
+  .notetaker-table tbody tr:last-child td{border-bottom:0}
+  .notetaker-table tbody td.dim{
     color:var(--ink);font-weight:500;font-size:14px;
     font-family:'Geist Mono',monospace;letter-spacing:.02em;width:24%;
   }
-  .gong-table tbody td.col-s{background:rgba(254,133,49,.03);color:var(--ink)}
-  .gong-table tbody td.col-s strong{color:var(--copper);font-weight:500}
-  .gong-table tbody td.col-g{color:var(--ink-3)}
-  .gong-table .icon{
+  .notetaker-table tbody td.col-s{background:rgba(254,133,49,.03);color:var(--ink)}
+  .notetaker-table tbody td.col-s strong{color:var(--copper);font-weight:500}
+  .notetaker-table tbody td.col-g{color:var(--ink-3)}
+  .notetaker-table .icon{
     display:inline-block;margin-right:8px;font-family:'Geist Mono',monospace;
     font-size:11px;width:16px;text-align:center;
   }
-  .gong-table .col-s .icon{color:var(--copper)}
-  .gong-table .col-g .icon{color:var(--ink-4)}
+  .notetaker-table .col-s .icon{color:var(--copper)}
+  .notetaker-table .col-g .icon{color:var(--ink-4)}
 
   /* ═══════════ Investor register ═══════════ */
   .reg-inv{

--- a/components/sections/GongSection.tsx
+++ b/components/sections/GongSection.tsx
@@ -30,73 +30,73 @@ export function GongSection() {
           <tr>
             <td className="dim">Output</td>
             <td className="col-g">
-              <span className="ic">—</span>Transcript + call summary
+              <span className="icon">—</span>Transcript + call summary
             </td>
             <td className="col-s">
-              <span className="ic">→</span>
+              <span className="icon">→</span>
               <strong>Structured signals</strong> mapped to your catalog
             </td>
           </tr>
           <tr>
             <td className="dim">Unit of memory</td>
             <td className="col-g">
-              <span className="ic">—</span>The call
+              <span className="icon">—</span>The call
             </td>
             <td className="col-s">
-              <span className="ic">→</span>The <strong>account</strong> — every
+              <span className="icon">→</span>The <strong>account</strong> — every
               pain, promise, stakeholder, across every call
             </td>
           </tr>
           <tr>
             <td className="dim">Survives rep turnover</td>
             <td className="col-g">
-              <span className="ic">×</span>Transcript survives. Context
+              <span className="icon">×</span>Transcript survives. Context
               doesn&apos;t.
             </td>
             <td className="col-s">
-              <span className="ic">✓</span>New rep inherits the{' '}
+              <span className="icon">✓</span>New rep inherits the{' '}
               <strong>full account state</strong> before their first call
             </td>
           </tr>
           <tr>
             <td className="dim">Citations</td>
             <td className="col-g">
-              <span className="ic">—</span>Timestamps in transcript
+              <span className="icon">—</span>Timestamps in transcript
             </td>
             <td className="col-s">
-              <span className="ic">✓</span>Every extraction cited —{' '}
+              <span className="icon">✓</span>Every extraction cited —{' '}
               <strong>transcript + timestamp + confidence</strong>
             </td>
           </tr>
           <tr>
             <td className="dim">Who reads it</td>
             <td className="col-g">
-              <span className="ic">—</span>Managers, spot-checking coaching
+              <span className="icon">—</span>Managers, spot-checking coaching
               moments
             </td>
             <td className="col-s">
-              <span className="ic">→</span>AE, CSM, director — every role on
+              <span className="icon">→</span>AE, CSM, director — every role on
               the account, on demand
             </td>
           </tr>
           <tr>
             <td className="dim">Handoff artefact</td>
             <td className="col-g">
-              <span className="ic">×</span>None — you still write the handoff
+              <span className="icon">×</span>None — you still write the handoff
               doc by hand
             </td>
             <td className="col-s">
-              <span className="ic">✓</span>Handoff doc is the{' '}
+              <span className="icon">✓</span>Handoff doc is the{' '}
               <strong>live memory layer</strong> itself
             </td>
           </tr>
           <tr>
             <td className="dim">Works alongside</td>
             <td className="col-g">
-              <span className="ic">→</span>Your CRM
+              <span className="icon">→</span>Your CRM
             </td>
             <td className="col-s">
-              <span className="ic">→</span>Your notetaker + your CRM —{' '}
+              <span className="icon">→</span>Your notetaker + your CRM —{' '}
               <strong>zero rip-and-replace</strong>
             </td>
           </tr>

--- a/components/sections/GongSection.tsx
+++ b/components/sections/GongSection.tsx
@@ -1,7 +1,7 @@
 export function GongSection() {
   return (
-    <section className="gong">
-      <div className="gong-head">
+    <section className="notetaker">
+      <div className="notetaker-head">
         <div className="eb">vs AI notetakers</div>
         <h2>
           The last mile <em>AI notetakers leave unaddressed.</em>
@@ -12,7 +12,7 @@ export function GongSection() {
           turns. Here&apos;s where the two diverge.
         </p>
       </div>
-      <table className="gong-table">
+      <table className="notetaker-table">
         <thead>
           <tr>
             <th>Dimension</th>

--- a/components/sections/HowItWorksSection.tsx
+++ b/components/sections/HowItWorksSection.tsx
@@ -27,8 +27,8 @@ export function HowItWorksSection() {
             speaker, and the timestamp.
           </p>
           <div className="ex">
-            <div className="el">Example extraction</div>
-            <div className="eq">
+            <div className="example-label">Example extraction</div>
+            <div className="example-quote">
               <strong>Pain</strong> · CS director inherits accounts blind at
               renewal · Priya Shah, VP Sales · 18:02
             </div>
@@ -47,8 +47,8 @@ export function HowItWorksSection() {
             changed over time.
           </p>
           <div className="ex">
-            <div className="el">Example mapping</div>
-            <div className="eq">
+            <div className="example-label">Example mapping</div>
+            <div className="example-quote">
               Pain <em>&ldquo;handoff loses context&rdquo;</em>{' '}
               <strong>→ 3 products ranked</strong>, contradictions flagged
             </div>
@@ -66,8 +66,8 @@ export function HowItWorksSection() {
             memory outlasts any rep.
           </p>
           <div className="ex">
-            <div className="el">Example surface</div>
-            <div className="eq">
+            <div className="example-label">Example surface</div>
+            <div className="example-quote">
               <strong>Next steps</strong> · Renewal conversation by Mar 15 ·
               Open commitments: 3
             </div>

--- a/components/sections/HubSection.tsx
+++ b/components/sections/HubSection.tsx
@@ -12,10 +12,10 @@ export function HubSection() {
         <div className="hub-main">
         <div className="hub-head">
           <span className="eb">
-            Inputs <span className="arr">→</span>
+            Inputs <span className="arrow">→</span>
           </span>
           <span className="eb r">
-            <span className="arr">→</span> Outputs
+            <span className="arrow">→</span> Outputs
           </span>
         </div>
 
@@ -251,19 +251,19 @@ export function HubSection() {
           <div className="hub-outcome-eb">Outcome</div>
           <div className="hub-outcome-grid">
             <div className="hub-outcome-row">
-              <div className="hub-outcome-rk">New AE</div>
-              <div className="hub-outcome-rt">Inherits the account</div>
-              <div className="hub-outcome-rs">Every pain, objection, and commitment from prior calls</div>
+              <div className="hub-outcome-role">New AE</div>
+              <div className="hub-outcome-role-title">Inherits the account</div>
+              <div className="hub-outcome-role-summary">Every pain, objection, and commitment from prior calls</div>
             </div>
             <div className="hub-outcome-row">
-              <div className="hub-outcome-rk">CSM</div>
-              <div className="hub-outcome-rt">Picks up the relationship</div>
-              <div className="hub-outcome-rs">Cited pain-to-product mappings, no re-asking</div>
+              <div className="hub-outcome-role">CSM</div>
+              <div className="hub-outcome-role-title">Picks up the relationship</div>
+              <div className="hub-outcome-role-summary">Cited pain-to-product mappings, no re-asking</div>
             </div>
             <div className="hub-outcome-row">
-              <div className="hub-outcome-rk">Director</div>
-              <div className="hub-outcome-rt">Sees the pattern</div>
-              <div className="hub-outcome-rs">Pains and objections across every deal in the pipe</div>
+              <div className="hub-outcome-role">Director</div>
+              <div className="hub-outcome-role-title">Sees the pattern</div>
+              <div className="hub-outcome-role-summary">Pains and objections across every deal in the pipe</div>
             </div>
           </div>
         </div>

--- a/components/sections/InvestorsSection.tsx
+++ b/components/sections/InvestorsSection.tsx
@@ -46,8 +46,8 @@ export function InvestorsSection() {
               the same core graph. One primitive. Everything else is surface.
             </p>
             <div className="primitive">
-              <span className="lbl">Data primitive</span>
-              <p className="tt">
+              <span className="label">Data primitive</span>
+              <p className="title">
                 Structured account memory —{' '}
                 <em>cited, scoped, and compounding</em> — is the input every
                 future revenue tool will be measured against.
@@ -57,8 +57,8 @@ export function InvestorsSection() {
 
           <section className="roadmap">
             <div className="roadmap-card">
-              <span className="v">On the roadmap</span>
-              <span className="t">
+              <span className="pill">On the roadmap</span>
+              <span className="body">
                 A <em>Recall.ai meeting bot</em> that joins Zoom, Meet, and
                 Teams calls directly — feeding the extraction pipeline without
                 a transcript upload step.
@@ -87,7 +87,7 @@ export function InvestorsSection() {
                   Treasure. MBET, Waterloo.
                 </p>
                 <div className="fit">
-                  <div className="lbl">Unfair advantage</div>
+                  <div className="label">Unfair advantage</div>
                   <p>
                     Has <em>lost deals to forgotten context personally</em>, in
                     rooms where the budget was real. The product spec comes
@@ -110,7 +110,7 @@ export function InvestorsSection() {
                   management and AML/KYC compliance in banking.
                 </p>
                 <div className="fit">
-                  <div className="lbl">Unfair advantage</div>
+                  <div className="label">Unfair advantage</div>
                   <p>
                     Knows what sales ops <em>actually trusts</em>, how handoffs
                     break at 50 reps, and which metrics survive a board deck.
@@ -133,7 +133,7 @@ export function InvestorsSection() {
                   applied-AI operator — not a research hire.
                 </p>
                 <div className="fit">
-                  <div className="lbl">Unfair advantage</div>
+                  <div className="label">Unfair advantage</div>
                   <p>
                     The core technical risk in Salency is not &ldquo;can an LLM
                     summarise a call.&rdquo; It is{' '}

--- a/components/sections/NotDoSection.tsx
+++ b/components/sections/NotDoSection.tsx
@@ -2,16 +2,16 @@ export function NotDoSection() {
   return (
     <section className="notdo">
       <div className="notdo-card">
-        <div className="hdr">
+        <div className="header">
           <span className="eb">What it is · what it isn&apos;t</span>Salency, in
           plain terms.
         </div>
         <div className="notdo-list">
           <div className="notdo-item">
             <span className="x">×</span>
-            <div className="t">Not a CRM replacement</div>
+            <div className="title">Not a CRM replacement</div>
             <span className="check" aria-label="What it does">✓</span>
-            <div className="s">
+            <div className="subtitle">
               CRM tracks pipeline stages and quotes. Salency tracks what the
               customer said: pain graph, contradictions, account brief. The
               memory layer stays on Salency; flat fields export to Salesforce,
@@ -21,9 +21,9 @@ export function NotDoSection() {
           </div>
           <div className="notdo-item">
             <span className="x">×</span>
-            <div className="t">Not an in-call coach</div>
+            <div className="title">Not an in-call coach</div>
             <span className="check" aria-label="What it does">✓</span>
-            <div className="s">
+            <div className="subtitle">
               In-call coaching is a different product. Salency works between
               calls. After each conversation it updates the account&apos;s
               memory, so the rep walks into the next call already briefed.
@@ -31,9 +31,9 @@ export function NotDoSection() {
           </div>
           <div className="notdo-item">
             <span className="x">×</span>
-            <div className="t">Not a magic close button</div>
+            <div className="title">Not a magic close button</div>
             <span className="check" aria-label="What it does">✓</span>
-            <div className="s">
+            <div className="subtitle">
               We don&apos;t claim to close more deals. We capture what gets
               lost: the pain a buyer named, the contradiction from last
               week&apos;s call, the next step nobody wrote down. The hour
@@ -42,9 +42,9 @@ export function NotDoSection() {
           </div>
           <div className="notdo-item">
             <span className="x">×</span>
-            <div className="t">Not another call recorder</div>
+            <div className="title">Not another call recorder</div>
             <span className="check" aria-label="What it does">✓</span>
-            <div className="s">
+            <div className="subtitle">
               Salency sits <em>on top of</em> your notetaker. Gong, Fathom,
               Fireflies, or raw text go in. A cited, queryable memory layer
               comes out. Survives rep rotation.

--- a/components/sections/PilotApplication.tsx
+++ b/components/sections/PilotApplication.tsx
@@ -15,7 +15,7 @@ const IDEAL = [
 
 export function PilotApplication() {
   return (
-    <main className="pilot-app max-w-6xl mx-auto px-6 md:px-10 pt-[120px] pb-24">
+    <main className="pilot-app max-w-[1280px] mx-auto mt-20 px-10 py-5">
       <section className="mb-16 md:mb-20 max-w-3xl">
         <p className="eb mb-5">Pilot cohort · Spring 2026</p>
         <h1 className="text-5xl md:text-6xl mb-6 text-balance">

--- a/components/sections/ProblemSection.tsx
+++ b/components/sections/ProblemSection.tsx
@@ -23,7 +23,7 @@ export function ProblemSection() {
       <div className="prob-row">
         <div className="prob-card">
           <div className="idx">i.</div>
-          <h3 className="ttl">
+          <h3 className="title">
             Calls are <em>recorded.</em> Context isn&apos;t <em>captured.</em>
           </h3>
           <p className="desc">
@@ -32,7 +32,7 @@ export function ProblemSection() {
             — the unprompted pain at minute 42 — stays locked in the audio.
           </p>
           <div className="cost">
-            <span className="lbl">
+            <span className="label">
               Transcripts are the artifact no one scrubs after the handoff.
             </span>
           </div>
@@ -40,7 +40,7 @@ export function ProblemSection() {
 
         <div className="prob-card">
           <div className="idx">ii.</div>
-          <h3 className="ttl">
+          <h3 className="title">
             Every handoff restarts from <em>zero.</em>
           </h3>
           <p className="desc">
@@ -51,7 +51,7 @@ export function ProblemSection() {
           </p>
           <div className="cost">
             <span className="num">40–50%</span>
-            <span className="lbl">
+            <span className="label">
               of customers visibly frustrated when asked to repeat themselves ·
               Customer interview, Jan 2026
             </span>
@@ -60,7 +60,7 @@ export function ProblemSection() {
 
         <div className="prob-card">
           <div className="idx">iii.</div>
-          <h3 className="ttl">
+          <h3 className="title">
             Reps pay a <em>busywork tax</em> to keep the lights on.
           </h3>
           <p className="desc">
@@ -69,7 +69,7 @@ export function ProblemSection() {
             re-encoding information the system already has.
           </p>
           <div className="cost">
-            <span className="lbl">
+            <span className="label">
               Hours spent re-encoding what the recording already captured.
             </span>
           </div>
@@ -77,14 +77,14 @@ export function ProblemSection() {
       </div>
 
       <div className="prob-resolve">
-        <span className="rlbl">— The fix</span>
-        <p className="rtxt">
+        <span className="label">— The fix</span>
+        <p className="text">
           Salency sits above your AI notetaker and CRM as an{' '}
           <em>institutional memory layer</em> — extracting structured context
           from every call, keeping it current as the account evolves, and
           surfacing it the moment someone new picks up the relationship.
         </p>
-        <Link href="/" className="ra">
+        <Link href="/" className="link">
           See how it works →
         </Link>
       </div>


### PR DESCRIPTION
## Summary

Three cleanup passes that started from eyebrow-size alignment and expanded into fuller CSS consistency work.

### Standalone intro container — one canonical across every page

\`.prob\`, \`.coming-soon\`, \`.inv-intro\`, and \`.pilot-app\` (via \`PilotApplication\`) all now use the same container: \`max-width: 1280px; margin: 80px auto 0; padding: 20px 40px\`. Header-to-content spacing is identical across \`/\`, \`/why-salency\`, \`/memory\`, \`/investors\`, \`/pricing\`, and \`/pilot\`.

DESIGN.md Section 4 rewritten as "Standalone section container" documenting the single canonical.

### Eyebrow canonical — single recipe

\`.coming-soon .eb\` was the last holdout at \`10px / .16em\`; every other \`.eb\` variant was already \`11px / .18em\`. Bumped to match. DESIGN.md eyebrow recipe tightened from a range to a single value.

### Cryptic class rename sweep

Coordinated JSX + CSS renames so every class name describes what it is instead of being a one-letter abbreviation.

| Old (cryptic) | New (readable) | Parent scope |
|---|---|---|
| \`.arr\` | \`.arrow\` | \`.hub-head\` |
| \`.hub-outcome-rk\` / \`-rt\` / \`-rs\` | \`.hub-outcome-role\` / \`-role-title\` / \`-role-summary\` | (global) |
| \`.hub-input-lbl\` | \`.hub-input-label\` | (global) |
| \`.hdr\` | \`.header\` | \`.notdo-card\` |
| \`.t\` | \`.title\` | \`.notdo-item\` (also \`.pain .body\` if revived) |
| \`.s\` | \`.subtitle\` | \`.notdo-item\` |
| \`.ttl\` | \`.title\` | \`.prob-card\` |
| \`.rtxt\` | \`.text\` | \`.prob-resolve\` |
| \`.rlbl\` | \`.label\` | \`.prob-resolve\` |
| \`.ra\` | \`.link\` | \`.prob-resolve\` |
| \`.lbl\` | \`.label\` | \`.prob-card .cost\`, \`.founder .fit\`, \`.platform .primitive\` |
| \`.el\` / \`.eq\` | \`.example-label\` / \`.example-quote\` | \`.how-step .ex\` |
| \`.ic\` | \`.icon\` | \`.gong-table\` (all 3 column variants) |
| \`.v\` | \`.pill\` | \`.roadmap-card\` |
| \`.t\` (roadmap) | \`.body\` | \`.roadmap-card\` |
| \`.tt\` | \`.title\` | \`.platform .primitive\` |

**Well-established short names kept:** \`.eb\` (eyebrow, in DESIGN.md), \`.sub\`, \`.fine\`, \`.crumb\`, \`.tag\`, \`.brand\`, \`.hair\`, \`.btn\`, \`.btn-primary\`, \`.btn-ghost\`, \`.btn-submit\`.

**Not touched:** Dead CSS blocks referenced by components that have been deleted or migrated to Tailwind (\`.mside\`, \`.ai-strip\`, \`.pain\`, parts of \`.stats\`). Those should be purged in a follow-up dead-code pass.

## Files changed
- \`app/globals.css\` — selectors renamed, intro container canonical normalized
- \`DESIGN.md\` — Section 4 rewritten, eyebrow canonical tightened
- \`components/sections/GongSection.tsx\` — \`.ic\` → \`.icon\`
- \`components/sections/HowItWorksSection.tsx\` — \`.el\` / \`.eq\` → \`.example-label\` / \`.example-quote\`
- \`components/sections/HubSection.tsx\` — \`.arr\` → \`.arrow\`, outcome row classes
- \`components/sections/InvestorsSection.tsx\` — roadmap, platform.primitive, founder.fit
- \`components/sections/NotDoSection.tsx\` — \`.hdr\` / \`.t\` / \`.s\`
- \`components/sections/PilotApplication.tsx\` — container spacing
- \`components/sections/ProblemSection.tsx\` — \`.ttl\` / \`.lbl\` / \`.rtxt\` / \`.rlbl\` / \`.ra\`

## Test plan

- [ ] Hard-refresh every page: \`/\`, \`/why-salency\`, \`/memory\`, \`/investors\`, \`/pricing\`, \`/pilot\`, \`/privacy\`, \`/terms\`. Header-to-content spacing feels identical across the set.
- [ ] Spot-check Problem section (home + why-salency): card titles render, fix block renders with link + label + text.
- [ ] Spot-check How-it-works example boxes: label + quote render correctly across all 3 steps.
- [ ] Spot-check Gong comparison table: icons (— / → / ✓ / ×) still render in each cell.
- [ ] Spot-check Not-Do cards: header renders, title + subtitle render.
- [ ] Spot-check Hub outcome rows: role / role-title / role-summary all styled.
- [ ] Spot-check /investors roadmap card: pill + body render.
- [ ] Spot-check /investors platform primitive: label + title render.
- [ ] Spot-check /investors founders: role + bio + fit (label + text) render.
- [ ] Eyebrow (\`.eb\`) sits at 11px / .18em on every marketing page including \`/memory\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)