### PR TITLE
content(memory): cross-link /memory bridge to /investors#moat

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2143,6 +2143,16 @@ header button:focus:not(:focus-visible){
       letter-spacing: .12em;
       text-transform: uppercase;
       line-height: 1.55;
+
+      .bridge-link {
+        color: var(--copper);
+        text-decoration: none;
+        border-bottom: 1px solid var(--copper-a18);
+        transition: border-color .18s;
+        white-space: nowrap;
+
+        &:hover { border-bottom-color: var(--copper); }
+      }
     }
   }
 

--- a/components/sections/MemorySection.tsx
+++ b/components/sections/MemorySection.tsx
@@ -190,7 +190,10 @@ export function MemorySection() {
             </span>
             <span className="bridge-also">
               Also in the brief: commitments &middot; contradictions &middot;
-              pain &rarr; product &middot; cliffhanger
+              pain &rarr; product &middot; cliffhanger.{' '}
+              <Link href="/investors#moat" className="bridge-link">
+                Why not Salesforce &rarr;
+              </Link>
             </span>
           </div>
         </section>


### PR DESCRIPTION
## Summary

Adds one outbound link to the `/memory` hero bridge strip so readers of Surface 01 have an obvious next stop for "why does this matter strategically." Points at the §moat section added to \`/investors\` via PR #60.

## Change

**Before:**
```
This is what the rep opens Monday at 1:45pm.
Also in the brief: commitments · contradictions · pain → product · cliffhanger
```

**After:**
```
This is what the rep opens Monday at 1:45pm.
Also in the brief: commitments · contradictions · pain → product · cliffhanger.
Why not Salesforce →
```

Where \`Why not Salesforce →\` is an inline link to \`/investors#moat\`.

## Why this copy

Direct mirror of the §moat section's H2 on \`/investors\` ("Why this doesn't live in *Salesforce*."). Short, names the destination concept, no hedging. Same voice pattern as the existing \`/investors#thesis\` link on the \`/memory\` compare-foot.

## CSS

New \`.bridge-link\` class nested inside \`.bridge-also\` per DESIGN.md §6 native nesting:
- Copper text via \`var(--copper)\`
- \`var(--copper-a18)\` subtle bottom border, intensifies to solid copper on hover
- \`white-space: nowrap\` so the arrow stays attached to the label through line wrap

Mirrors the same pattern as \`.mem-compare-foot a\` (the "Read the full thesis →" link further down /memory).

## PR #60 dependency

If PR #60 (§moat section on /investors) hasn't merged yet, the link still navigates to /investors cleanly — the \`#moat\` anchor is a no-op until the section exists. Graceful degradation. Once #60 merges, the anchor scrolls to the moat block as intended.

## Test plan

- [ ] Preview URL: /memory hero bridge renders with "Why not Salesforce →" inline after "cliffhanger."
- [ ] Link color = copper, subtle border-bottom, hover strengthens border
- [ ] Click navigates to /investors (and once PR #60 lands, scrolls to §moat)
- [ ] Mobile <720px: bridge stacks vertically per existing rule; link stays on its own line if wrapped
- [ ] No other /memory content moved

## Out of scope

- Same-page anchor scroll to Surface 02/03 (that was Option B — not shipped; we chose A)
- Anchor offsets for sticky-header positioning
- Surface 02/03 id attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)