### PR TITLE
fix(css): scroll-padding-top for hash-anchor jumps

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -163,6 +163,7 @@ h6 {
 
 html {
   scroll-behavior: smooth;
+  scroll-padding-top: 100px; /* sticky header (~76px) + breathing room for hash-anchor jumps */
   color-scheme: dark;
 }
 


### PR DESCRIPTION
## Summary

One-line fix for the awkward anchor scroll you caught on \`/investors#moat\` after merging PR #62. Applies site-wide.

## The bug

Clicking "Why not Salesforce →" on \`/memory\` navigated to \`/investors#moat\` correctly, but the browser scrolled the target section flush to viewport top — directly **underneath** the sticky \`<MarketingHeader />\`. The "Moat" eyebrow + H2 were either cut off or visually crowded against the header's bottom edge.

## Root cause

\`html\` had \`scroll-behavior: smooth\` but no \`scroll-padding-top\`. Browsers use the viewport's *actual* top edge as the scroll landing point. With a sticky header ~76px tall (brand 44px + 32px padding), every hash-anchor target lands hidden behind the header by that much.

## The fix

```css
html {
  scroll-behavior: smooth;
  scroll-padding-top: 100px; /* sticky header (~76px) + breathing room */
  color-scheme: dark;
}
```

100px = 76px header + ~24px breathing room so the section heading has visual margin above it (editorial rhythm, not flush).

## Blast radius

Fixes **every** existing and future hash-anchor site-wide. No per-section \`scroll-margin-top\` rules needed. Current beneficiaries:
- \`/investors#moat\` (the reported one)
- \`/investors#thesis\` (linked from /memory compare-foot + home page CTA ghost button)
- \`/investors#platform\`, \`/investors#team\` (ids exist, not currently linked but now clean if someone deep-links)
- Any future anchor we add

No JS. Native CSS property — good browser support (Chrome 69+, Firefox 68+, Safari 15+).

## Test plan

- [ ] Preview URL: click "Why not Salesforce →" from \`/memory\` — lands on \`/investors#moat\` with the **Moat** eyebrow ~24px below the sticky header, not crowded underneath it
- [ ] Click "Read the full thesis →" from \`/memory\` compare-foot — same for \`/investors#thesis\`
- [ ] Click "Read our thesis" ghost button on home hero — same for \`/investors#thesis\`
- [ ] Manually navigate to \`/investors#platform\`, \`/investors#team\` — each lands with header-clearing breathing room

## Out of scope

- Adjusting individual section top paddings (100px global works; sections don't need per-section overrides)
- Offsetting for a taller header breakpoint on mobile (current MarketingHeader height is stable across viewports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)