### PR TITLE
feat(memory): /memory page with featured 6-block Day-1 brief

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2139,233 +2139,31 @@ header button:focus:not(:focus-visible){
     .intensity-dot.off { background: var(--ink-4); opacity: .4; }
   }
 
-  /* Block 3 — We Owe Them */
-  .mem-brief .owed { display: grid; }
-  .mem-brief .owed-row {
-    display: grid;
-    grid-template-columns: 28px 1fr auto;
-    gap: 14px;
-    align-items: baseline;
-    padding: 14px 0;
-    border-bottom: 1px dashed var(--hair);
+  /* Brief foot — promise strip hinting at what lives inside the full product brief */
+  .mem-brief .brief-foot {
+    margin-top: 28px;
+    padding-top: 22px;
+    border-top: 1px solid var(--hair);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    font-family: var(--font-body), 'Instrument Sans', system-ui, sans-serif;
 
-    &:last-child { border-bottom: 0; }
-
-    .owed-glyph {
-      width: 14px; height: 14px; margin-top: 6px;
-      border-radius: 50%;
-      justify-self: center;
-    }
-
-    &.open .owed-glyph {
-      background: var(--copper);
-      box-shadow: 0 0 0 3px rgba(254, 133, 49, 0.14);
-    }
-    &.scheduled .owed-glyph {
-      background: transparent;
-      border: 2px solid var(--ink-2);
-    }
-    &.closed .owed-glyph {
-      background: var(--ink-4);
-      opacity: .7;
-    }
-
-    .owed-text {
+    > span:first-child {
+      font-family: var(--font-display), 'Instrument Sans', system-ui, sans-serif;
+      font-style: italic;
       font-size: 15px;
-      color: var(--ink);
-      line-height: 1.5;
-
-      em {
-        font-style: italic;
-        color: var(--copper);
-        font-size: 16px;
-        font-weight: 400;
-      }
+      color: var(--ink-2);
+      line-height: 1.4;
     }
 
-    &.closed .owed-text {
-      color: var(--ink-3);
-      text-decoration: line-through;
-      text-decoration-color: var(--ink-4);
-    }
-
-    .owed-meta {
+    .brief-foot-also {
       font-family: 'Geist Mono', monospace;
       font-size: 10.5px;
       color: var(--ink-3);
       letter-spacing: .12em;
       text-transform: uppercase;
-      white-space: nowrap;
-    }
-    &.open .owed-meta { color: var(--copper); }
-    &.closed .owed-meta { color: var(--ink-4); }
-  }
-
-  /* Block 4 — What's Changed */
-  .mem-brief .contra {
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
-    gap: 20px;
-    align-items: stretch;
-    padding: 22px;
-    background: rgba(254, 133, 49, 0.04);
-    border: 1px solid rgba(254, 133, 49, 0.18);
-    border-radius: 10px;
-
-    .contra-col {
-      display: grid; gap: 10px; align-content: start;
-
-      &.left { text-align: right; }
-    }
-
-    .contra-date {
-      font-family: 'Geist Mono', monospace;
-      font-size: 10.5px;
-      font-weight: 500;
-      letter-spacing: .18em;
-      text-transform: uppercase;
-      color: var(--copper);
-    }
-
-    .contra-quote {
-      font-family: var(--font-display), 'Instrument Sans', system-ui, sans-serif;
-      font-style: italic;
-      font-weight: 400;
-      font-size: 18px;
-      line-height: 1.4;
-      color: var(--ink);
-      letter-spacing: -.005em;
-    }
-
-    .contra-who {
-      font-family: 'Geist Mono', monospace;
-      font-size: 10.5px;
-      color: var(--ink-3);
-      letter-spacing: .04em;
-    }
-
-    .contra-arrow {
-      display: flex; align-items: center; justify-content: center;
-      font-family: 'Geist Mono', monospace;
-      font-size: 22px;
-      color: var(--copper);
-      padding: 0 4px;
-    }
-  }
-
-  .mem-brief .contra-obs {
-    margin-top: 16px;
-    padding: 12px 16px;
-    background: rgba(254, 133, 49, 0.05);
-    border-left: 2px solid var(--copper);
-    border-radius: 0 6px 6px 0;
-    font-size: 13.5px;
-    color: var(--ink-2);
-    line-height: 1.5;
-
-    .label {
-      font-family: 'Geist Mono', monospace;
-      font-size: 10px;
-      font-weight: 500;
-      letter-spacing: .2em;
-      text-transform: uppercase;
-      color: var(--copper);
-      display: block;
-      margin-bottom: 4px;
-    }
-  }
-
-  /* Block 5 — How We Map */
-  .mem-brief .mapping { display: grid; gap: 12px; }
-  .mem-brief .mapping-row {
-    display: grid;
-    grid-template-columns: 1fr 180px auto;
-    gap: 18px;
-    align-items: center;
-    padding: 12px 0;
-    border-bottom: 1px dashed var(--hair);
-
-    &:last-child { border-bottom: 0; }
-
-    .mapping-prod {
-      font-size: 15px;
-      color: var(--ink);
-      font-weight: 500;
-
-      em {
-        font-style: italic;
-        color: var(--copper);
-        font-size: 16px;
-        font-weight: 400;
-      }
-    }
-
-    .mapping-bar {
-      position: relative;
-      height: 6px;
-      border-radius: 3px;
-      background: rgba(254, 133, 49, 0.10);
-      overflow: hidden;
-
-      .mapping-bar-fill {
-        position: absolute; inset: 0;
-        background: linear-gradient(90deg, var(--copper), var(--copper-soft));
-        border-radius: 3px;
-      }
-    }
-
-    .mapping-conf {
-      font-family: 'Geist Mono', monospace;
-      font-size: 13px;
-      font-weight: 500;
-      color: var(--copper);
-      letter-spacing: .04em;
-      min-width: 48px;
-      text-align: right;
-    }
-  }
-
-  /* Block 6 — Next */
-  .mem-brief .next { display: grid; gap: 14px; }
-  .mem-brief .next-row {
-    display: grid;
-    grid-template-columns: 160px 1fr;
-    gap: 24px;
-    align-items: baseline;
-    padding: 10px 0;
-    border-bottom: 1px dashed var(--hair);
-
-    &:last-child { border-bottom: 0; }
-
-    .next-key {
-      font-family: 'Geist Mono', monospace;
-      font-size: 10.5px;
-      font-weight: 500;
-      letter-spacing: .18em;
-      text-transform: uppercase;
-      color: var(--ink-3);
-    }
-
-    .next-val {
-      font-size: 15px;
-      color: var(--ink);
-      line-height: 1.5;
-
-      em {
-        font-style: italic;
-        color: var(--copper);
-        font-size: 16px;
-        font-weight: 400;
-      }
-    }
-
-    .cliffhanger {
-      font-family: var(--font-display), 'Instrument Sans', system-ui, sans-serif;
-      font-style: italic;
-      font-weight: 400;
-      color: var(--ink);
-      font-size: 17px;
-      line-height: 1.4;
+      line-height: 1.55;
     }
   }
 
@@ -2755,25 +2553,6 @@ header button:focus:not(:focus-visible){
     .mem-hero-surface { padding: 0 18px; }
     .mem-hero-frame { padding: 24px 20px 28px; }
     .mem-hero-head { flex-direction: column; align-items: flex-start; }
-
-    .mem-brief .contra {
-      grid-template-columns: 1fr;
-      gap: 14px;
-      padding: 18px;
-
-      .contra-col.left { text-align: left; }
-      .contra-arrow { padding: 0; font-size: 16px; justify-content: flex-start; }
-    }
-
-    .mem-brief .mapping-row {
-      grid-template-columns: 1fr;
-      gap: 8px;
-
-      .mapping-bar { width: 100%; }
-      .mapping-conf { text-align: left; }
-    }
-
-    .mem-brief .next-row { grid-template-columns: 1fr; gap: 4px; }
 
     .mem-compare { margin-top: 72px; padding: 0 22px; }
     .mem-table { font-size: 13px; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1849,10 +1849,10 @@ header button:focus:not(:focus-visible){
     }
   }
 
-  /* ── Featured hero surface (Surface 01: the brief) ── */
+  /* ── Featured hero surface (Surface 01: tight 2-col, fits viewport) ── */
   .mem-hero-surface {
     max-width: 1100px;
-    margin: 24px auto 0;
+    margin: 20px auto 0;
     padding: 0 40px;
   }
 
@@ -1861,7 +1861,7 @@ header button:focus:not(:focus-visible){
     background: rgba(254, 133, 49, 0.03);
     border: 1px solid var(--hair-2);
     border-radius: 16px;
-    padding: 36px 36px 40px;
+    padding: 22px 28px 20px;
     overflow: hidden;
 
     /* Hero-card 2px left gradient per DESIGN.md §5 card chrome */
@@ -1874,33 +1874,57 @@ header button:focus:not(:focus-visible){
     }
   }
 
+  /* Card header — brief-title + meta on the left, preview chip on the right */
   .mem-hero-head {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding-bottom: 24px;
-    margin-bottom: 28px;
-    border-bottom: 1px solid var(--hair);
-    gap: 16px;
+    padding-bottom: 18px;
+    border-bottom: 1px solid var(--hair-2);
+    gap: 14px;
     flex-wrap: wrap;
 
-    .mem-hero-kicker {
-      font-family: 'Geist Mono', monospace;
-      font-size: 11px;
-      font-weight: 500;
-      letter-spacing: .18em;
-      text-transform: uppercase;
-      color: var(--copper);
-      display: inline-flex;
-      align-items: center;
-      gap: 10px;
+    .mem-hero-title-group {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      min-width: 0;
+    }
 
-      &::before {
-        content: "";
-        width: 28px;
-        height: 1px;
-        background: var(--copper);
-        display: inline-block;
+    .mem-hero-title {
+      font-family: var(--font-display), 'Instrument Sans', system-ui, sans-serif;
+      font-weight: 500;
+      font-size: 17px;
+      color: var(--ink);
+      letter-spacing: -.01em;
+      line-height: 1.3;
+
+      em { font-style: italic; color: var(--copper); font-weight: 400; }
+    }
+
+    .mem-hero-meta {
+      font-family: 'Geist Mono', monospace;
+      font-size: 10px;
+      color: var(--ink-3);
+      letter-spacing: .04em;
+      display: inline-flex;
+      gap: 8px;
+      align-items: center;
+      flex-wrap: wrap;
+
+      .sep { color: var(--ink-4); opacity: .5; }
+
+      .pulse {
+        display: inline-flex; align-items: center; gap: 6px;
+        color: var(--copper);
+
+        &::before {
+          content: "";
+          width: 5px; height: 5px; border-radius: 50%;
+          background: var(--copper);
+          box-shadow: 0 0 0 0 rgba(254, 133, 49, 0.55);
+          animation: memPulse 2.4s ease-in-out infinite;
+        }
       }
     }
 
@@ -1915,77 +1939,27 @@ header button:focus:not(:focus-visible){
       border: 1px solid rgba(254, 133, 49, 0.26);
       border-radius: 4px;
       padding: 5px 10px;
+      white-space: nowrap;
     }
   }
 
-  /* ── The brief (6 blocks) ── */
-  .mem-brief {
-    max-width: 760px;
-    margin: 0 auto;
-  }
+  /* Brief grid — People left, They need right */
+  .mem-brief-grid {
+    display: grid;
+    grid-template-columns: 0.9fr 1.1fr;
+    gap: 28px;
+    padding-top: 16px;
 
-  .mem-brief .crumb {
-    font-family: 'Geist Mono', monospace;
-    font-size: 11px;
-    letter-spacing: .12em;
-    text-transform: uppercase;
-    color: var(--ink-4);
-    margin-bottom: 16px;
-
-    .crumb-link { color: var(--ink-3); }
-    .sep { color: var(--ink-4); margin: 0 8px; }
-  }
-
-  .mem-brief .brief-title {
-    font-family: var(--font-display), 'Instrument Sans', system-ui, sans-serif;
-    font-weight: 400;
-    font-size: clamp(36px, 4.6vw, 52px);
-    line-height: 1.04;
-    letter-spacing: -.02em;
-    color: var(--ink);
-    margin: 0 0 14px;
-
-    em { font-style: italic; color: var(--copper); }
-  }
-
-  .mem-brief .brief-meta {
-    font-family: 'Geist Mono', monospace;
-    font-size: 11px;
-    color: var(--ink-3);
-    letter-spacing: .04em;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 12px;
-    align-items: center;
-    margin-bottom: 48px;
-
-    .sep { color: var(--ink-4); opacity: .6; }
-
-    .pulse {
-      display: inline-flex; align-items: center; gap: 8px;
-      color: var(--copper);
-
-      &::before {
-        content: "";
-        width: 6px; height: 6px; border-radius: 50%;
-        background: var(--copper);
-        box-shadow: 0 0 0 0 rgba(254, 133, 49, 0.55);
-        animation: memPulse 2.4s ease-in-out infinite;
-      }
+    .brief-block {
+      padding: 0;
+      border: 0;
     }
-  }
-
-  .mem-brief .brief-block {
-    padding: 32px 0 36px;
-    border-top: 1px solid var(--hair);
-
-    &:first-of-type { border-top: 1px solid var(--hair-2); padding-top: 0; }
   }
 
   /* Canonical eyebrow inside brief blocks */
-  .mem-brief .eb {
+  .mem-hero-surface .eb {
     font-family: 'Geist Mono', monospace;
-    font-size: 11px;
+    font-size: 10px;
     font-weight: 500;
     letter-spacing: .18em;
     text-transform: uppercase;
@@ -1993,11 +1967,11 @@ header button:focus:not(:focus-visible){
     display: inline-flex;
     align-items: center;
     gap: 10px;
-    margin-bottom: 22px;
+    margin-bottom: 12px;
 
     &::before {
       content: "";
-      width: 28px;
+      width: 24px;
       height: 1px;
       background: var(--copper);
       display: inline-block;
@@ -2006,42 +1980,42 @@ header button:focus:not(:focus-visible){
     .sub {
       font-family: var(--font-body), 'Instrument Sans', system-ui, sans-serif;
       color: var(--ink-3);
-      font-size: 12.5px;
+      font-size: 11.5px;
       letter-spacing: .04em;
       font-weight: 400;
       text-transform: none;
     }
   }
 
-  /* Block 1 — People */
-  .mem-brief .people { display: grid; gap: 18px; }
-  .mem-brief .person {
+  /* People — compact stacked rows */
+  .mem-hero-surface .people { display: grid; gap: 8px; }
+  .mem-hero-surface .person {
     display: grid;
     grid-template-columns: 1fr;
-    gap: 10px;
-    padding: 14px 0;
+    gap: 3px;
+    padding: 8px 0;
     border-bottom: 1px dashed var(--hair);
 
     &:last-child { border-bottom: 0; }
 
     .person-main {
-      display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap;
+      display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap;
     }
 
     .person-name {
       font-family: var(--font-display), 'Instrument Sans', system-ui, sans-serif;
       font-weight: 500;
-      font-size: 22px;
+      font-size: 17px;
       color: var(--ink);
       letter-spacing: -.01em;
-      line-height: 1.15;
+      line-height: 1.2;
     }
 
     .person-role {
       font-family: 'Geist Mono', monospace;
-      font-size: 11px;
+      font-size: 10px;
       color: var(--ink-3);
-      letter-spacing: .12em;
+      letter-spacing: .1em;
       text-transform: uppercase;
     }
 
@@ -2049,33 +2023,28 @@ header button:focus:not(:focus-visible){
       font-family: var(--font-display), 'Instrument Sans', system-ui, sans-serif;
       font-style: italic;
       font-weight: 400;
-      font-size: 17px;
-      line-height: 1.45;
+      font-size: 14px;
+      line-height: 1.35;
       color: var(--ink-2);
     }
 
     .person-cite {
       font-family: 'Geist Mono', monospace;
-      font-size: 11px;
+      font-size: 10px;
       color: var(--ink-3);
       letter-spacing: .04em;
-      display: inline-flex;
-      gap: 8px;
-      align-items: center;
-      flex-wrap: wrap;
 
       .person-cite-link { color: var(--copper); }
-      .arrow { color: var(--copper); opacity: .7; }
     }
   }
 
-  .mem-brief .stance {
+  .mem-hero-surface .stance {
     font-family: 'Geist Mono', monospace;
-    font-size: 10.5px;
+    font-size: 9px;
     font-weight: 500;
     letter-spacing: .16em;
     text-transform: uppercase;
-    padding: 4px 10px;
+    padding: 2px 6px;
     border-radius: 4px;
 
     &.champion {
@@ -2095,71 +2064,69 @@ header button:focus:not(:focus-visible){
     }
   }
 
-  /* Block 2 — They Need */
-  .mem-brief .pains { display: grid; gap: 10px; }
-  .mem-brief .pain {
-    padding: 14px 0 14px 20px;
+  /* They need — compact pain rows */
+  .mem-hero-surface .pains { display: grid; gap: 6px; }
+  .mem-hero-surface .pain {
+    padding: 8px 0 8px 14px;
     border-left: 2px solid var(--copper);
     background: linear-gradient(90deg, rgba(254, 133, 49, 0.04), transparent 60%);
-    border-radius: 0 6px 6px 0;
+    border-radius: 0 4px 4px 0;
 
     .pain-quote {
       font-family: var(--font-display), 'Instrument Sans', system-ui, sans-serif;
       font-style: italic;
       font-weight: 400;
-      font-size: 19px;
-      line-height: 1.4;
+      font-size: 14.5px;
+      line-height: 1.3;
       color: var(--ink);
-      margin: 0 0 8px;
+      margin: 0 0 4px;
       letter-spacing: -.005em;
     }
 
     .pain-cite {
       font-family: 'Geist Mono', monospace;
-      font-size: 11px;
+      font-size: 10px;
       color: var(--ink-3);
       letter-spacing: .04em;
       display: flex;
       justify-content: space-between;
       align-items: center;
-      gap: 12px;
+      gap: 10px;
       flex-wrap: wrap;
 
       .pain-cite-link { color: var(--copper); }
     }
   }
 
-  .mem-brief .intensity {
+  .mem-hero-surface .intensity {
     display: inline-flex; gap: 3px; align-items: center;
 
     .intensity-dot {
-      width: 5px; height: 5px; border-radius: 50%;
+      width: 4px; height: 4px; border-radius: 50%;
       background: var(--copper);
     }
     .intensity-dot.off { background: var(--ink-4); opacity: .4; }
   }
 
-  /* Brief foot — promise strip hinting at what lives inside the full product brief */
-  .mem-brief .brief-foot {
-    margin-top: 28px;
-    padding-top: 22px;
-    border-top: 1px solid var(--hair);
+  /* Bridge "also in the brief" strip — outside the card */
+  .mem-hero-bridge {
+    margin-top: 18px;
     display: flex;
-    flex-direction: column;
-    gap: 8px;
-    font-family: var(--font-body), 'Instrument Sans', system-ui, sans-serif;
+    justify-content: space-between;
+    gap: 16px;
+    flex-wrap: wrap;
 
-    > span:first-child {
+    .bridge-lead {
       font-family: var(--font-display), 'Instrument Sans', system-ui, sans-serif;
       font-style: italic;
-      font-size: 15px;
+      font-size: 14px;
       color: var(--ink-2);
       line-height: 1.4;
     }
 
-    .brief-foot-also {
+    .bridge-also {
       font-family: 'Geist Mono', monospace;
-      font-size: 10.5px;
+      font-size: 10px;
       color: var(--ink-3);
       letter-spacing: .12em;
       text-transform: uppercase;
@@ -2548,11 +2515,16 @@ header button:focus:not(:focus-visible){
     .mem-support-grid { grid-template-columns: 1fr; gap: 18px; }
   }
 
+  @media (max-width: 860px) {
+    .mem-brief-grid { grid-template-columns: 1fr; gap: 20px; }
+  }
+
   @media (max-width: 720px) {
     .mem-intro { padding: 96px 22px 36px; }
     .mem-hero-surface { padding: 0 18px; }
-    .mem-hero-frame { padding: 24px 20px 28px; }
+    .mem-hero-frame { padding: 20px 18px 18px; }
     .mem-hero-head { flex-direction: column; align-items: flex-start; }
+    .mem-hero-bridge { flex-direction: column; gap: 8px; }
 
     .mem-compare { margin-top: 72px; padding: 0 22px; }
     .mem-table { font-size: 13px; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1790,11 +1790,11 @@ header button:focus:not(:focus-visible){
    Memory page — /memory (per DESIGN.md §2–§7 alignment)
 ═══════════════════════════════════════════════════════════ */
 .memory-page {
-  /* ── Intro (matches .coming-soon / .inv-intro canonical 120/40/96) ── */
+  /* ── Intro (matches standalone canonical per DESIGN.md §4) ── */
   .mem-intro {
-    max-width: 1100px;
-    margin: 0 auto;
-    padding: 120px 40px 48px;
+    max-width: 1280px;
+    margin: 80px auto 0;
+    padding: 20px 40px;
 
     .eb {
       font-family: 'Geist Mono', monospace;
@@ -2519,7 +2519,7 @@ header button:focus:not(:focus-visible){
   }
 
   @media (max-width: 720px) {
-    .mem-intro { padding: 96px 22px 36px; }
+    .mem-intro { padding: 20px 22px; margin-top: 48px; }
     .mem-hero-surface { padding: 0 18px; }
     .mem-hero-frame { padding: 20px 18px 18px; }
     .mem-hero-head { flex-direction: column; align-items: flex-start; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1786,3 +1786,1010 @@ header button:focus:not(:focus-visible){
   from {left:-50%}
   to   {left:100%}
 }
+
+/* ═══════════════════════════════════════════════════════════
+   Memory page — /memory (per DESIGN.md §2–§7 alignment)
+═══════════════════════════════════════════════════════════ */
+.memory-page {
+  /* ── Intro (matches .coming-soon / .inv-intro canonical 120/40/96) ── */
+  .mem-intro {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 120px 40px 48px;
+
+    .eb {
+      font-family: 'Geist Mono', monospace;
+      font-size: 11px;
+      font-weight: 500;
+      letter-spacing: .18em;
+      text-transform: uppercase;
+      color: var(--copper);
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 28px;
+
+      &::before {
+        content: "";
+        width: 28px;
+        height: 1px;
+        background: var(--copper);
+        display: inline-block;
+      }
+    }
+
+    h1 {
+      font-family: var(--font-display), 'Instrument Sans', system-ui, sans-serif;
+      font-weight: 400;
+      font-size: clamp(44px, 5.2vw, 72px);
+      line-height: 1.04;
+      letter-spacing: -.025em;
+      color: var(--ink);
+      margin: 0 0 28px;
+      max-width: 22ch;
+      text-wrap: balance;
+    }
+    h1 em { font-style: italic; color: var(--copper); }
+
+    .lede {
+      font-family: var(--font-body), 'Instrument Sans', system-ui, sans-serif;
+      font-weight: 300;
+      font-size: 18px;
+      line-height: 1.7;
+      color: var(--ink-2);
+      max-width: 62ch;
+      margin: 0;
+    }
+    .lede em {
+      font-family: var(--font-display), 'Instrument Sans', system-ui, sans-serif;
+      font-style: italic;
+      color: var(--ink);
+      font-size: 19px;
+      font-weight: 400;
+    }
+  }
+
+  /* ── Featured hero surface (Surface 01: the brief) ── */
+  .mem-hero-surface {
+    max-width: 1100px;
+    margin: 24px auto 0;
+    padding: 0 40px;
+  }
+
+  .mem-hero-frame {
+    position: relative;
+    background: rgba(254, 133, 49, 0.03);
+    border: 1px solid var(--hair-2);
+    border-radius: 16px;
+    padding: 36px 36px 40px;
+    overflow: hidden;
+
+    /* Hero-card 2px left gradient per DESIGN.md §5 card chrome */
+    &::before {
+      content: "";
+      position: absolute;
+      top: 0; left: 0;
+      width: 2px; height: 100%;
+      background: linear-gradient(180deg, var(--copper), rgba(254, 133, 49, 0));
+    }
+  }
+
+  .mem-hero-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-bottom: 24px;
+    margin-bottom: 28px;
+    border-bottom: 1px solid var(--hair);
+    gap: 16px;
+    flex-wrap: wrap;
+
+    .mem-hero-kicker {
+      font-family: 'Geist Mono', monospace;
+      font-size: 11px;
+      font-weight: 500;
+      letter-spacing: .18em;
+      text-transform: uppercase;
+      color: var(--copper);
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+
+      &::before {
+        content: "";
+        width: 28px;
+        height: 1px;
+        background: var(--copper);
+        display: inline-block;
+      }
+    }
+
+    .mem-hero-chip {
+      font-family: 'Geist Mono', monospace;
+      font-size: 10px;
+      font-weight: 500;
+      letter-spacing: .18em;
+      text-transform: uppercase;
+      color: var(--copper);
+      background: rgba(254, 133, 49, 0.08);
+      border: 1px solid rgba(254, 133, 49, 0.26);
+      border-radius: 4px;
+      padding: 5px 10px;
+    }
+  }
+
+  /* ── The brief (6 blocks) ── */
+  .mem-brief {
+    max-width: 760px;
+    margin: 0 auto;
+  }
+
+  .mem-brief .crumb {
+    font-family: 'Geist Mono', monospace;
+    font-size: 11px;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+    color: var(--ink-4);
+    margin-bottom: 16px;
+
+    .crumb-link { color: var(--ink-3); }
+    .sep { color: var(--ink-4); margin: 0 8px; }
+  }
+
+  .mem-brief .brief-title {
+    font-family: var(--font-display), 'Instrument Sans', system-ui, sans-serif;
+    font-weight: 400;
+    font-size: clamp(36px, 4.6vw, 52px);
+    line-height: 1.04;
+    letter-spacing: -.02em;
+    color: var(--ink);
+    margin: 0 0 14px;
+
+    em { font-style: italic; color: var(--copper); }
+  }
+
+  .mem-brief .brief-meta {
+    font-family: 'Geist Mono', monospace;
+    font-size: 11px;
+    color: var(--ink-3);
+    letter-spacing: .04em;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+    margin-bottom: 48px;
+
+    .sep { color: var(--ink-4); opacity: .6; }
+
+    .pulse {
+      display: inline-flex; align-items: center; gap: 8px;
+      color: var(--copper);
+
+      &::before {
+        content: "";
+        width: 6px; height: 6px; border-radius: 50%;
+        background: var(--copper);
+        box-shadow: 0 0 0 0 rgba(254, 133, 49, 0.55);
+        animation: memPulse 2.4s ease-in-out infinite;
+      }
+    }
+  }
+
+  .mem-brief .brief-block {
+    padding: 32px 0 36px;
+    border-top: 1px solid var(--hair);
+
+    &:first-of-type { border-top: 1px solid var(--hair-2); padding-top: 0; }
+  }
+
+  /* Canonical eyebrow inside brief blocks */
+  .mem-brief .eb {
+    font-family: 'Geist Mono', monospace;
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: .18em;
+    text-transform: uppercase;
+    color: var(--copper);
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 22px;
+
+    &::before {
+      content: "";
+      width: 28px;
+      height: 1px;
+      background: var(--copper);
+      display: inline-block;
+    }
+
+    .sub {
+      font-family: var(--font-body), 'Instrument Sans', system-ui, sans-serif;
+      color: var(--ink-3);
+      font-size: 12.5px;
+      letter-spacing: .04em;
+      font-weight: 400;
+      text-transform: none;
+    }
+  }
+
+  /* Block 1 — People */
+  .mem-brief .people { display: grid; gap: 18px; }
+  .mem-brief .person {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 10px;
+    padding: 14px 0;
+    border-bottom: 1px dashed var(--hair);
+
+    &:last-child { border-bottom: 0; }
+
+    .person-main {
+      display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap;
+    }
+
+    .person-name {
+      font-family: var(--font-display), 'Instrument Sans', system-ui, sans-serif;
+      font-weight: 500;
+      font-size: 22px;
+      color: var(--ink);
+      letter-spacing: -.01em;
+      line-height: 1.15;
+    }
+
+    .person-role {
+      font-family: 'Geist Mono', monospace;
+      font-size: 11px;
+      color: var(--ink-3);
+      letter-spacing: .12em;
+      text-transform: uppercase;
+    }
+
+    .person-quote {
+      font-family: var(--font-display), 'Instrument Sans', system-ui, sans-serif;
+      font-style: italic;
+      font-weight: 400;
+      font-size: 17px;
+      line-height: 1.45;
+      color: var(--ink-2);
+    }
+
+    .person-cite {
+      font-family: 'Geist Mono', monospace;
+      font-size: 11px;
+      color: var(--ink-3);
+      letter-spacing: .04em;
+      display: inline-flex;
+      gap: 8px;
+      align-items: center;
+      flex-wrap: wrap;
+
+      .person-cite-link { color: var(--copper); }
+      .arrow { color: var(--copper); opacity: .7; }
+    }
+  }
+
+  .mem-brief .stance {
+    font-family: 'Geist Mono', monospace;
+    font-size: 10.5px;
+    font-weight: 500;
+    letter-spacing: .16em;
+    text-transform: uppercase;
+    padding: 4px 10px;
+    border-radius: 4px;
+
+    &.champion {
+      color: var(--copper);
+      background: rgba(254, 133, 49, 0.08);
+      border: 1px solid rgba(254, 133, 49, 0.24);
+    }
+    &.skeptic {
+      color: var(--ink-2);
+      background: rgba(232, 230, 227, 0.04);
+      border: 1px solid var(--hair-2);
+    }
+    &.blocker {
+      color: var(--rust);
+      background: rgba(209, 60, 19, 0.10);
+      border: 1px solid rgba(209, 60, 19, 0.26);
+    }
+  }
+
+  /* Block 2 — They Need */
+  .mem-brief .pains { display: grid; gap: 10px; }
+  .mem-brief .pain {
+    padding: 14px 0 14px 20px;
+    border-left: 2px solid var(--copper);
+    background: linear-gradient(90deg, rgba(254, 133, 49, 0.04), transparent 60%);
+    border-radius: 0 6px 6px 0;
+
+    .pain-quote {
+      font-family: var(--font-display), 'Instrument Sans', system-ui, sans-serif;
+      font-style: italic;
+      font-weight: 400;
+      font-size: 19px;
+      line-height: 1.4;
+      color: var(--ink);
+      margin: 0 0 8px;
+      letter-spacing: -.005em;
+    }
+
+    .pain-cite {
+      font-family: 'Geist Mono', monospace;
+      font-size: 11px;
+      color: var(--ink-3);
+      letter-spacing: .04em;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
+
+      .pain-cite-link { color: var(--copper); }
+    }
+  }
+
+  .mem-brief .intensity {
+    display: inline-flex; gap: 3px; align-items: center;
+
+    .intensity-dot {
+      width: 5px; height: 5px; border-radius: 50%;
+      background: var(--copper);
+    }
+    .intensity-dot.off { background: var(--ink-4); opacity: .4; }
+  }
+
+  /* Block 3 — We Owe Them */
+  .mem-brief .owed { display: grid; }
+  .mem-brief .owed-row {
+    display: grid;
+    grid-template-columns: 28px 1fr auto;
+    gap: 14px;
+    align-items: baseline;
+    padding: 14px 0;
+    border-bottom: 1px dashed var(--hair);
+
+    &:last-child { border-bottom: 0; }
+
+    .owed-glyph {
+      width: 14px; height: 14px; margin-top: 6px;
+      border-radius: 50%;
+      justify-self: center;
+    }
+
+    &.open .owed-glyph {
+      background: var(--copper);
+      box-shadow: 0 0 0 3px rgba(254, 133, 49, 0.14);
+    }
+    &.scheduled .owed-glyph {
+      background: transparent;
+      border: 2px solid var(--ink-2);
+    }
+    &.closed .owed-glyph {
+      background: var(--ink-4);
+      opacity: .7;
+    }
+
+    .owed-text {
+      font-size: 15px;
+      color: var(--ink);
+      line-height: 1.5;
+
+      em {
+        font-style: italic;
+        color: var(--copper);
+        font-size: 16px;
+        font-weight: 400;
+      }
+    }
+
+    &.closed .owed-text {
+      color: var(--ink-3);
+      text-decoration: line-through;
+      text-decoration-color: var(--ink-4);
+    }
+
+    .owed-meta {
+      font-family: 'Geist Mono', monospace;
+      font-size: 10.5px;
+      color: var(--ink-3);
+      letter-spacing: .12em;
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+    &.open .owed-meta { color: var(--copper); }
+    &.closed .owed-meta { color: var(--ink-4); }
+  }
+
+  /* Block 4 — What's Changed */
+  .mem-brief .contra {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    gap: 20px;
+    align-items: stretch;
+    padding: 22px;
+    background: rgba(254, 133, 49, 0.04);
+    border: 1px solid rgba(254, 133, 49, 0.18);
+    border-radius: 10px;
+
+    .contra-col {
+      display: grid; gap: 10px; align-content: start;
+
+      &.left { text-align: right; }
+    }
+
+    .contra-date {
+      font-family: 'Geist Mono', monospace;
+      font-size: 10.5px;
+      font-weight: 500;
+      letter-spacing: .18em;
+      text-transform: uppercase;
+      color: var(--copper);
+    }
+
+    .contra-quote {
+      font-family: var(--font-display), 'Instrument Sans', system-ui, sans-serif;
+      font-style: italic;
+      font-weight: 400;
+      font-size: 18px;
+      line-height: 1.4;
+      color: var(--ink);
+      letter-spacing: -.005em;
+    }
+
+    .contra-who {
+      font-family: 'Geist Mono', monospace;
+      font-size: 10.5px;
+      color: var(--ink-3);
+      letter-spacing: .04em;
+    }
+
+    .contra-arrow {
+      display: flex; align-items: center; justify-content: center;
+      font-family: 'Geist Mono', monospace;
+      font-size: 22px;
+      color: var(--copper);
+      padding: 0 4px;
+    }
+  }
+
+  .mem-brief .contra-obs {
+    margin-top: 16px;
+    padding: 12px 16px;
+    background: rgba(254, 133, 49, 0.05);
+    border-left: 2px solid var(--copper);
+    border-radius: 0 6px 6px 0;
+    font-size: 13.5px;
+    color: var(--ink-2);
+    line-height: 1.5;
+
+    .label {
+      font-family: 'Geist Mono', monospace;
+      font-size: 10px;
+      font-weight: 500;
+      letter-spacing: .2em;
+      text-transform: uppercase;
+      color: var(--copper);
+      display: block;
+      margin-bottom: 4px;
+    }
+  }
+
+  /* Block 5 — How We Map */
+  .mem-brief .mapping { display: grid; gap: 12px; }
+  .mem-brief .mapping-row {
+    display: grid;
+    grid-template-columns: 1fr 180px auto;
+    gap: 18px;
+    align-items: center;
+    padding: 12px 0;
+    border-bottom: 1px dashed var(--hair);
+
+    &:last-child { border-bottom: 0; }
+
+    .mapping-prod {
+      font-size: 15px;
+      color: var(--ink);
+      font-weight: 500;
+
+      em {
+        font-style: italic;
+        color: var(--copper);
+        font-size: 16px;
+        font-weight: 400;
+      }
+    }
+
+    .mapping-bar {
+      position: relative;
+      height: 6px;
+      border-radius: 3px;
+      background: rgba(254, 133, 49, 0.10);
+      overflow: hidden;
+
+      .mapping-bar-fill {
+        position: absolute; inset: 0;
+        background: linear-gradient(90deg, var(--copper), var(--copper-soft));
+        border-radius: 3px;
+      }
+    }
+
+    .mapping-conf {
+      font-family: 'Geist Mono', monospace;
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--copper);
+      letter-spacing: .04em;
+      min-width: 48px;
+      text-align: right;
+    }
+  }
+
+  /* Block 6 — Next */
+  .mem-brief .next { display: grid; gap: 14px; }
+  .mem-brief .next-row {
+    display: grid;
+    grid-template-columns: 160px 1fr;
+    gap: 24px;
+    align-items: baseline;
+    padding: 10px 0;
+    border-bottom: 1px dashed var(--hair);
+
+    &:last-child { border-bottom: 0; }
+
+    .next-key {
+      font-family: 'Geist Mono', monospace;
+      font-size: 10.5px;
+      font-weight: 500;
+      letter-spacing: .18em;
+      text-transform: uppercase;
+      color: var(--ink-3);
+    }
+
+    .next-val {
+      font-size: 15px;
+      color: var(--ink);
+      line-height: 1.5;
+
+      em {
+        font-style: italic;
+        color: var(--copper);
+        font-size: 16px;
+        font-weight: 400;
+      }
+    }
+
+    .cliffhanger {
+      font-family: var(--font-display), 'Instrument Sans', system-ui, sans-serif;
+      font-style: italic;
+      font-weight: 400;
+      color: var(--ink);
+      font-size: 17px;
+      line-height: 1.4;
+    }
+  }
+
+  /* ── Supporting surfaces 02 / 03 / 04 ── */
+  .mem-supporting {
+    max-width: 1280px;
+    margin: 120px auto 0;
+    padding: 0 40px;
+  }
+
+  .mem-support-head { margin-bottom: 36px; }
+
+  .mem-support-head .eb {
+    font-family: 'Geist Mono', monospace;
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: .18em;
+    text-transform: uppercase;
+    color: var(--copper);
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+
+    &::before {
+      content: "";
+      width: 28px;
+      height: 1px;
+      background: var(--copper);
+      display: inline-block;
+    }
+
+    .sub {
+      font-family: var(--font-body), 'Instrument Sans', system-ui, sans-serif;
+      color: var(--ink-3);
+      font-size: 12.5px;
+      letter-spacing: .04em;
+      font-weight: 400;
+      text-transform: none;
+    }
+  }
+
+  .mem-support-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 24px;
+  }
+
+  .mem-support-card {
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid var(--hair-2);
+    border-radius: 12px;
+    padding: 26px 26px 22px;
+    display: flex;
+    flex-direction: column;
+
+    .support-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 14px;
+      gap: 10px;
+
+      .idx {
+        font-family: 'Geist Mono', monospace;
+        font-size: 10.5px;
+        font-weight: 500;
+        letter-spacing: .2em;
+        text-transform: uppercase;
+        color: var(--copper);
+      }
+
+      .support-chip {
+        font-family: 'Geist Mono', monospace;
+        font-size: 9.5px;
+        font-weight: 500;
+        letter-spacing: .16em;
+        text-transform: uppercase;
+        color: var(--copper);
+        background: rgba(254, 133, 49, 0.08);
+        border: 1px solid rgba(254, 133, 49, 0.24);
+        border-radius: 4px;
+        padding: 3px 8px;
+      }
+    }
+
+    h3 {
+      font-family: var(--font-display), 'Instrument Sans', system-ui, sans-serif;
+      font-weight: 400;
+      font-size: 22px;
+      line-height: 1.15;
+      letter-spacing: -.015em;
+      color: var(--ink);
+      margin: 0 0 10px;
+    }
+    h3 em { font-style: italic; color: var(--copper); }
+
+    .support-desc {
+      font-family: var(--font-body), 'Instrument Sans', system-ui, sans-serif;
+      font-weight: 400;
+      font-size: 13.5px;
+      line-height: 1.55;
+      color: var(--ink-2);
+      margin: 0 0 18px;
+      flex-grow: 1;
+    }
+
+    .support-mock {
+      background: #0A0910;
+      border: 1px solid var(--hair);
+      border-radius: 8px;
+      padding: 14px 16px;
+      font-family: var(--font-body), 'Instrument Sans', system-ui, sans-serif;
+    }
+  }
+
+  /* Pain-product mini mock */
+  .mem-support-card .pp-mock {
+    display: grid;
+    gap: 10px;
+
+    .pp-row {
+      display: grid;
+      grid-template-columns: 1fr 70px auto;
+      gap: 10px;
+      align-items: center;
+      font-size: 12.5px;
+
+      .pp-prod { color: var(--ink); font-weight: 500; }
+      .pp-conf {
+        font-family: 'Geist Mono', monospace;
+        font-size: 11px;
+        color: var(--copper);
+        min-width: 34px;
+        text-align: right;
+      }
+
+      .mapping-bar {
+        position: relative;
+        height: 5px;
+        border-radius: 3px;
+        background: rgba(254, 133, 49, 0.10);
+        overflow: hidden;
+
+        .mapping-bar-fill {
+          position: absolute; inset: 0;
+          background: linear-gradient(90deg, var(--copper), var(--copper-soft));
+          border-radius: 3px;
+        }
+      }
+    }
+  }
+
+  /* Contradictions mini mock */
+  .mem-support-card .cx-mock {
+    display: grid;
+    gap: 8px;
+
+    .cx-row {
+      display: grid;
+      grid-template-columns: 54px 1fr;
+      gap: 12px;
+      align-items: baseline;
+      padding: 6px 0;
+
+      .cx-date {
+        font-family: 'Geist Mono', monospace;
+        font-size: 10px;
+        font-weight: 500;
+        letter-spacing: .18em;
+        text-transform: uppercase;
+        color: var(--copper);
+      }
+
+      .cx-quote {
+        font-family: var(--font-display), 'Instrument Sans', system-ui, sans-serif;
+        font-style: italic;
+        font-size: 14px;
+        line-height: 1.35;
+        color: var(--ink);
+      }
+    }
+
+    .cx-arrow {
+      text-align: center;
+      font-family: 'Geist Mono', monospace;
+      font-size: 16px;
+      color: var(--copper);
+      opacity: .8;
+      line-height: 1;
+      margin: 2px 0;
+    }
+  }
+
+  /* Handoff export mini mock */
+  .mem-support-card .hx-mock {
+    font-family: 'Geist Mono', monospace;
+    font-size: 11.5px;
+    line-height: 1.7;
+
+    .hx-line { color: var(--ink-2); }
+    .hx-line.muted { color: var(--copper); opacity: .85; }
+  }
+
+  /* ── CRM vs Salency compare ── */
+  .mem-compare {
+    max-width: 1280px;
+    margin: 120px auto 0;
+    padding: 0 40px;
+  }
+
+  .mem-compare-head { margin-bottom: 36px; max-width: 60ch; }
+
+  .mem-compare-head .eb {
+    font-family: 'Geist Mono', monospace;
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: .18em;
+    text-transform: uppercase;
+    color: var(--copper);
+    margin-bottom: 20px;
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+
+    &::before {
+      content: "";
+      width: 28px;
+      height: 1px;
+      background: var(--copper);
+      display: inline-block;
+    }
+  }
+
+  .mem-compare-head h2 {
+    font-family: var(--font-display), 'Instrument Sans', system-ui, sans-serif;
+    font-weight: 400;
+    font-size: clamp(34px, 4vw, 52px);
+    line-height: 1.05;
+    letter-spacing: -.025em;
+    color: var(--ink);
+    margin: 0;
+    max-width: 22ch;
+    text-wrap: balance;
+  }
+  .mem-compare-head h2 em { font-style: italic; color: var(--copper); }
+
+  .mem-table {
+    width: 100%;
+    border-collapse: collapse;
+    border: 1px solid var(--hair-2);
+    border-radius: 12px;
+    overflow: hidden;
+    background: rgba(255, 255, 255, 0.02);
+
+    thead th {
+      text-align: left;
+      padding: 16px 22px;
+      font-family: 'Geist Mono', monospace;
+      font-size: 10.5px;
+      font-weight: 500;
+      letter-spacing: .18em;
+      text-transform: uppercase;
+      color: var(--ink-4);
+      border-bottom: 1px solid var(--hair-2);
+      background: rgba(0, 0, 0, 0.12);
+    }
+    thead th:nth-child(2) { color: var(--ink-3); }
+    thead th:nth-child(3) { color: var(--copper); }
+
+    td {
+      padding: 18px 22px;
+      vertical-align: top;
+      font-family: var(--font-body), 'Instrument Sans', system-ui, sans-serif;
+      font-size: 14px;
+      line-height: 1.55;
+      border-bottom: 1px solid var(--hair);
+    }
+    tr:last-child td { border-bottom: 0; }
+    td:nth-child(1) { color: var(--ink); font-weight: 500; width: 22%; }
+    td:nth-child(2) { color: var(--ink-3); width: 39%; }
+    td:nth-child(3) { color: var(--ink); width: 39%; }
+  }
+
+  .mem-compare-foot {
+    margin-top: 22px;
+    font-family: var(--font-body), 'Instrument Sans', system-ui, sans-serif;
+    font-size: 14px;
+    color: var(--ink-3);
+
+    a {
+      color: var(--copper);
+      text-decoration: none;
+      border-bottom: 1px solid rgba(254, 133, 49, 0.3);
+      transition: border-color .18s;
+    }
+    a:hover { border-bottom-color: var(--copper); }
+  }
+
+  /* ── Transcript sources ── */
+  .mem-compat {
+    max-width: 1280px;
+    margin: 96px auto 0;
+    padding: 32px 40px;
+    border-top: 1px solid var(--hair);
+    border-bottom: 1px solid var(--hair);
+    text-align: center;
+
+    .eb {
+      font-family: 'Geist Mono', monospace;
+      font-size: 10.5px;
+      font-weight: 500;
+      letter-spacing: .2em;
+      text-transform: uppercase;
+      color: var(--ink-4);
+      margin-bottom: 16px;
+      display: block;
+    }
+  }
+
+  .mem-compat-line {
+    font-family: var(--font-body), 'Instrument Sans', system-ui, sans-serif;
+    font-weight: 400;
+    font-size: 16px;
+    line-height: 1.6;
+    color: var(--ink-2);
+    max-width: 68ch;
+    margin: 0 auto;
+
+    em {
+      font-family: var(--font-display), 'Instrument Sans', system-ui, sans-serif;
+      font-style: italic;
+      color: var(--ink);
+      font-size: 17px;
+      font-weight: 400;
+    }
+  }
+
+  /* ── Pilot CTA ── */
+  .mem-cta {
+    max-width: 1280px;
+    margin: 96px auto 120px;
+    padding: 0 40px;
+    text-align: center;
+
+    .eb {
+      font-family: 'Geist Mono', monospace;
+      font-size: 11px;
+      font-weight: 500;
+      letter-spacing: .2em;
+      text-transform: uppercase;
+      color: var(--copper);
+      margin-bottom: 22px;
+      display: block;
+    }
+
+    h2 {
+      font-family: var(--font-display), 'Instrument Sans', system-ui, sans-serif;
+      font-weight: 400;
+      font-size: clamp(36px, 4.5vw, 56px);
+      line-height: 1.05;
+      letter-spacing: -.025em;
+      color: var(--ink);
+      margin: 0 auto 18px;
+      max-width: 22ch;
+      text-wrap: balance;
+    }
+    h2 em { font-style: italic; color: var(--copper); }
+
+    .sub {
+      font-family: var(--font-body), 'Instrument Sans', system-ui, sans-serif;
+      font-weight: 300;
+      font-size: 16.5px;
+      line-height: 1.6;
+      color: var(--ink-2);
+      max-width: 52ch;
+      margin: 0 auto 30px;
+    }
+  }
+
+  /* ── Responsive ── */
+  @media (max-width: 960px) {
+    .mem-support-grid { grid-template-columns: 1fr; gap: 18px; }
+  }
+
+  @media (max-width: 720px) {
+    .mem-intro { padding: 96px 22px 36px; }
+    .mem-hero-surface { padding: 0 18px; }
+    .mem-hero-frame { padding: 24px 20px 28px; }
+    .mem-hero-head { flex-direction: column; align-items: flex-start; }
+
+    .mem-brief .contra {
+      grid-template-columns: 1fr;
+      gap: 14px;
+      padding: 18px;
+
+      .contra-col.left { text-align: left; }
+      .contra-arrow { padding: 0; font-size: 16px; justify-content: flex-start; }
+    }
+
+    .mem-brief .mapping-row {
+      grid-template-columns: 1fr;
+      gap: 8px;
+
+      .mapping-bar { width: 100%; }
+      .mapping-conf { text-align: left; }
+    }
+
+    .mem-brief .next-row { grid-template-columns: 1fr; gap: 4px; }
+
+    .mem-compare { margin-top: 72px; padding: 0 22px; }
+    .mem-table { font-size: 13px; }
+    .mem-table thead th { padding: 14px 16px; }
+    .mem-table td { padding: 14px 16px; font-size: 13px; }
+    .mem-table td:nth-child(1) { width: 30%; }
+
+    .mem-compat { margin-top: 72px; padding: 24px 22px; }
+    .mem-compat-line { font-size: 15px; }
+    .mem-compat-line em { font-size: 16px; }
+
+    .mem-cta { margin: 72px auto 72px; padding: 0 22px; }
+  }
+}
+
+@keyframes memPulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(254, 133, 49, 0.55); }
+  50% { box-shadow: 0 0 0 5px rgba(254, 133, 49, 0); }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -736,7 +736,7 @@ html {
   .h1 em{font-style:normal;font-weight:inherit;color:var(--copper)}
   .h1 .soft{color:var(--ink-3)}
 
-  .sub{
+  .hero .sub{
     margin:28px 0 0;max-width:58ch;
     font-family:var(--font-body), 'Geist', sans-serif;font-weight:300;
     font-size:19px;line-height:1.55;color:var(--ink-2);

--- a/app/memory/page.tsx
+++ b/app/memory/page.tsx
@@ -1,16 +1,18 @@
 import { MarketingHeader } from '@/components/MarketingHeader';
-import { ComingSoon } from '@/components/sections/ComingSoon';
+import { MemorySection } from '@/components/sections/MemorySection';
 import { SiteFooter } from '@/components/sections/SiteFooter';
+
+export const metadata = {
+  title: 'Memory · Salency',
+  description:
+    'Institutional memory for revenue teams. Every call becomes cited, queryable context — stakeholders, pains, open commitments, contradictions, pain-to-product mapping. Built for the rep inheriting the account at 2pm Monday.',
+};
 
 export default function MemoryPage() {
   return (
-    <div className="page">
+    <div className="page memory-page">
       <MarketingHeader />
-      <ComingSoon
-        eyebrow="Memory · New"
-        title="Memory —"
-        description="A cited, queryable memory graph for every account your team touches. Pains, stakeholders, commitments, objections — all mapped to your catalog, all linked to the call they came from. Deep-dive page under construction."
-      />
+      <MemorySection />
       <SiteFooter />
     </div>
   );

--- a/components/sections/MemorySection.tsx
+++ b/components/sections/MemorySection.tsx
@@ -45,39 +45,6 @@ const PAINS = [
   },
 ];
 
-const OWED = [
-  {
-    state: 'open' as const,
-    stateLabel: 'Owed · due Apr 26',
-    text: 'Pricing memo',
-    tail: 'to Priya with 3-year commit scenarios',
-  },
-  {
-    state: 'scheduled' as const,
-    stateLabel: 'Scheduled Apr 30',
-    text: 'Security walkthrough',
-    tail: 'with Marcus · SOC 2 roadmap + on-prem options',
-  },
-  {
-    state: 'open' as const,
-    stateLabel: 'Owed · unscheduled',
-    text: 'Reference call',
-    tail: 'with a design-partner revenue team',
-  },
-  {
-    state: 'closed' as const,
-    stateLabel: 'Closed Apr 18',
-    text: null,
-    tail: 'Send transcript-only evaluation workflow for legal review',
-  },
-];
-
-const MAPPING = [
-  { prod: 'Memory Layer', tail: 'Handoff Brief', conf: 0.92 },
-  { prod: 'Contradiction Detection', tail: 'add-on', conf: 0.74 },
-  { prod: 'Account Pattern Search', tail: null, conf: 0.61 },
-];
-
 const COMPARE_ROWS = [
   {
     signal: 'Customer pain',
@@ -165,9 +132,9 @@ export function MemorySection() {
               <div className="brief-meta">
                 <span>Updated 2026-04-22</span>
                 <span className="sep">&middot;</span>
-                <span className="pulse">3 new signals since last open</span>
+                <span className="pulse">3 new pains flagged</span>
                 <span className="sep">&middot;</span>
-                <span>12 calls indexed &middot; 4 stakeholders tracked</span>
+                <span>12 calls indexed &middot; 2 stakeholders on this card</span>
               </div>
 
               {/* People */}
@@ -222,106 +189,11 @@ export function MemorySection() {
                 </div>
               </div>
 
-              {/* We owe them */}
-              <div className="brief-block">
-                <div className="eb">
-                  We owe them <span className="sub">open commitments</span>
-                </div>
-                <div className="owed">
-                  {OWED.map((o, idx) => (
-                    <div key={idx} className={`owed-row ${o.state}`}>
-                      <span className="owed-glyph" aria-label={o.state} />
-                      <div className="owed-text">
-                        {o.text && <em>{o.text}</em>}
-                        {o.text && ' '}
-                        {o.tail}
-                      </div>
-                      <span className="owed-meta">{o.stateLabel}</span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              {/* What's changed */}
-              <div className="brief-block">
-                <div className="eb">
-                  What&rsquo;s changed{' '}
-                  <span className="sub">contradictions flagged</span>
-                </div>
-                <div className="contra">
-                  <div className="contra-col left">
-                    <span className="contra-date">Apr 07</span>
-                    <span className="contra-quote">
-                      &ldquo;budget is fifty.&rdquo;
-                    </span>
-                    <span className="contra-who">
-                      Priya Shah &middot; call 02 &middot; 22:13
-                    </span>
-                  </div>
-                  <div className="contra-arrow">&rarr;</div>
-                  <div className="contra-col">
-                    <span className="contra-date">Apr 14</span>
-                    <span className="contra-quote">
-                      &ldquo;budget&rsquo;s tight, maybe twenty.&rdquo;
-                    </span>
-                    <span className="contra-who">
-                      Priya Shah &middot; call 03 &middot; 18:02
-                    </span>
-                  </div>
-                </div>
-                <div className="contra-obs">
-                  <span className="label">System note</span>
-                  Budget may have reset between Mar and Apr &middot; verify
-                  before the pricing memo lands.
-                </div>
-              </div>
-
-              {/* How we map */}
-              <div className="brief-block">
-                <div className="eb">
-                  How we map{' '}
-                  <span className="sub">
-                    pain &rarr; product, confidence-ranked
-                  </span>
-                </div>
-                <div className="mapping">
-                  {MAPPING.map((m) => (
-                    <div key={m.prod} className="mapping-row">
-                      <div className="mapping-prod">
-                        <em>{m.prod}</em>
-                        {m.tail && ` \u00B7 ${m.tail}`}
-                      </div>
-                      <ConfBar pct={m.conf} />
-                      <div className="mapping-conf">{m.conf.toFixed(2)}</div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              {/* Next */}
-              <div className="brief-block">
-                <div className="eb">
-                  Next <span className="sub">where to pick up</span>
-                </div>
-                <div className="next">
-                  <div className="next-row">
-                    <span className="next-key">Meeting</span>
-                    <span className="next-val">
-                      <em>Apr 25, 2:00 PM PT</em> &middot; 45 min &middot;
-                      Priya, Marcus, Howard
-                    </span>
-                  </div>
-                  <div className="next-row">
-                    <span className="next-key">Since last contact</span>
-                    <span className="next-val">8 days</span>
-                  </div>
-                  <div className="next-row">
-                    <span className="next-key">Call 03 ended on</span>
-                    <span className="next-val cliffhanger">
-                      &ldquo;walk us through pricing.&rdquo;
-                    </span>
-                  </div>
-                </div>
+              <div className="brief-foot">
+                <span>This is what the rep opens Monday at 1:45pm.</span>
+                <span className="brief-foot-also">
+                  Also in the brief: open commitments &middot; contradictions &middot; pain &rarr; product mapping &middot; next-step cliffhanger.
+                </span>
               </div>
             </div>
           </div>

--- a/components/sections/MemorySection.tsx
+++ b/components/sections/MemorySection.tsx
@@ -26,20 +26,19 @@ const PEOPLE = [
 const PAINS = [
   {
     quote: 'Handoff loses context every time an AE rotates off.',
-    who: 'Priya Shah, VP Sales',
+    who: 'Priya Shah',
     cite: 'call 03, Apr 14 · 18:02',
     urgency: 3,
   },
   {
-    quote:
-      'We can\u2019t tell which pains repeat across accounts \u2014 it\u2019s all in reps\u2019 heads.',
-    who: 'Priya Shah, VP Sales',
+    quote: 'Pains repeat across accounts \u2014 all in reps\u2019 heads.',
+    who: 'Priya Shah',
     cite: 'call 02, Apr 07 · 27:44',
     urgency: 2,
   },
   {
-    quote: 'Our CRM has a notes field, but nothing structured we can query.',
-    who: 'Marcus Chen, Sales Ops',
+    quote: 'CRM has notes, not anything we can query.',
+    who: 'Marcus Chen',
     cite: 'call 03, Apr 14 · 41:02',
     urgency: 1,
   },
@@ -111,37 +110,33 @@ export function MemorySection() {
         </section>
       </ScrollReveal>
 
-      {/* ─── Surface 01: featured brief ─── */}
+      {/* ─── Surface 01: featured brief (tight 2-col, fits viewport) ─── */}
       <ScrollReveal>
         <section className="mem-hero-surface">
           <div className="mem-hero-frame">
             <div className="mem-hero-head">
-              <span className="mem-hero-kicker">The brief &middot; Surface 01</span>
-              <span className="mem-hero-chip">Design preview</span>
+              <div className="mem-hero-title-group">
+                <span className="mem-hero-title">
+                  Acme Corp &middot; <em>Day-1 brief</em>
+                </span>
+                <span className="mem-hero-meta">
+                  <span>Updated 2026-04-22</span>
+                  <span className="sep">&middot;</span>
+                  <span className="pulse">3 new pains flagged</span>
+                  <span className="sep">&middot;</span>
+                  <span>12 calls indexed</span>
+                </span>
+              </div>
+              <span className="mem-hero-chip">
+                Surface 01 &middot; Design preview
+              </span>
             </div>
 
-            <div className="mem-brief">
-              <div className="crumb">
-                <span className="crumb-link">Prospects</span>
-                <span className="sep">/</span>
-                <span>Acme Corp</span>
-              </div>
-              <h2 className="brief-title">
-                Acme Corp &middot; <em>Day-1 brief</em>
-              </h2>
-              <div className="brief-meta">
-                <span>Updated 2026-04-22</span>
-                <span className="sep">&middot;</span>
-                <span className="pulse">3 new pains flagged</span>
-                <span className="sep">&middot;</span>
-                <span>12 calls indexed &middot; 2 stakeholders on this card</span>
-              </div>
-
-              {/* People */}
+            <div className="mem-brief-grid">
+              {/* LEFT: People */}
               <div className="brief-block">
                 <div className="eb">
-                  People{' '}
-                  <span className="sub">who&rsquo;s in the room</span>
+                  People <span className="sub">who&rsquo;s in the room</span>
                 </div>
                 <div className="people">
                   {PEOPLE.map((p) => (
@@ -157,18 +152,15 @@ export function MemorySection() {
                         &ldquo;{p.quote}&rdquo;
                       </div>
                       <div className="person-cite">
-                        <span>
-                          {p.name}, {p.role} &middot;
-                        </span>
+                        <span>{p.name} &middot; </span>
                         <span className="person-cite-link">{p.cite}</span>
-                        <span className="arrow">&rsaquo;&rsaquo;</span>
                       </div>
                     </div>
                   ))}
                 </div>
               </div>
 
-              {/* They need */}
+              {/* RIGHT: They need */}
               <div className="brief-block">
                 <div className="eb">
                   They need <span className="sub">top pains, cited</span>
@@ -188,14 +180,18 @@ export function MemorySection() {
                   ))}
                 </div>
               </div>
-
-              <div className="brief-foot">
-                <span>This is what the rep opens Monday at 1:45pm.</span>
-                <span className="brief-foot-also">
-                  Also in the brief: open commitments &middot; contradictions &middot; pain &rarr; product mapping &middot; next-step cliffhanger.
-                </span>
-              </div>
             </div>
+          </div>
+
+          {/* "Also in the brief" bridge — moved outside the card */}
+          <div className="mem-hero-bridge">
+            <span className="bridge-lead">
+              This is what the rep opens Monday at 1:45pm.
+            </span>
+            <span className="bridge-also">
+              Also in the brief: commitments &middot; contradictions &middot;
+              pain &rarr; product &middot; cliffhanger
+            </span>
           </div>
         </section>
       </ScrollReveal>

--- a/components/sections/MemorySection.tsx
+++ b/components/sections/MemorySection.tsx
@@ -1,0 +1,496 @@
+'use client';
+
+import Link from 'next/link';
+import { ScrollReveal } from '@/components/ScrollReveal';
+import { openPilotModal } from '@/components/PilotModal';
+
+const PEOPLE = [
+  {
+    name: 'Priya Shah',
+    role: 'VP Sales',
+    stance: 'champion' as const,
+    stanceLabel: 'Champion',
+    quote: 'We lose deals to forgotten context every quarter.',
+    cite: 'call 03, Apr 14 · 18:02',
+  },
+  {
+    name: 'Marcus Chen',
+    role: 'Sales Ops',
+    stance: 'skeptic' as const,
+    stanceLabel: 'Skeptic',
+    quote: 'How does this not become another tab we forget about?',
+    cite: 'call 03, Apr 14 · 42:18',
+  },
+];
+
+const PAINS = [
+  {
+    quote: 'Handoff loses context every time an AE rotates off.',
+    who: 'Priya Shah, VP Sales',
+    cite: 'call 03, Apr 14 · 18:02',
+    urgency: 3,
+  },
+  {
+    quote:
+      'We can\u2019t tell which pains repeat across accounts \u2014 it\u2019s all in reps\u2019 heads.',
+    who: 'Priya Shah, VP Sales',
+    cite: 'call 02, Apr 07 · 27:44',
+    urgency: 2,
+  },
+  {
+    quote: 'Our CRM has a notes field, but nothing structured we can query.',
+    who: 'Marcus Chen, Sales Ops',
+    cite: 'call 03, Apr 14 · 41:02',
+    urgency: 1,
+  },
+];
+
+const OWED = [
+  {
+    state: 'open' as const,
+    stateLabel: 'Owed · due Apr 26',
+    text: 'Pricing memo',
+    tail: 'to Priya with 3-year commit scenarios',
+  },
+  {
+    state: 'scheduled' as const,
+    stateLabel: 'Scheduled Apr 30',
+    text: 'Security walkthrough',
+    tail: 'with Marcus · SOC 2 roadmap + on-prem options',
+  },
+  {
+    state: 'open' as const,
+    stateLabel: 'Owed · unscheduled',
+    text: 'Reference call',
+    tail: 'with a design-partner revenue team',
+  },
+  {
+    state: 'closed' as const,
+    stateLabel: 'Closed Apr 18',
+    text: null,
+    tail: 'Send transcript-only evaluation workflow for legal review',
+  },
+];
+
+const MAPPING = [
+  { prod: 'Memory Layer', tail: 'Handoff Brief', conf: 0.92 },
+  { prod: 'Contradiction Detection', tail: 'add-on', conf: 0.74 },
+  { prod: 'Account Pattern Search', tail: null, conf: 0.61 },
+];
+
+const COMPARE_ROWS = [
+  {
+    signal: 'Customer pain',
+    crm: 'Free-text field, last writer wins',
+    salency: 'Cited quote, speaker, timestamp \u2014 ranked by urgency',
+  },
+  {
+    signal: 'Contradiction between calls',
+    crm: 'Invisible \u2014 fields overwrite silently',
+    salency: 'Flagged with both source citations',
+  },
+  {
+    signal: 'Pain \u2192 product fit',
+    crm: 'One value per field, no ranking',
+    salency: 'Confidence-ranked, top-N per pain',
+  },
+  {
+    signal: 'Pattern across accounts',
+    crm: 'CSV export to a spreadsheet',
+    salency:
+      'Live graph query, "handoff loses context" lights up 7 accounts',
+  },
+];
+
+function UrgencyDots({ level }: { level: number }) {
+  return (
+    <span className="intensity" aria-label={`Urgency ${level} of 3`}>
+      {[1, 2, 3].map((i) => (
+        <span
+          key={i}
+          className={i <= level ? 'intensity-dot' : 'intensity-dot off'}
+        />
+      ))}
+    </span>
+  );
+}
+
+function ConfBar({ pct }: { pct: number }) {
+  return (
+    <span className="mapping-bar">
+      <span
+        className="mapping-bar-fill"
+        style={{ width: `${Math.round(pct * 100)}%` }}
+      />
+    </span>
+  );
+}
+
+export function MemorySection() {
+  return (
+    <>
+      <ScrollReveal>
+        <section className="mem-intro">
+          <span className="eb">Memory · Built for revenue teams</span>
+          <h1>
+            Institutional memory, <em>built.</em>
+          </h1>
+          <p className="lede">
+            Every call your team runs becomes{' '}
+            <em>structured, cited, queryable</em> context, mapped to your product
+            catalog and tied to the rep who heard it. The new AE inherits a Day-1
+            brief. The CS director picks up mid-story. Nothing is re-asked.
+          </p>
+        </section>
+      </ScrollReveal>
+
+      {/* ─── Surface 01: featured brief ─── */}
+      <ScrollReveal>
+        <section className="mem-hero-surface">
+          <div className="mem-hero-frame">
+            <div className="mem-hero-head">
+              <span className="mem-hero-kicker">The brief &middot; Surface 01</span>
+              <span className="mem-hero-chip">Design preview</span>
+            </div>
+
+            <div className="mem-brief">
+              <div className="crumb">
+                <span className="crumb-link">Prospects</span>
+                <span className="sep">/</span>
+                <span>Acme Corp</span>
+              </div>
+              <h2 className="brief-title">
+                Acme Corp &middot; <em>Day-1 brief</em>
+              </h2>
+              <div className="brief-meta">
+                <span>Updated 2026-04-22</span>
+                <span className="sep">&middot;</span>
+                <span className="pulse">3 new signals since last open</span>
+                <span className="sep">&middot;</span>
+                <span>12 calls indexed &middot; 4 stakeholders tracked</span>
+              </div>
+
+              {/* People */}
+              <div className="brief-block">
+                <div className="eb">
+                  People{' '}
+                  <span className="sub">who&rsquo;s in the room</span>
+                </div>
+                <div className="people">
+                  {PEOPLE.map((p) => (
+                    <div key={p.name} className="person">
+                      <div className="person-main">
+                        <span className="person-name">{p.name}</span>
+                        <span className="person-role">{p.role}</span>
+                        <span className={`stance ${p.stance}`}>
+                          {p.stanceLabel}
+                        </span>
+                      </div>
+                      <div className="person-quote">
+                        &ldquo;{p.quote}&rdquo;
+                      </div>
+                      <div className="person-cite">
+                        <span>
+                          {p.name}, {p.role} &middot;
+                        </span>
+                        <span className="person-cite-link">{p.cite}</span>
+                        <span className="arrow">&rsaquo;&rsaquo;</span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* They need */}
+              <div className="brief-block">
+                <div className="eb">
+                  They need <span className="sub">top pains, cited</span>
+                </div>
+                <div className="pains">
+                  {PAINS.map((p) => (
+                    <div key={p.cite} className="pain">
+                      <p className="pain-quote">&ldquo;{p.quote}&rdquo;</p>
+                      <div className="pain-cite">
+                        <span>
+                          {p.who} &middot;{' '}
+                          <span className="pain-cite-link">{p.cite}</span>
+                        </span>
+                        <UrgencyDots level={p.urgency} />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* We owe them */}
+              <div className="brief-block">
+                <div className="eb">
+                  We owe them <span className="sub">open commitments</span>
+                </div>
+                <div className="owed">
+                  {OWED.map((o, idx) => (
+                    <div key={idx} className={`owed-row ${o.state}`}>
+                      <span className="owed-glyph" aria-label={o.state} />
+                      <div className="owed-text">
+                        {o.text && <em>{o.text}</em>}
+                        {o.text && ' '}
+                        {o.tail}
+                      </div>
+                      <span className="owed-meta">{o.stateLabel}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* What's changed */}
+              <div className="brief-block">
+                <div className="eb">
+                  What&rsquo;s changed{' '}
+                  <span className="sub">contradictions flagged</span>
+                </div>
+                <div className="contra">
+                  <div className="contra-col left">
+                    <span className="contra-date">Apr 07</span>
+                    <span className="contra-quote">
+                      &ldquo;budget is fifty.&rdquo;
+                    </span>
+                    <span className="contra-who">
+                      Priya Shah &middot; call 02 &middot; 22:13
+                    </span>
+                  </div>
+                  <div className="contra-arrow">&rarr;</div>
+                  <div className="contra-col">
+                    <span className="contra-date">Apr 14</span>
+                    <span className="contra-quote">
+                      &ldquo;budget&rsquo;s tight, maybe twenty.&rdquo;
+                    </span>
+                    <span className="contra-who">
+                      Priya Shah &middot; call 03 &middot; 18:02
+                    </span>
+                  </div>
+                </div>
+                <div className="contra-obs">
+                  <span className="label">System note</span>
+                  Budget may have reset between Mar and Apr &middot; verify
+                  before the pricing memo lands.
+                </div>
+              </div>
+
+              {/* How we map */}
+              <div className="brief-block">
+                <div className="eb">
+                  How we map{' '}
+                  <span className="sub">
+                    pain &rarr; product, confidence-ranked
+                  </span>
+                </div>
+                <div className="mapping">
+                  {MAPPING.map((m) => (
+                    <div key={m.prod} className="mapping-row">
+                      <div className="mapping-prod">
+                        <em>{m.prod}</em>
+                        {m.tail && ` \u00B7 ${m.tail}`}
+                      </div>
+                      <ConfBar pct={m.conf} />
+                      <div className="mapping-conf">{m.conf.toFixed(2)}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Next */}
+              <div className="brief-block">
+                <div className="eb">
+                  Next <span className="sub">where to pick up</span>
+                </div>
+                <div className="next">
+                  <div className="next-row">
+                    <span className="next-key">Meeting</span>
+                    <span className="next-val">
+                      <em>Apr 25, 2:00 PM PT</em> &middot; 45 min &middot;
+                      Priya, Marcus, Howard
+                    </span>
+                  </div>
+                  <div className="next-row">
+                    <span className="next-key">Since last contact</span>
+                    <span className="next-val">8 days</span>
+                  </div>
+                  <div className="next-row">
+                    <span className="next-key">Call 03 ended on</span>
+                    <span className="next-val cliffhanger">
+                      &ldquo;walk us through pricing.&rdquo;
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </ScrollReveal>
+
+      {/* ─── Supporting surfaces 02 / 03 / 04 ─── */}
+      <ScrollReveal>
+        <section className="mem-supporting">
+          <div className="mem-support-head">
+            <span className="eb">
+              What else lives here <span className="sub">supporting surfaces</span>
+            </span>
+          </div>
+          <div className="mem-support-grid">
+            <article className="mem-support-card">
+              <div className="support-head">
+                <span className="idx">02</span>
+                <span className="support-chip">Design preview</span>
+              </div>
+              <h3>
+                <em>Pain &rarr; product</em> mapping
+              </h3>
+              <p className="support-desc">
+                Every extracted pain ranked against your catalog, confidence-scored.
+                Three upsells queued before the AE has ended the call.
+              </p>
+              <div className="support-mock pp-mock">
+                <div className="pp-row">
+                  <span className="pp-prod">Memory Layer</span>
+                  <ConfBar pct={0.92} />
+                  <span className="pp-conf">0.92</span>
+                </div>
+                <div className="pp-row">
+                  <span className="pp-prod">Contradiction Detection</span>
+                  <ConfBar pct={0.74} />
+                  <span className="pp-conf">0.74</span>
+                </div>
+                <div className="pp-row">
+                  <span className="pp-prod">Account Pattern Search</span>
+                  <ConfBar pct={0.61} />
+                  <span className="pp-conf">0.61</span>
+                </div>
+              </div>
+            </article>
+
+            <article className="mem-support-card">
+              <div className="support-head">
+                <span className="idx">03</span>
+                <span className="support-chip">Design preview</span>
+              </div>
+              <h3>
+                <em>Contradictions</em> flagged
+              </h3>
+              <p className="support-desc">
+                Call A: &ldquo;budget is fifty.&rdquo; Call B: &ldquo;budget&rsquo;s
+                tight.&rdquo; Salency flags it with both citations before the rep
+                re-pitches the wrong number.
+              </p>
+              <div className="support-mock cx-mock">
+                <div className="cx-row">
+                  <span className="cx-date">Apr 07</span>
+                  <span className="cx-quote">
+                    &ldquo;budget is fifty.&rdquo;
+                  </span>
+                </div>
+                <div className="cx-arrow">&darr;</div>
+                <div className="cx-row">
+                  <span className="cx-date">Apr 14</span>
+                  <span className="cx-quote">
+                    &ldquo;budget&rsquo;s tight, maybe twenty.&rdquo;
+                  </span>
+                </div>
+              </div>
+            </article>
+
+            <article className="mem-support-card">
+              <div className="support-head">
+                <span className="idx">04</span>
+                <span className="support-chip">Design preview</span>
+              </div>
+              <h3>
+                <em>Handoff export</em>
+              </h3>
+              <p className="support-desc">
+                One-click markdown. The new AE gets a brief. The CS director gets
+                a handoff. Nobody gets &ldquo;I wasn&rsquo;t in that call.&rdquo;
+              </p>
+              <div className="support-mock hx-mock">
+                <div className="hx-line"># Acme Corp — handoff</div>
+                <div className="hx-line muted">## Stakeholders</div>
+                <div className="hx-line">- Priya Shah, VP Sales (champion)</div>
+                <div className="hx-line">- Marcus Chen, Sales Ops (skeptic)</div>
+                <div className="hx-line muted">## Open commitments</div>
+                <div className="hx-line">- Pricing memo &middot; due Apr 26</div>
+                <div className="hx-line muted">## Watch-outs</div>
+                <div className="hx-line">- Budget reset flagged Apr 14</div>
+              </div>
+            </article>
+          </div>
+        </section>
+      </ScrollReveal>
+
+      {/* ─── CRM vs Salency ─── */}
+      <ScrollReveal>
+        <section className="mem-compare">
+          <div className="mem-compare-head">
+            <span className="eb">Not another CRM field</span>
+            <h2>
+              Memory is a <em>graph with time.</em> CRMs store flat rows.
+            </h2>
+          </div>
+          <table className="mem-table">
+            <thead>
+              <tr>
+                <th>Signal</th>
+                <th>In your CRM</th>
+                <th>In Salency</th>
+              </tr>
+            </thead>
+            <tbody>
+              {COMPARE_ROWS.map((row) => (
+                <tr key={row.signal}>
+                  <td>{row.signal}</td>
+                  <td>{row.crm}</td>
+                  <td>{row.salency}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <p className="mem-compare-foot">
+            Flatten the graph and you kill the thing.{' '}
+            <Link href="/investors#thesis">Read the full thesis &rarr;</Link>
+          </p>
+        </section>
+      </ScrollReveal>
+
+      {/* ─── Transcript sources ─── */}
+      <ScrollReveal>
+        <section className="mem-compat">
+          <span className="eb">Transcript sources</span>
+          <p className="mem-compat-line">
+            Bring transcripts from{' '}
+            <em>Gong, Fathom, Fireflies, Otter, Zoom</em>, or raw .vtt / .txt.
+            Paste or upload &mdash; takes about a minute per call.
+          </p>
+        </section>
+      </ScrollReveal>
+
+      {/* ─── Pilot CTA ─── */}
+      <ScrollReveal>
+        <section className="mem-cta">
+          <span className="eb">Pilot cohort &middot; Spring 2026</span>
+          <h2>
+            Inherit every account&rsquo;s <em>memory</em> from Day 1.
+          </h2>
+          <p className="sub">
+            We&rsquo;re onboarding a small group of revenue teams this cohort.
+            Tell us about your team and we&rsquo;ll scope the fit together.
+          </p>
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={() => openPilotModal()}
+          >
+            Request a pilot &rarr;
+          </button>
+        </section>
+      </ScrollReveal>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Replaces the `/memory` `ComingSoon` stub with a buyer-deep page that leads with the 6-block Day-1 brief as the featured surface — the single artifact that makes the "institutional memory" thesis physically visible — supported by 3 compact evidence cards, a CRM-vs-Salency comparison table, honesty-reframed transcript-sources line, and pilot CTA.

## Layout (per CEO + Design review)

```
Intro (eyebrow + H1 + lede)
Surface 01 — featured brief hero card (full 6 blocks)
What else lives here — 3 supporting cards (02 / 03 / 04, with mini mocks)
CRM vs Salency comparison table
Transcript sources line
Pilot CTA
```

Brief gets featured hero treatment because it IS the proof of the platform thesis. Compact grid treatment for 02/03/04 reads as supporting evidence, not equal-weight siblings.

## DESIGN.md alignment

Every rule checked:

- **§2 Typography:** all font-family use `var(--font-display)` / `var(--font-body)` (Instrument Sans) + `'Geist Mono'`. Zero Inter/Roboto/JetBrains drift.
- **§3 Color:** all ink via `var(--ink*)`, all accent via `var(--copper)` + `rgba(254, 133, 49, *)` alpha idioms. Zero off-brand peach. One narrow `rgba(209, 60, 19, *)` use on `.stance.blocker` (defensive CSS, matches §9 narrow-scope rust allowance).
- **§5 Eyebrow:** 10+ `.eb` instances, all canonical — 28×1 copper dash `::before`, `.18em` tracking, 11px, uppercase, copper. No invented variants.
- **§2 Italic accent rule:** every `em` inside display renders italic + copper.
- **§5 Hero card chrome:** featured brief frame uses 2px copper left gradient `::before` per `.thesis-card` / `.cta-card` pattern.
- **§6 Native nesting:** entire `.memory-page` block uses `&::before`, `&.modifier`, `&:hover` nested selectors.
- **§4 Standalone intro padding:** `.mem-intro` uses 120/40/48 matching `.coming-soon` / `.inv-intro` / `.pilot-app` canonical.

## Content locked to spec

All 6 blocks match the locked spec in `company-context.md §5 "Day-1 account brief — content spec (locked 2026-04-22)"`:

1. **People** — Priya Shah (VP Sales, Champion), Marcus Chen (Sales Ops, Skeptic)
2. **They need** — 3 cited pains with urgency dots (3/3, 2/3, 1/3)
3. **We owe them** — 4 commitment rows (2 open, 1 scheduled, 1 closed)
4. **What's changed** — Apr 07 "budget is fifty" → Apr 14 "budget's tight, maybe twenty" + system note
5. **How we map** — pain → product confidence-ranked (0.92 / 0.74 / 0.61)
6. **Next** — Apr 25 meeting, 8 days since contact, call 03 cliffhanger "walk us through pricing"

Supporting surfaces (02 / 03 / 04) each ship with condensed inline mocks:
- 02 — pain → product mini mock (3 ranked product rows with confidence bars)
- 03 — contradictions mini mock (two dated quotes with downward copper arrow)
- 04 — handoff export mini mock (monospace markdown preview)

All with "Design preview" chips — swap for real screenshots from cerebro-frontend when ready (tracked in Project-Cerebro/cerebro-frontend#274).

## Honesty fixes carried forward

- Transcript sources line reads "Bring transcripts from Gong, Fathom, Fireflies, Otter, Zoom, or raw .vtt / .txt" — user-action verbs, no integration claim, no logos per the `/memory` compat-strip discipline earlier this session.
- CTA opens existing `PilotModal` — consistent with site-wide pattern.

## Build / verification

- `npm run build` passes — `/memory` prerenders as static route
- `npm run lint` clean for this diff (pre-existing `ProblemCard.tsx` errors unchanged)
- `npx tsc --noEmit` clean

## Test plan (on Vercel preview)

- [ ] `/memory` intro: eyebrow "Memory · Built for revenue teams", H1 "Institutional memory, built." with italic copper "built."
- [ ] Featured brief card renders with 2px copper left gradient + "Design preview" chip top-right
- [ ] All 6 brief blocks visible: People, They need, We owe them, What's changed, How we map, Next
- [ ] Citations render in copper
- [ ] Urgency dots (3/3, 2/3, 1/3) render with correct on/off states
- [ ] Commitment rows show correct state glyphs (open = copper dot, scheduled = ring, closed = strikethrough)
- [ ] Contradiction card: Apr 07 left, copper arrow, Apr 14 right
- [ ] Confidence bars fill at 92% / 74% / 61%
- [ ] 3 supporting cards below render with Design preview chips + mini mocks
- [ ] CRM-vs-Salency table: 3 columns, "In Salency" header in copper
- [ ] "Read the full thesis →" links to `/investors#thesis`
- [ ] Transcript sources line has italic copper on tool names
- [ ] Pilot CTA opens `PilotModal`
- [ ] Mobile <960px: supporting grid collapses to 1-col
- [ ] Mobile <720px: brief internal grids (contradictions, mapping, next) collapse to 1-col
- [ ] `prefers-reduced-motion`: ScrollReveal entries bypassed, all content visible

## Out of scope (follow-ups)

- Real screenshots for surfaces 02 / 03 / 04 (gated on cerebro-frontend#274)
- Once cerebro-frontend brief ships: swap Surface 01 inline mock for real screenshot, drop "Design preview" chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)