### PR TITLE
refactor(apply): rename + full utility-soup cleanup on /pilot + /pricing

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -45,8 +45,8 @@ Both `--font-body` and `--font-display` currently resolve to **Instrument Sans**
 
 | Role | Font | Weight | Used on |
 |---|---|---|---|
-| Hero h1, section h2, card h3, editorial accents | `var(--font-display)` (Instrument Sans) | 400 normal, 400 italic for `em` | `.h1`, `.hero h1`, `.prob-head h2`, `.how-head h2`, `.notetaker-head h2`, `.platform h2`, `.thesis-card h2`, `.coming-soon h1`, `.pilot-app h1`/`h3`, `.inv-intro h1`, `.founder .name` |
-| Body, ledes, paragraph text, list items | `var(--font-body)` (Instrument Sans) | 300 for ledes, 400 for body | `.sub`, `.how-head .lede`, `.platform p`, `.inv-intro p`, `.pilot-lede`, `.founder .bio`, `.thesis-card p` |
+| Hero h1, section h2, card h3, editorial accents | `var(--font-display)` (Instrument Sans) | 400 normal, 400 italic for `em` | `.h1`, `.hero h1`, `.prob-head h2`, `.how-head h2`, `.notetaker-head h2`, `.platform h2`, `.thesis-card h2`, `.coming-soon h1`, `.apply-page h1`/`h3`, `.inv-intro h1`, `.founder .name` |
+| Body, ledes, paragraph text, list items | `var(--font-body)` (Instrument Sans) | 300 for ledes, 400 for body | `.sub`, `.how-head .lede`, `.platform p`, `.inv-intro p`, `.apply-lede`, `.founder .bio`, `.thesis-card p` |
 | Eyebrows, meta strips, labels, pill tags, footer legal | `'Geist Mono', monospace` | 400 or 500 | `.eb`, `.hero-meta`, `.inv-intro-meta`, `.founder .role`, `.roadmap-card .v`, `.sample-label`, `footer`, legal pages |
 | Brand wordmark (header logo) | `var(--font-outfit)` | 800 | `.brand .name`, `.nav-brand` |
 
@@ -151,7 +151,7 @@ Every marketing section that sits at the top of a standalone page (not home) use
 - `.prob` (the Problem section — shared with home as a mid-page spacer, with the same `80px` acting as section-to-section rhythm there)
 - `.coming-soon` (on `/memory`)
 - `.inv-intro` (on `/investors`)
-- `.pilot-app` (on `/pilot` and `/pricing`, applied via `max-w-[1280px] mx-auto mt-20 px-10 py-5` in `PilotApplication.tsx`)
+- `.apply-page` (on `/pilot` and `/pricing`, applied via `max-w-[1280px] mx-auto mt-20 px-10 py-5` in `PilotApplication.tsx`). Generic "apply-*" naming so classes aren't misleading on `/pricing`. Sidebar cards use `.apply-card` (`background:rgba(255,255,255,.05); border:1px solid rgba(255,255,255,.1); border-radius:.75rem; padding:1.5rem` → `2rem` at ≥768px).
 
 Home (`/`) hero uses the tighter `.hero` 96/40/72 variant because it has more above-the-fold content. Legal pages (`/privacy`, `/terms`) use `pt-32` (128px) via Tailwind since they're narrow-measure prose.
 
@@ -203,7 +203,7 @@ Shipped copies (all use the same 28×1 dash, copper, `.18em` tracking):
 - `.notetaker-head .eb` / `::before` — Notetaker comparison
 - `.platform .eb` / `::before` — Platform framing (investors)
 - `.coming-soon .eb` / `::before` — Pricing + Memory stubs
-- `.pilot-app .eb` / `::before` — Pilot + Pricing page intro
+- `.apply-page .eb` / `::before` — Pilot + Pricing page intro
 - `.inv-intro .eb` / `::before` — Investors intro
 - `.thesis-card .eb` / `::before` — Future-fit thesis
 
