### PR TITLE
feat(investors): add §moat section between #platform and #roadmap

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1331,6 +1331,47 @@ html {
     }
   }
 
+  /* Moat framing — why the data lives on Salency, not Salesforce (§6 platform-native posture, §8 uncopyable pair) */
+  .moat{
+    max-width:1280px;margin:80px auto 0;padding:0 40px;
+
+    .eb{
+      font-family:'Geist Mono',monospace;font-size:11px;font-weight:500;
+      letter-spacing:.18em;text-transform:uppercase;color:var(--copper);
+      margin-bottom:28px;display:flex;align-items:center;gap:10px;
+
+      &::before{content:"";width:28px;height:1px;background:var(--copper);display:inline-block}
+    }
+    h2{
+      font-size:clamp(38px,4.2vw,54px);line-height:1.1;color:var(--ink);
+      margin:0 0 28px;max-width:28ch;text-wrap:balance;
+
+      em{font-style:italic;color:var(--copper)}
+    }
+    p{
+      font-family:var(--font-body), 'Geist', sans-serif;font-weight:300;font-size:18px;
+      color:var(--ink-2);max-width:62ch;margin:0 0 18px;
+
+      em{font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;color:var(--copper);font-size:19px;font-weight:400}
+    }
+    .primitive{
+      margin-top:44px;padding:28px 32px;
+      background:rgba(254,133,49,.05);border:1px solid var(--copper-a18);
+      border-radius:12px;display:grid;grid-template-columns:auto 1fr;gap:28px;align-items:center;
+
+      .label{
+        font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
+        letter-spacing:.18em;text-transform:uppercase;color:var(--copper);
+      }
+      .title{
+        font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;font-size:22px;
+        line-height:1.35;color:var(--ink);max-width:62ch;margin:0;
+
+        em{font-style:italic;color:var(--copper)}
+      }
+    }
+  }
+
   /* V1.5 roadmap */
   .roadmap{
     max-width:1280px;margin:80px auto 0;padding:0 40px;

--- a/components/sections/InvestorsSection.tsx
+++ b/components/sections/InvestorsSection.tsx
@@ -55,6 +55,40 @@ export function InvestorsSection() {
             </div>
           </section>
 
+          <section className="moat" id="moat">
+            <div className="eb">Moat</div>
+            <h2>
+              Why this doesn&apos;t live in <em>Salesforce.</em>
+            </h2>
+            <p>
+              The wedge is the <em>shape of the data</em>. Contradiction pairs,
+              pain evolution over time, confidence-ranked pain → product
+              matches, cross-account pattern graphs. None of these fit a CRM
+              row. Flatten any of them into a field and you kill the thing
+              that makes Salency uncopyable.
+            </p>
+            <p>
+              So Salency sits <em>on top</em> of your stack, not inside it.
+              Linear syncs completion status to GitHub, keeps the ticket
+              experience in Linear. Superhuman reads your Gmail, keeps the
+              triage experience in Superhuman. Reps live in CRM for pipeline
+              stages. Reps live in Salency for the qualitative layer — what
+              the customer actually said, what contradicts what, which pains
+              map to which products.
+            </p>
+            <div className="primitive">
+              <span className="label">The uncopyable pair</span>
+              <p className="title">
+                Pain-product mapping plus contradiction detection, embedded in
+                product-management workflows.{' '}
+                <em>
+                  Either alone is defensible for 6 to 9 months. Together, with
+                  workflow depth, switching cost is measured in quarters.
+                </em>
+              </p>
+            </div>
+          </section>
+
           <section className="roadmap">
             <div className="roadmap-card">
               <span className="pill">On the roadmap</span>


### PR DESCRIPTION
## Summary

Adds a new **§moat** section to `/investors` between `#platform` and `#roadmap` answering the #1 investor objection: *"why can't Gong / Salesforce just add this?"* Lifted from the (now-closed) PR #47 work.

## What's new

- **Eyebrow:** \`Moat\`
- **H2:** "Why this doesn't live in *Salesforce*."
- **Body p1** — \`The wedge is the *shape of the data*.\` Names the four uncopyable structures: contradiction pairs, pain evolution over time, confidence-ranked pain → product matches, cross-account pattern graphs. Closes with "flatten any of them and you kill the thing."
- **Body p2** — Linear/Superhuman "layer on top" analogy. Reps live in CRM for pipeline stages; reps live in Salency for the qualitative layer.
- **Primitive callout block** — "The uncopyable pair": *Either alone is defensible for 6 to 9 months. Together, with workflow depth, switching cost is measured in quarters.* (§8 uncopyable pair, verbatim to the locked company-context §8 language.)

## Why it matters for YC

Current `/investors` leaves a gap between the platform thesis and the team bios. A YC partner or angel reads \`#platform\` → "great, so you'll get eaten by Salesforce when they wake up" → no rebuttal until \`#thesis\` at the very end. §moat closes that gap with the exact language Howard would use on a call.

Lifted content is sourced from locked company-context.md sections:
- §6 platform-native posture (why CRM is complementary, not destination)
- §8 the specific uncopyable thing (pain-product + contradictions pair)

## Design system alignment

- \`.moat\` CSS mirrors \`.platform\` 1:1 via native CSS nesting (DESIGN.md §6)
- Uses current class conventions: \`.label\` and \`.title\` (post b4ea8a8 rename sweep)
- Eyebrow canonical: \`11px / .18em / 28×1 copper dash ::before\` (§5)
- \`margin-top: 80px\` for section rhythm below \`.platform\`
- Copper accents via \`var(--copper)\` and \`var(--copper-a18)\`; zero new hexes
- \`em\` → copper italic rule applied throughout (§2)

## Test plan

- [ ] Preview URL: navigate to \`/investors#moat\` — section renders between \`#platform\` and \`#roadmap\`
- [ ] Eyebrow \`Moat\` shows 28×1 copper dash + \`.18em\` tracking uppercase
- [ ] H2 italic \`Salesforce.\` renders in copper
- [ ] Two \`p\` blocks render with \`em\` accents (shape of the data, on top) in copper italic
- [ ] \`.primitive\` callout — label \`The uncopyable pair\` in mono copper, title in serif with trailing italic copper paragraph
- [ ] Nothing else on \`/investors\` moved or reflowed
- [ ] Home page \`/\`, \`/memory\`, \`/pilot\`, \`/pricing\`, \`/why-salency\` unaffected (no global CSS changes)
- [ ] Mobile under 720px: text reflows naturally (matches \`.platform\` responsive behavior — inherits from parent \`.investors-register\`)

## Out of scope

- No changes to `.platform`, `.roadmap`, `.team`, `.thesis` content or styling
- No changes to DESIGN.md (new section uses patterns already documented in §2–§6)
- No changes to home page or other marketing routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)