### PR TITLE
design(spacing): tighten first-section top margin 80px → 40px

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -168,14 +168,15 @@ All investor-page sections (`.inv-intro`, `.platform`, `.roadmap`, `.team`, `.th
 - First section on a page: `padding: 48–96px top`.
 - Last section before footer: `padding-bottom: 96–120px`.
 
-### Standalone section container — `max-width:1280px; margin:80px auto 0; padding:20px 40px` (canonical)
+### Standalone section container — `max-width:1280px; margin:40px auto 0; padding:20px 40px` (canonical)
 
-Every marketing section that sits at the top of a standalone page (not home) uses the same container: 1280px max-width, `80px` top margin as header-to-content spacing, `20px` vertical padding, `40px` fixed horizontal padding. Selectors:
+Every marketing section that sits at the top of a standalone page (not home) uses the same container: 1280px max-width, `40px` top margin as header-to-content spacing (tightened from 80px on 2026-04-23 — header already has adequate internal padding, 80px was creating a second gap), `20px` vertical padding, `40px` fixed horizontal padding. Selectors:
 
-- `.prob` (the Problem section — shared with home as a mid-page spacer, with the same `80px` acting as section-to-section rhythm there)
-- `.coming-soon` (on `/memory`)
+- `.prob` (the Problem section on `/why-salency`)
+- `.mem-intro` (on `/memory`)
 - `.inv-intro` (on `/investors`)
 - `.apply-page` (on `/pilot` and `/pricing`). Fully CSS-driven — no Tailwind utilities in the JSX. Layout, typography, grid, responsive breakpoints all nested under `.apply-page` in globals. Sub-classes: `.apply-intro` (intro section), `.apply-lede` (lede paragraph), `.apply-layout` (two-column grid), `.apply-sidebar` (vertical stack of cards), `.apply-form` (email form column), `.apply-card` (shared card panel), `.apply-check` and `.apply-dot` (list-item markers).
+- `.coming-soon` (legacy stub template — still at 80px, update if re-used)
 
 Home (`/`) hero uses the tighter `.hero` 96/40/72 variant because it has more above-the-fold content. Legal pages (`/privacy`, `/terms`) use `pt-32` (128px) via Tailwind since they're narrow-measure prose.
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -664,7 +664,7 @@ html {
      viewed through the pricing-page lens. All layout/typography lives
      here so the JSX is semantic (no Tailwind utility soup). */
   .apply-page{
-    max-width:1280px;margin:80px auto 0;padding:20px 40px;
+    max-width:1280px;margin:40px auto 0;padding:20px 40px;
 
     .apply-intro{max-width:48rem;margin-bottom:64px}
 
@@ -1038,7 +1038,7 @@ html {
 
   /* ═══════════ Problem section ═══════════ */
   .prob{
-    max-width:1280px;margin:80px auto 0;padding:20px 40px;
+    max-width:1280px;margin:40px auto 0;padding:20px 40px;
   }
   .prob-head{
     display:grid;grid-template-columns:1fr 1.1fr;gap:64px;align-items:end;
@@ -1594,7 +1594,7 @@ html {
   }
 
   .inv-intro{
-    max-width:1280px;margin:80px auto 0;padding:20px 40px;
+    max-width:1280px;margin:40px auto 0;padding:20px 40px;
     border-bottom:1px solid var(--hair);position:relative;
 
     &::after{
@@ -1848,7 +1848,7 @@ header button:focus:not(:focus-visible){
   /* ── Intro (matches standalone canonical per DESIGN.md §4) ── */
   .mem-intro {
     max-width: 1280px;
-    margin: 80px auto 0;
+    margin: 40px auto 0;
     padding: 20px 40px;
 
     .eb {


### PR DESCRIPTION
## What

Tighten the top margin on the first section of four standalone pages:

| Page | Selector | Before | After |
|---|---|---|---|
| `/why-salency` | `.prob` | `margin: 80px auto 0` | `margin: 40px auto 0` |
| `/memory` | `.mem-intro` | `margin: 80px auto 0` | `margin: 40px auto 0` |
| `/investors` | `.inv-intro` | `margin: 80px auto 0` | `margin: 40px auto 0` |
| `/pilot` + `/pricing` | `.apply-page` | `margin: 80px auto 0` | `margin: 40px auto 0` |

## Why

The `MarketingHeader` already has adequate internal padding. Adding 80px below it created a double-gap — a strip of dead space before the first eyebrow that read as "nothing is happening yet." 40px lets the eye land on the first eyebrow + headline immediately after the header.

## Not changed

- `.coming-soon` stays at 80px — it's a legacy stub template not currently wired to any live route. Noted in DESIGN.md §4.
- Home `/` uses the tighter `.hero` (96/40/72) — already different, unchanged.
- Legal pages (`/privacy`, `/terms`) use `pt-32` (128px) — different scale for narrow-measure prose, unchanged.

## Files
- `app/globals.css` — 4 margin updates.
- `DESIGN.md` §4 — canonical "Standalone section container" heading updated from 80px to 40px + rationale inline.

## Test plan
- [ ] `npm run build` clean (verified — 14 routes).
- [ ] Vercel preview: `/why-salency`, `/memory`, `/investors`, `/pilot`, `/pricing` all show a tighter gap between the header and the first eyebrow. The rest of each page is visually unchanged.
- [ ] Confirm `/memory`, `/investors`, `/pilot`, `/pricing` still feel "breathing" rather than cramped on wide viewports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)