### PR TITLE
feat(mobile): pilot modal close + /investors mobile overrides

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1629,6 +1629,63 @@ html {
     }
   }
 
+  /* ═══════════ Investor page — mobile overrides ═══════════ */
+  @media (max-width: 768px) {
+    .investors-register .reg-inv {
+      padding-top: 48px;
+      padding-bottom: 80px;
+    }
+    .inv-intro,
+    .platform,
+    .roadmap,
+    .team,
+    .thesis {
+      padding-left: 22px;
+      padding-right: 22px;
+    }
+    .platform .primitive {
+      /* Stack the "Data primitive" label above the title on narrow screens. */
+      grid-template-columns: 1fr;
+      gap: 12px;
+      padding: 22px 22px;
+    }
+    .roadmap-card {
+      /* Same for the "On the roadmap" pill + body. */
+      grid-template-columns: 1fr;
+      gap: 12px;
+      padding: 18px 22px;
+    }
+    .team .sect-head {
+      grid-template-columns: 1fr;
+      gap: 12px;
+      margin-bottom: 40px;
+    }
+    .founder,
+    .founder.rev {
+      /* Photo on top, body below — at 375px the 128px photo + 1fr body
+         cramped the bio to ~12ch per line. Reversed variant collapses
+         to the same stacked layout. */
+      grid-template-columns: 1fr;
+      gap: 20px;
+      padding-bottom: 40px;
+      margin-bottom: 40px;
+
+      .photo { order: 0; width: 96px; height: 96px; font-size: 40px; }
+      .body { order: 1; text-align: left; }
+    }
+    .thesis-card {
+      /* 56/64 padding was the desktop editorial feel — at mobile that
+         left only ~200px for text. */
+      padding: 32px 24px;
+    }
+    .thesis-card h2 {
+      font-size: clamp(28px, 7vw, 40px);
+    }
+    .thesis-card .close {
+      font-size: 18px;
+    }
+  }
+
 /* ═══════════ Marketing font mapping ═══════════ */
 /* Bind --font-body / --font-display to next/font variables. */
 :root{
@@ -2622,4 +2679,77 @@ header button:focus:not(:focus-visible){
 @keyframes memPulse {
   0%, 100% { box-shadow: 0 0 0 0 rgba(232, 230, 227, 0.35); }
   50% { box-shadow: 0 0 0 5px rgba(232, 230, 227, 0); }
+}
+
+/* ═══════════ Pilot modal (Request-your-pilot form) ═══════════ */
+.pilot-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(4px);
+  animation: pilotModalFadeIn 200ms ease-out;
+}
+@media (min-width: 768px) {
+  .pilot-modal-backdrop { padding: 24px; }
+}
+
+.pilot-modal-panel {
+  position: relative;
+  width: 100%;
+  max-width: 42rem;
+  max-height: 90vh;
+  overflow-y: auto;
+  animation: pilotModalFadeZoomIn 200ms ease-out;
+}
+
+/* Close button — pinned top-right of the scrolling panel so it stays
+   visible even when the form content is longer than the viewport.
+   44×44 hit area per WCAG touch-target guidance. */
+.pilot-modal-close {
+  position: sticky;
+  top: 8px;
+  margin-left: auto;
+  margin-right: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  background: rgba(20, 17, 25, 0.85);
+  border: 1px solid var(--hair-2);
+  border-radius: 9999px;
+  color: var(--ink-2);
+  cursor: pointer;
+  z-index: 10;
+  transition: color 180ms, background-color 180ms, border-color 180ms;
+}
+.pilot-modal-close:hover,
+.pilot-modal-close:focus-visible {
+  color: var(--ink);
+  background: rgba(32, 29, 36, 0.95);
+  border-color: var(--hair);
+  outline: none;
+}
+.pilot-modal-close-icon {
+  width: 18px;
+  height: 18px;
+}
+
+@keyframes pilotModalFadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@keyframes pilotModalFadeZoomIn {
+  from { opacity: 0; transform: scale(.95); }
+  to   { opacity: 1; transform: scale(1); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .pilot-modal-backdrop,
+  .pilot-modal-panel { animation: none; }
 }

--- a/components/PilotModal.tsx
+++ b/components/PilotModal.tsx
@@ -48,20 +48,23 @@ export function PilotModal() {
       role="dialog"
       aria-modal="true"
       aria-label="Request your pilot"
-      className="fixed inset-0 z-[100] flex items-center justify-center p-4 md:p-6 bg-black/70 backdrop-blur-sm animate-in fade-in duration-200"
+      className="pilot-modal-backdrop"
       onClick={close}
     >
       <div
-        className="relative w-full max-w-2xl max-h-[90vh] overflow-y-auto animate-in fade-in zoom-in-95 duration-200"
+        className="pilot-modal-panel"
         onClick={(e) => e.stopPropagation()}
       >
+        {/* Close button stays visible no matter how far the form scrolls
+            on a small viewport — the panel is the scroll container, so
+            a position:sticky close stays pinned to the top-right. */}
         <button
           type="button"
           onClick={close}
           aria-label="Close"
-          className="absolute top-3 right-3 z-10 p-2 text-gray-400 hover:text-white transition-colors"
+          className="pilot-modal-close"
         >
-          <X className="w-5 h-5" />
+          <X className="pilot-modal-close-icon" aria-hidden />
         </button>
         <EmailForm prefillEmail={prefill} />
       </div>


### PR DESCRIPTION
First concrete pass under #66. Two targeted mobile fixes.

## 1. PilotModal — "make sure the form can be closed on mobile"

**Problem:** the close button was `absolute; top-3 right-3` inside the panel, which is also the scroll container. On a small viewport the form scrolls past 90vh, and the close button scrolled out of view. Plus the 36×36 hit area was under the WCAG 44×44 touch target.

**Fix:**
- `position: sticky; top: 8px` — stays pinned to the top-right of the scroll container no matter how far the user scrolls into the form.
- 44×44 hit area.
- Pill background (`rgba(20,17,25,.85)`) + hair border so the X reads as a button, not a floating glyph on arbitrary form content.
- Moved the Tailwind-utility soup (`fixed inset-0 z-[100] flex items-center justify-center p-4 md:p-6 bg-black/70 backdrop-blur-sm animate-in fade-in`) out of the JSX into scoped CSS classes: `.pilot-modal-backdrop`, `.pilot-modal-panel`, `.pilot-modal-close`. Fade + zoom-in keyframes defined inline. `prefers-reduced-motion` respected.

Keep Escape-key close (desktop) and backdrop-click close (works on touch). No a11y regression.

## 2. /investors mobile overrides at `@media (max-width: 768px)`

Current state: at 375px, the investors page was largely broken — 128px founder photo + 1fr body left ~12ch of bio per line; `.thesis-card` padding 56/64 left ~200px of text width; `.platform .primitive` and `.roadmap-card` used 2-col grids that didn't fit.

**Changes (all inside one new `@media (max-width: 768px)` block nested under `.reg-inv`):**

| Selector | Desktop | Mobile (≤768px) |
|---|---|---|
| `.inv-intro / .platform / .roadmap / .team / .thesis` padding | `40px` horizontal | `22px` |
| `.investors-register .reg-inv` padding | `72px 0 120px` | `48px 0 80px` |
| `.platform .primitive` grid | `auto 1fr`, padding 28/32 | `1fr`, padding 22/22 |
| `.roadmap-card` grid | `auto 1fr`, padding 22/28 | `1fr`, padding 18/22 |
| `.team .sect-head` grid | `auto 1fr` | `1fr` |
| `.founder` / `.founder.rev` grid | `128px 1fr` / `1fr 128px` | `1fr` — photo on top, body below, reversed variant collapses to same stack |
| `.founder .photo` | `128×128` | `96×96`, font-size 40 |
| `.thesis-card` padding | `56 64` | `32 24` |
| `.thesis-card h2` | `clamp(34, 3.6vw, 46)` | `clamp(28, 7vw, 40)` |
| `.thesis-card .close` | `22px` | `18px` |

## Out of scope (for #66)

- Home page mobile (P0 in the issue).
- `/memory` mobile — tables, hero brief grid, support grid.
- `/why-salency` — Problem grid + Gong comparison table.
- `/pilot`, `/pricing` — already has `md:` / `lg:` breakpoints; needs verification not fixes.
- Hamburger nav touch behavior audit.
- Breakpoint unification across globals.css (still uses 640/720/768/860/900/960/1024 inconsistently).

## Test plan
- [ ] `npm run build` clean (verified — 14 routes).
- [ ] iOS Safari / Chrome Android @ 375px: open Request-a-pilot modal, scroll the form all the way down — close button stays visible in the top-right corner.
- [ ] 44×44 tap target on the close button.
- [ ] Escape-key and backdrop-click close still work.
- [ ] `/investors` at 375px: no horizontal scroll, founder cards stack photo-over-body, thesis card reads without visual cramping.
- [ ] `/investors` at 768px: overrides still active (they apply up to 768 inclusive), desktop 2-col grids return at 769px+.
- [ ] `prefers-reduced-motion`: modal fade/zoom animations disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)