@@ -289,7 +289,7 @@ Hero cards (`.thesis-card`, `.cta-card`) add a 2px left gradient via `::before`:
 
 ### Native CSS nesting is the convention
 
-`globals.css` migrates flat selectors to native CSS nesting. Existing nested blocks: `.hub-wrap`, `.loading-screen`, `.btn-submit`, `.pilot-app`, `.coming-soon`, `.reg-inv`, `.platform`, `.roadmap`, `.team`, `.founder`, `.thesis-card`, `.investors-register`, `.inv-intro`, `header`, `footer`.
+`globals.css` migrates flat selectors to native CSS nesting. Existing nested blocks: `.hub-wrap`, `.loading-screen`, `.btn-submit`, `.apply-page`, `.coming-soon`, `.reg-inv`, `.platform`, `.roadmap`, `.team`, `.founder`, `.thesis-card`, `.investors-register`, `.inv-intro`, `header`, `footer`.
 
 When writing new CSS, nest descendants, `&::before`, `&::after`, `&:hover`, `&.modifier`, `&:disabled` inside the parent selector. Use blank lines between the parent's own rules and nested children for readability.
 
@@ -322,7 +322,7 @@ All selectors above live in a single file: `app/globals.css`. Section headers us
 1. **Off-brand peach `#F0A876`.** Previously used as a muted copper on the investor page. Purged 2026-04-23 in favor of the single `--copper` token.
 2. **`rgba(240,168,118,*)` gradients.** Same drift. Use `rgba(254,133,49,*)` for copper-at-alpha.
 3. **Hardcoded ink hexes** (`#E8E6E3`, `#B6B4B0`, `#7C7A77`, `#4E4C4A`). Use `var(--ink)` / `--ink-2` / `--ink-3` / `--ink-4`.
-4. **Tailwind `font-serif` / `font-mono` / `font-light` on marketing headings.** These resolve to generic `ui-serif`, `ui-monospace`, and system sans — not our loaded fonts. Use the CSS tokens via globals selectors (`.eb`, `.pilot-lede`, `h1` inside `.pilot-app`).
+4. **Tailwind `font-serif` / `font-mono` / `font-light` on marketing headings.** These resolve to generic `ui-serif`, `ui-monospace`, and system sans — not our loaded fonts. Use the CSS tokens via globals selectors (`.eb`, `.apply-lede`, `h1` inside `.apply-page`).
 5. **New eyebrow variants.** Always use `.eb` with the 28×1 copper dash. Don't invent `.kicker` / `.pilot-eb` / `.inv-eb` — they drift. `.kicker` and the `.reg-div` scene-break band that contained it were removed from `/investors` on 2026-04-23.
 6. **Inter / Roboto / system-ui as a primary font.** Never add those back as the first font family. Instrument Sans loads via `next/font` and is reliable.
 7. **Purple gradients, icon-in-circle feature grids, centered-everything hero, emoji as design, cookie-cutter section rhythm.** Standard AI-slop blacklist. Salency explicitly rejects these.
@@ -334,7 +334,7 @@ All selectors above live in a single file: `app/globals.css`. Section headers us
 When building a new marketing page:
 
 1. Root wrapper: `<div className="page"><MarketingHeader />...<SiteFooter /></div>`.
-2. For editorial intro (hero-like section), use or mirror `.inv-intro` / `.coming-soon` / `.pilot-app` — a scoped block with nested `.eb`, `h1`, lede `p`.
+2. For editorial intro (hero-like section), use or mirror `.inv-intro` / `.coming-soon` / `.apply-page` — a scoped block with nested `.eb`, `h1`, lede `p`.
 3. For structured sections below, use the `.prob-head` / `.how-head` / `.platform` patterns — `.eb` + `h2` + supporting copy.
 4. CTAs: `.btn .btn-primary` for primary, `.btn .btn-ghost` for secondary. Form submits: `.btn-submit`.
 5. Colors: only `var(--copper)` for accents, `var(--ink)` scale for text, `var(--hair)` / `--hair-2` for dividers.
