### PR TITLE
design(investors): unify sections to 1280px spine + copper em

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -67,14 +67,15 @@ Geist Sans is loaded but effectively not used — `body` lists it after `--font-
 
 ### Italic accent rule
 
-Inside display text, `em` = italic color accent. Two forms:
+Inside display text **and body copy**, `em` = color accent. Two forms:
 
 ```css
 .hero .h1 em       { font-style: normal; font-weight: inherit; color: var(--copper); }
 .platform h2 em    { font-style: italic;  color: var(--copper); }
+.platform p em     { font-family: var(--font-display); font-style: italic; color: var(--copper); }
 ```
 
-Some heroes use `font-style: normal` for the accent (kept upright), others use italic. Either is acceptable — `em` always switches color to `--copper`, the italicness is per-context.
+Some heroes use `font-style: normal` for the accent (kept upright), others use italic. Either is acceptable — `em` always switches color to `--copper`, the italicness is per-context. Body-text `em` (paragraphs, bios, pullquotes) also resolves to `--copper`; never `--ink`. One-tier accent hierarchy across the page.
 
 ---
 
@@ -135,7 +136,7 @@ margin: 0 auto;
 padding: 0 40px;
 ```
 
-Wider sections (investor) use `max-width: 1100px` with the same padding. Legal pages use narrower.
+All investor-page sections (`.inv-intro`, `.platform`, `.roadmap`, `.team`, `.thesis`) share the canonical `1280px` container so every section lines up on one vertical spine. Legal pages use narrower.
 
 ### Section rhythm
 
@@ -308,7 +309,7 @@ When adding a new top-level section, use the thick banner. When adding a sub-sec
 
 ### Italic accent
 
-`em` inside a display heading changes color to `var(--copper)`. Italicness is per-context. Never introduce `<strong>` for color emphasis — that shift is reserved for `em`.
+`em` — anywhere, heading or body — changes color to `var(--copper)`. Italicness is per-context (display headings may use upright `em`). Never introduce `<strong>` for color emphasis — that shift is reserved for `em`.
 
 ### File path reference
 
@@ -355,3 +356,8 @@ When building a new marketing page:
 Known investor-specific deliberate choices (not drift):
 - Background `#0C0A10` (darker than home `--bg`) for the `.investors-register` band — scene break.
 - Founder photo gradients use `rgba(107,78,255,...)` (purple) and `rgba(0,181,160,...)` (teal) to differentiate founders. Exception to the "copper only" rule, narrow in scope (3 avatars only).
+
+### Follow-up pass (2026-04-23)
+
+- All five investor-page containers (`.inv-intro`, `.platform`, `.roadmap`, `.team`, `.thesis`) unified at `max-width:1280px` + `padding:0 40px`. Previously `.inv-intro` sat in a 1280px band while the four section blocks sat in 1100px, offsetting the content by ~90px per side at wide viewports. Single vertical spine restored.
+- Body-text `em` across the investors page (`.platform p`, `.founder .bio`, `.founder .fit p`, `.thesis-card p`) flipped from `color:var(--ink)` to `color:var(--copper)`. One-tier accent treatment page-wide. Display headings (`h1`, `h2`, `.primitive .title`, `.roadmap-card .body`, `.close`) were already copper — now body emphasis matches.

--- a/app/globals.css
+++ b/app/globals.css
@@ -1331,7 +1331,7 @@ html {
 
   /* Platform framing */
   .platform{
-    max-width:1100px;margin:0 auto;padding:0 40px;
+    max-width:1280px;margin:0 auto;padding:0 40px;
 
     .eb{
       font-family:'Geist Mono',monospace;font-size:11px;font-weight:500;
@@ -1350,7 +1350,7 @@ html {
       font-family:var(--font-body), 'Geist', sans-serif;font-weight:300;font-size:18px;
       color:var(--ink-2);max-width:62ch;margin:0 0 18px;
 
-      em{font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;color:var(--ink);font-size:19px;font-weight:400}
+      em{font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;color:var(--copper);font-size:19px;font-weight:400}
     }
     .primitive{
       margin-top:44px;padding:28px 32px;
@@ -1372,7 +1372,7 @@ html {
 
   /* V1.5 roadmap */
   .roadmap{
-    max-width:1100px;margin:80px auto 0;padding:0 40px;
+    max-width:1280px;margin:80px auto 0;padding:0 40px;
 
     .roadmap-card{
       padding:22px 28px;border:1px solid var(--hair-2);border-radius:10px;
@@ -1394,7 +1394,7 @@ html {
 
   /* Team */
   .team{
-    max-width:1100px;margin:100px auto 0;padding:0 40px;
+    max-width:1280px;margin:100px auto 0;padding:0 40px;
 
     .sect-head{
       margin-bottom:64px;display:grid;grid-template-columns:auto 1fr;gap:28px;align-items:baseline;
@@ -1444,7 +1444,7 @@ html {
       font-family:var(--font-body), 'Geist', sans-serif;font-weight:300;font-size:16px;line-height:1.75;
       color:var(--ink-2);max-width:62ch;margin:0 0 20px;
 
-      em{font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;color:var(--ink);font-size:17px;font-weight:400}
+      em{font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;color:var(--copper);font-size:17px;font-weight:400}
     }
     .fit{
       padding:14px 18px;border-left:2px solid rgba(254,133,49,.4);
@@ -1458,13 +1458,13 @@ html {
         font-family:var(--font-body), 'Geist', sans-serif;font-size:14.5px;line-height:1.55;color:var(--ink-2);
         font-weight:300;margin:0;max-width:62ch;
 
-        em{font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;color:var(--ink);font-weight:400}
+        em{font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;color:var(--copper);font-weight:400}
       }
     }
   }
 
   /* Future-fit thesis */
-  .thesis{max-width:1100px;margin:100px auto 0;padding:0 40px 20px}
+  .thesis{max-width:1280px;margin:100px auto 0;padding:0 40px 20px}
   .thesis-card{
     padding:56px 64px;background:rgba(255,255,255,.02);
     border:1px solid var(--hair-2);border-radius:16px;position:relative;overflow:hidden;
@@ -1490,7 +1490,7 @@ html {
       font-family:var(--font-body), 'Geist', sans-serif;font-weight:300;font-size:17px;
       color:var(--ink-2);max-width:64ch;margin:0 0 18px;
 
-      em{font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;color:var(--ink);font-size:18px;font-weight:400}
+      em{font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;color:var(--copper);font-size:18px;font-weight:400}
     }
     .close{
       margin-top:28px;padding-top:24px;border-top:1px solid var(--hair);


### PR DESCRIPTION
## Summary
- Widen `.platform`, `.roadmap`, `.team`, `.thesis` from `max-width:1100px` to `1280px` so all investors-page sections share the same vertical gutters as `.inv-intro` (previously misaligned by ~90px per side).
- Flip body-text `em` color from `--ink` to `--copper` in `.platform p`, `.founder .bio`, `.founder .fit p`, and `.thesis-card p` for consistent accent treatment across the page.

## Test plan
- [ ] Load `/investors` and confirm the left edge of the "For investors" eyebrow sits on the same vertical line as "Platform", the team `03.` heading, and the thesis card.
- [ ] Confirm the intro's border-bottom divider stops at the same x-coordinate as the section content beneath it.
- [ ] Confirm every italic `em` in body copy renders in copper (Viggle, Adaptavist Group, "actually trusts", "more accounts with less tribal knowledge", etc.).
- [ ] Spot-check mobile (375px) — sections should still stack cleanly with no horizontal overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)