@@ -350,7 +350,7 @@ When building a new marketing page:
 - Every eyebrow (`.inv-intro .eb`, `.platform .eb`, `.thesis-card .eb`) uses the 28×1 copper dash `::before` with `.18em` tracking.
 - Every investor-block selector is native-nested CSS.
 - The `.reg-div` 96px scene-break band at the top of the section was removed — it held only a single `.kicker` span that wasn't earning its weight. `.reg-div`, `.kicker`, `.wrap`, and `.inv-footer` CSS blocks all dropped as dead code.
-- `.inv-intro` padding normalized to `120px 40px 96px` to match `.coming-soon` and `.pilot-app` — the standalone intro canonical.
+- `.inv-intro` padding normalized to `120px 40px 96px` to match `.coming-soon` and `.apply-page` — the standalone intro canonical.
 - Chrome: `/investors` renders `<MarketingHeader />` and `<SiteFooter />`, same as every other marketing + legal page.
 
 Known investor-specific deliberate choices (not drift):

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -151,7 +151,7 @@ Every marketing section that sits at the top of a standalone page (not home) use
 - `.prob` (the Problem section — shared with home as a mid-page spacer, with the same `80px` acting as section-to-section rhythm there)
 - `.coming-soon` (on `/memory`)
 - `.inv-intro` (on `/investors`)
-- `.apply-page` (on `/pilot` and `/pricing`, applied via `max-w-[1280px] mx-auto mt-20 px-10 py-5` in `PilotApplication.tsx`). Generic "apply-*" naming so classes aren't misleading on `/pricing`. Sidebar cards use `.apply-card` (`background:rgba(255,255,255,.05); border:1px solid rgba(255,255,255,.1); border-radius:.75rem; padding:1.5rem` → `2rem` at ≥768px).
+- `.apply-page` (on `/pilot` and `/pricing`). Fully CSS-driven — no Tailwind utilities in the JSX. Layout, typography, grid, responsive breakpoints all nested under `.apply-page` in globals. Sub-classes: `.apply-intro` (intro section), `.apply-lede` (lede paragraph), `.apply-layout` (two-column grid), `.apply-sidebar` (vertical stack of cards), `.apply-form` (email form column), `.apply-card` (shared card panel), `.apply-check` and `.apply-dot` (list-item markers).
 
 Home (`/`) hero uses the tighter `.hero` 96/40/72 variant because it has more above-the-fold content. Legal pages (`/privacy`, `/terms`) use `pt-32` (128px) via Tailwind since they're narrow-measure prose.
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -660,13 +660,18 @@ html {
 
   /* Application/intake page — shared by /pilot and /pricing.
      Generic "apply-*" naming so the classes aren't misleading when
-     viewed through the pricing-page lens. */
+     viewed through the pricing-page lens. All layout/typography lives
+     here so the JSX is semantic (no Tailwind utility soup). */
   .apply-page{
+    max-width:1280px;margin:80px auto 0;padding:20px 40px;
+
+    .apply-intro{max-width:48rem;margin-bottom:64px}
+
     .eb{
       font-family:'Geist Mono','SFMono-Regular',Consolas,monospace;
       font-size:11px;font-weight:500;letter-spacing:.18em;
       text-transform:uppercase;color:var(--copper);
-      display:inline-flex;align-items:center;gap:10px;
+      display:inline-flex;align-items:center;gap:10px;margin-bottom:20px;
 
       &::before{
         content:"";width:28px;height:1px;background:var(--copper);display:inline-block;
@@ -675,32 +680,65 @@ html {
     h1{
       font-family:var(--font-display), 'Instrument Serif', serif;
       font-weight:400;line-height:1.04;letter-spacing:-.025em;
-      color:var(--ink);
+      color:var(--ink);font-size:3rem;margin:0 0 24px;text-wrap:balance;
 
       em{font-style:italic;color:var(--copper)}
     }
     .apply-lede{
       font-family:var(--font-body), 'Geist', sans-serif;
       font-weight:300;line-height:1.55;color:var(--ink-2);
+      font-size:1.125rem;max-width:52ch;margin:0;
     }
-    h3{
-      font-family:var(--font-display), 'Instrument Serif', serif;
-      font-weight:400;line-height:1.2;color:var(--ink);
+
+    /* Two-column layout: sidebar cards + email form.
+       Form is visually first on narrow viewports, moves right on ≥1024px. */
+    .apply-layout{
+      display:grid;grid-template-columns:1fr;gap:48px;align-items:start;
     }
-    li{
-      font-family:var(--font-body), 'Geist', sans-serif;
-      line-height:1.55;color:var(--ink-2);
+    .apply-sidebar{
+      display:flex;flex-direction:column;gap:24px;order:2;
     }
+    .apply-form{order:1}
+
     /* Sidebar cards ("Pilot includes", "Good fit if") — identical
        styling, shared class so they stay in sync. */
     .apply-card{
       background:rgba(255,255,255,.05);
       border:1px solid rgba(255,255,255,.1);
-      border-radius:.75rem;
-      padding:1.5rem;
+      border-radius:.75rem;padding:1.5rem;
+
+      h3{
+        font-family:var(--font-display), 'Instrument Serif', serif;
+        font-weight:400;line-height:1.2;color:var(--ink);
+        font-size:1.25rem;margin:0 0 16px;
+      }
+      ul{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:12px}
+      li{
+        font-family:var(--font-body), 'Geist', sans-serif;
+        line-height:1.55;color:var(--ink-2);
+        font-size:.875rem;display:flex;align-items:flex-start;gap:12px;
+      }
     }
-    @media (min-width: 768px){
+    /* Bullet markers for the two list styles. */
+    .apply-check{color:var(--copper);margin-top:2px;flex-shrink:0}
+    .apply-dot{
+      width:6px;height:6px;border-radius:9999px;background:var(--copper);
+      margin-top:9px;flex-shrink:0;
+    }
+  }
+  @media (min-width: 768px){
+    .apply-page{
+      .apply-intro{margin-bottom:80px}
+      h1{font-size:3.75rem}
+      .apply-lede{font-size:1.25rem}
       .apply-card{padding:2rem}
+    }
+  }
+  @media (min-width: 1024px){
+    .apply-page{
+      .apply-layout{grid-template-columns:1fr 1.2fr;gap:64px}
+      .apply-sidebar{order:1}
+      .apply-form{order:2}
     }
   }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -658,7 +658,10 @@ html {
     &:disabled:hover{filter:none}
   }
 
-  .pilot-app{
+  /* Application/intake page — shared by /pilot and /pricing.
+     Generic "apply-*" naming so the classes aren't misleading when
+     viewed through the pricing-page lens. */
+  .apply-page{
     .eb{
       font-family:'Geist Mono','SFMono-Regular',Consolas,monospace;
       font-size:11px;font-weight:500;letter-spacing:.18em;
@@ -676,7 +679,7 @@ html {
 
       em{font-style:italic;color:var(--copper)}
     }
-    .pilot-lede{
+    .apply-lede{
       font-family:var(--font-body), 'Geist', sans-serif;
       font-weight:300;line-height:1.55;color:var(--ink-2);
     }
@@ -687,6 +690,17 @@ html {
     li{
       font-family:var(--font-body), 'Geist', sans-serif;
       line-height:1.55;color:var(--ink-2);
+    }
+    /* Sidebar cards ("Pilot includes", "Good fit if") — identical
+       styling, shared class so they stay in sync. */
+    .apply-card{
+      background:rgba(255,255,255,.05);
+      border:1px solid rgba(255,255,255,.1);
+      border-radius:.75rem;
+      padding:1.5rem;
+    }
+    @media (min-width: 768px){
+      .apply-card{padding:2rem}
     }
   }
 

--- a/components/sections/PilotApplication.tsx
+++ b/components/sections/PilotApplication.tsx
@@ -1,59 +1,72 @@
 import { EmailForm } from '@/components/EmailForm';
 
-const PILOT_INCLUDES = [
-  '60 days of free access',
-  'Weekly extraction reports on your calls',
-  '30-minute weekly debrief with our team',
-  '1–2 week setup, no obligation to continue',
+type MarkerKind = 'check' | 'dot';
+
+const APPLY_CARDS: Array<{ title: string; marker: MarkerKind; items: string[] }> = [
+  {
+    title: 'Pilot includes',
+    marker: 'check',
+    items: [
+      '60 days of free access',
+      'Weekly extraction reports on your calls',
+      '30-minute weekly debrief with our team',
+      '1–2 week setup, no obligation to continue',
+    ],
+  },
+  {
+    title: 'Good fit if',
+    marker: 'dot',
+    items: [
+      '5–50 reps on your revenue team',
+      'Already using a notetaker (Gong, Fathom, Fireflies) or raw transcripts',
+      'Reps inheriting accounts, deals, or customers',
+    ],
+  },
 ];
 
-const IDEAL = [
-  '5–50 reps on your revenue team',
-  'Already using a notetaker (Gong, Fathom, Fireflies) or raw transcripts',
-  'Reps inheriting accounts, deals, or customers',
-];
+function Marker({ kind }: { kind: MarkerKind }) {
+  if (kind === 'check') {
+    return (
+      <span className="apply-check" aria-hidden>
+        ✓
+      </span>
+    );
+  }
+  return <span className="apply-dot" aria-hidden />;
+}
 
 export function PilotApplication() {
   return (
-    <main className="apply-page max-w-[1280px] mx-auto mt-20 px-10 py-5">
-      <section className="mb-16 md:mb-20 max-w-3xl">
-        <p className="eb mb-5">Pilot cohort · Spring 2026</p>
-        <h1 className="text-5xl md:text-6xl mb-6 text-balance">
+    <main className="apply-page">
+      <section className="apply-intro">
+        <p className="eb">Pilot cohort · Spring 2026</p>
+        <h1>
           Join the <em>pilot.</em>
         </h1>
-        <p className="apply-lede text-lg md:text-xl max-w-[52ch]">
+        <p className="apply-lede">
           A memory layer that outlasts any rep. We&apos;re opening early access to a
           small group of revenue teams this cohort. Tell us about your team and
           we&apos;ll scope the fit together.
         </p>
       </section>
 
-      <section className="grid grid-cols-1 lg:grid-cols-[1fr_1.2fr] gap-12 lg:gap-16 items-start">
-        <div className="space-y-6 order-2 lg:order-1">
-          <div className="apply-card">
-            <h3 className="text-xl mb-4">Pilot includes</h3>
-            <ul className="space-y-3">
-              {PILOT_INCLUDES.map((item) => (
-                <li key={item} className="flex items-start gap-3 text-sm">
-                  <span className="text-accent-warm mt-[2px] shrink-0">✓</span>
-                  <span>{item}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div className="apply-card">
-            <h3 className="text-xl mb-4">Good fit if</h3>
-            <ul className="space-y-3">
-              {IDEAL.map((item) => (
-                <li key={item} className="flex items-start gap-3 text-sm">
-                  <span className="w-1.5 h-1.5 rounded-full bg-accent-warm mt-[9px] shrink-0" />
-                  <span>{item}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
+      <section className="apply-layout">
+        <div className="apply-sidebar">
+          {APPLY_CARDS.map((card) => (
+            <div key={card.title} className="apply-card">
+              <h3>{card.title}</h3>
+              <ul>
+                {card.items.map((item) => (
+                  <li key={item}>
+                    <Marker kind={card.marker} />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
         </div>
-        <div className="order-1 lg:order-2">
+        <div className="apply-form">
           <EmailForm />
         </div>
       </section>

--- a/components/sections/PilotApplication.tsx
+++ b/components/sections/PilotApplication.tsx
@@ -15,13 +15,13 @@ const IDEAL = [
 
 export function PilotApplication() {
   return (
-    <main className="pilot-app max-w-[1280px] mx-auto mt-20 px-10 py-5">
+    <main className="apply-page max-w-[1280px] mx-auto mt-20 px-10 py-5">
       <section className="mb-16 md:mb-20 max-w-3xl">
         <p className="eb mb-5">Pilot cohort · Spring 2026</p>
         <h1 className="text-5xl md:text-6xl mb-6 text-balance">
           Join the <em>pilot.</em>
         </h1>
-        <p className="pilot-lede text-lg md:text-xl max-w-[52ch]">
+        <p className="apply-lede text-lg md:text-xl max-w-[52ch]">
           A memory layer that outlasts any rep. We&apos;re opening early access to a
           small group of revenue teams this cohort. Tell us about your team and
           we&apos;ll scope the fit together.
@@ -30,7 +30,7 @@ export function PilotApplication() {
 
       <section className="grid grid-cols-1 lg:grid-cols-[1fr_1.2fr] gap-12 lg:gap-16 items-start">
         <div className="space-y-6 order-2 lg:order-1">
-          <div className="bg-white/5 border border-white/10 rounded-xl p-6 md:p-8">
+          <div className="apply-card">
             <h3 className="text-xl mb-4">Pilot includes</h3>
             <ul className="space-y-3">
               {PILOT_INCLUDES.map((item) => (
@@ -41,7 +41,7 @@ export function PilotApplication() {
               ))}
             </ul>
           </div>
-          <div className="bg-white/5 border border-white/10 rounded-xl p-6 md:p-8">
+          <div className="apply-card">
             <h3 className="text-xl mb-4">Good fit if</h3>
             <ul className="space-y-3">
               {IDEAL.map((item) => (


### PR DESCRIPTION
**Successor to PR #58**, which auto-closed when its base branch was deleted on #57's merge. Rebased cleanly onto current `main` (which includes #53's memory-page work and #57's copper tokens), so no changes from either get overwritten.

## Why

`<PilotApplication />` renders on BOTH `/pilot` and `/pricing`. Two problems:

1. Its root CSS class was `.pilot-app` and its lede was `.pilot-lede` — names that mislead anyone reading the pricing page.
2. The JSX was a soup of Tailwind utilities with zero semantic structure: `className="pilot-app max-w-[1280px] mx-auto mt-20 px-10 py-5"`, `className="grid grid-cols-1 lg:grid-cols-[1fr_1.2fr] gap-12 lg:gap-16 items-start"`, `className="bg-white/5 border border-white/10 rounded-xl p-6 md:p-8"`. You couldn't tell what anything WAS by reading the JSX.

## Commits

### `d23dfb5` — rename + extract .apply-card
- `.pilot-app` → `.apply-page` (CSS, JSX, DESIGN.md)
- `.pilot-lede` → `.apply-lede`
- Two inline `bg-white/5 border border-white/10 rounded-xl p-6 md:p-8` card blobs (identical, used 2×) collapsed to `.apply-card`.

### `1bd2888` — move all layout into CSS + data-driven cards
- Every Tailwind utility from the root, layout, sidebar, form, card, list, and marker elements moved into `globals.css` under scoped `.apply-*` classes.
- JSX now has zero utility classes. Every className is a semantic `.apply-*` name.
- The two hand-coded card JSX blocks (~40 lines, duplicate scaffolding with only title + items + marker kind varying) collapsed to `APPLY_CARDS.map()` + a local `<Marker kind>` component.
- Responsive breakpoints preserved exactly at 768px (typography scale-up + card padding) and 1024px (grid switches to 2-col, sidebar/form re-order).

## New semantic classes

| Class | Purpose |
|---|---|
| `.apply-page` | Page root — max-width, margin-top, padding |
| `.apply-intro` | Intro section — max-width + bottom margin |
| `.apply-lede` | Lede paragraph — font, size, max-w, color |
| `.apply-layout` | Two-column grid (sidebar + form) |
| `.apply-sidebar` | Vertical stack of cards, reorders on ≥1024px |
| `.apply-form` | Email form column, reorders on ≥1024px |
| `.apply-card` | Shared card panel (used 2×). Nested `h3`, `ul`, `li` styling. |
| `.apply-check` | Copper checkmark list marker |
| `.apply-dot` | Copper bullet dot list marker |

All nested under `.apply-page` via CSS nesting, so the cascade is bounded to the page context.

## Sizing parity with previous Tailwind values

| Tailwind (was) | CSS (is) |
|---|---|
| `max-w-[1280px]` | `max-width: 1280px` |
| `mt-20` | `margin-top: 80px` |
| `px-10 py-5` | `padding: 20px 40px` |
| `mb-16` / `md:mb-20` | `margin-bottom: 64px` → `80px` at ≥768px |
| `max-w-3xl` | `max-width: 48rem` |
| `text-5xl` / `md:text-6xl` | `font-size: 3rem` → `3.75rem` at ≥768px |
| `text-lg` / `md:text-xl` | `font-size: 1.125rem` → `1.25rem` at ≥768px |
| `max-w-[52ch]` | `max-width: 52ch` |
| `grid grid-cols-1 lg:grid-cols-[1fr_1.2fr]` | `grid-template-columns: 1fr` → `1fr 1.2fr` at ≥1024px |
| `gap-12 lg:gap-16` | `gap: 48px` → `64px` at ≥1024px |
| `space-y-6` | `gap: 24px` on flex column |
| `order-2 lg:order-1` / `order-1 lg:order-2` | `order: 2` / `1` at base, swapped at ≥1024px |
| `bg-white/5 border border-white/10 rounded-xl` | inline rgba equivalents + `border-radius: .75rem` |
| `p-6 md:p-8` | `padding: 1.5rem` → `2rem` at ≥768px |
| `text-xl mb-4` (h3) | `font-size: 1.25rem; margin: 0 0 16px` |
| `space-y-3` (ul) | `gap: 12px` on flex column |
| `flex items-start gap-3 text-sm` (li) | `display: flex; align-items: flex-start; gap: 12px; font-size: .875rem` |
| `text-accent-warm mt-[2px] shrink-0` | `.apply-check { color: var(--copper); margin-top: 2px; flex-shrink: 0 }` |
| `w-1.5 h-1.5 rounded-full bg-accent-warm mt-[9px] shrink-0` | `.apply-dot { width: 6px; height: 6px; border-radius: 9999px; background: var(--copper); margin-top: 9px; flex-shrink: 0 }` |

## Files

| File | Change |
|---|---|
| `app/globals.css` | `.apply-page` block rewritten — now owns all layout + responsive rules. +62 −10 net. |
| `components/sections/PilotApplication.tsx` | Data-driven cards, semantic classes, zero utilities. +50 −43. |
| `DESIGN.md` | Updated `.apply-page` entry in §4 to note "fully CSS-driven — no Tailwind utilities in the JSX" and list every sub-class. |

Post-rebase stat: `3 files changed, 123 insertions(+), 58 deletions(-)` — confirms ZERO overlap with #53's memory-page work or other live main content.

## Test plan
- [ ] `npm run build` clean (verified locally post-rebase — 14 routes compile).
- [ ] Vercel preview: `/pilot` renders identically to main.
- [ ] Vercel preview: `/pricing` renders identically to main.
- [ ] Sidebar cards at mobile: single column, stacked. At ≥1024px: cards on left, form on right.
- [ ] Keyboard focus on the email form still works.

## Out of scope
- Pricing-specific copy (h1 still says "Join the pilot" on `/pricing` — separate concern, flagged in #56).
- The broader naming rename pass for `.fit`, `.close`, `.rev`, `.p2`, `.p3`, `.num` (Chunk D in #56).
- `.eb` and `em` consolidation across the rest of the codebase (Chunk B in #56).

Tracked in #56. Replaces closed PR #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)