### PR TITLE
refactor(how-steps): keywords-only + mobile stack + copy nits

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1197,20 +1197,23 @@ html {
   .how-step{padding:36px 32px 36px 0;border-right:1px solid var(--hair);position:relative;display:flex;flex-direction:column}
   .how-step:nth-child(n+2){padding-left:32px}
   .how-step:last-child{border-right:0}
+  /* Between-step arrow: decoration, not a keyword — ink ramp. */
   .how-step:not(:last-child)::before{
     content:"→";position:absolute;right:-10px;top:34px;
     width:20px;height:20px;display:flex;align-items:center;justify-content:center;
-    background:var(--bg);color:var(--copper);font-size:14px;font-weight:400;
+    background:var(--bg);color:var(--ink-3);font-size:14px;font-weight:400;
     font-family:'Geist Mono',monospace;z-index:1;
   }
+  /* Step label — caption, not a keyword. */
   .how-step .idx{
     font-family:'Geist Mono',monospace;font-size:11px;font-weight:500;
-    letter-spacing:.2em;text-transform:uppercase;color:var(--copper);
+    letter-spacing:.2em;text-transform:uppercase;color:var(--ink-3);
     display:flex;align-items:center;gap:10px;margin-bottom:18px;
   }
   .how-step .idx::after{content:"";flex:1;height:1px;background:var(--hair)}
   .how-step .verb{
-    font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;font-size:34px;
+    font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;
+    font-size:clamp(26px, 5vw, 34px);
     line-height:1.1;letter-spacing:-.02em;color:var(--ink);margin:0 0 14px;
   }
   .how-step .verb em{font-style:italic;color:var(--copper)}
@@ -1218,19 +1221,37 @@ html {
     font-family:var(--font-body), 'Geist', sans-serif;font-weight:300;font-size:14.5px;
     line-height:1.65;color:var(--ink-2);margin:0 0 22px;max-width:34ch;
   }
+  /* Example callout — a tinted surface is chrome. Use the ink/hair ramp
+     so the copper em in the verb above stays the only page-accent in
+     each step. */
   .how-step .ex{
     margin-top:auto;
-    padding:14px 16px;background:var(--copper-a04);
-    border:1px solid var(--copper-a12);border-radius:8px;
+    padding:14px 16px;background:rgba(255,255,255,.02);
+    border:1px solid var(--hair-2);border-radius:8px;
   }
   .how-step .ex .example-label{
     font-family:'Geist Mono',monospace;font-size:9.5px;font-weight:500;
-    letter-spacing:.18em;text-transform:uppercase;color:var(--copper);margin-bottom:6px;
+    letter-spacing:.18em;text-transform:uppercase;color:var(--ink-3);margin-bottom:6px;
   }
   .how-step .ex .example-quote{
     font-family:var(--font-body), 'Geist', sans-serif;font-size:13px;line-height:1.45;color:var(--ink-2);
   }
   .how-step .ex .example-quote strong{color:var(--ink);font-weight:500}
+  /* Mobile: stack the 3 steps vertically. The horizontal arrows don't
+     translate to a vertical flow, so hide them; horizontal dividers
+     between stacked steps replace the vertical borders. */
+  @media (max-width: 768px) {
+    .how-steps { grid-template-columns: 1fr; }
+    .how-step {
+      padding: 32px 0;
+      border-right: 0;
+      border-bottom: 1px solid var(--hair);
+    }
+    .how-step:nth-child(n+2) { padding-left: 0; }
+    .how-step:last-child { border-bottom: 0; padding-bottom: 8px; }
+    .how-step:not(:last-child)::before { display: none; }
+    .how-step .desc { max-width: none; }
+  }
   .how-foot{
     margin-top:28px;padding:18px 24px;
     display:flex;justify-content:space-between;align-items:center;gap:24px;

--- a/components/sections/HowItWorksSection.tsx
+++ b/components/sections/HowItWorksSection.tsx
@@ -9,9 +9,9 @@ export function HowItWorksSection() {
           </h2>
         </div>
         <p className="lede">
-          Every transcript, <em>AI notetaker</em> or raw text, runs through the
-          same pipeline. The output is{' '}
-          <em>structured, cited, and queryable</em> before your next stand-up.
+          Any transcript &mdash; <em>AI notetaker</em> or raw &mdash; runs
+          through the same pipeline, and the output is{' '}
+          <em>structured, cited, queryable</em> before your next stand-up.
         </p>
       </div>
       <div className="how-steps">
@@ -42,9 +42,9 @@ export function HowItWorksSection() {
           <p className="desc">
             Each pain maps to a line in your product catalog, ranked by
             confidence. Every new call is compared against prior calls on the
-            same account, and contradictions get flagged. The graph keeps
-            growing: pains, products, stakeholders, and how the story has
-            changed over time.
+            same account, and contradictions get flagged. The memory graph
+            keeps growing: pains, products, stakeholders, and how the story
+            has changed over time.
           </p>
           <div className="ex">
             <div className="example-label">Example mapping</div>


### PR DESCRIPTION
Companion to #61 (keywords-only) and #66 (mobile responsive), scoped to the How-it-works section on `/`.

## Why

Three problems in `.how-steps`:

1. **Copper overreach.** Four chrome uses of `var(--copper)` that fail the keywords-only rule: step label (`"Step 01"`), the inter-step arrow, the example-callout surface tint, and the example label. Every step had three copper events competing for attention — only one (the verb em) is a keyword.
2. **Mobile broken.** The 3-col grid had no breakpoint below 768px. At 375px each step got ~125px, verbs and example boxes wrapped or overflowed, and the absolute-positioned `→` arrows (designed for horizontal flow) pointed into dead space.
3. **Two copy stumbles.** A parenthetical-comma run-on in the lede, and an undefined "the graph" first mention in Step 02.

## What changed

### CSS (`app/globals.css`)

Keyword demotions to the ink/hair ramp:

| Selector | Was | Now |
|---|---|---|
| `.how-step .idx` (step label) | `var(--copper)` | `var(--ink-3)` |
| `.how-step::before` (→ arrow) | `var(--copper)` | `var(--ink-3)` |
| `.how-step .ex` background | `var(--copper-a04)` | `rgba(255,255,255,.02)` |
| `.how-step .ex` border | `var(--copper-a12)` | `var(--hair-2)` |
| `.how-step .ex .example-label` | `var(--copper)` | `var(--ink-3)` |

Each step now has exactly one copper event: the verb em (*Extract* / *Map* / *Remember*).

Mobile breakpoint at ≤768px:
- `grid-template-columns: 1fr` (was `repeat(3, 1fr)`).
- `.how-step` padding resets to `32px 0` (removes desktop's asymmetric left/right).
- `border-right` → `border-bottom` between stacked cells.
- The absolute `→` arrows hide (were horizontal-flow only).
- `.verb` clamps `clamp(26px, 5vw, 34px)` so big display text scales down.
- `.desc` max-width removed so body copy fills the mobile column.

### JSX (`components/sections/HowItWorksSection.tsx`)

- Lede: `"Every transcript, AI notetaker or raw text, runs through the same pipeline. The output is structured, cited, and queryable..."` → `"Any transcript — AI notetaker or raw — runs through the same pipeline, and the output is structured, cited, queryable..."`
- Step 02: `"The graph keeps growing"` → `"The memory graph keeps growing"` (was undefined on first mention).

## Test plan
- [ ] `npm run build` clean (verified — 14 routes).
- [ ] `/` at 375px: the three steps stack vertically with clean horizontal dividers, verbs scale down, no horizontal scroll, no orphaned `→` arrows.
- [ ] `/` at 1280px: the 3-col desktop layout renders identically to before except the step labels, inter-step arrow, and example callouts now read in the ink ramp. Verb ems stay copper.
- [ ] Section heading "Three steps. *Every call,* every account." — unchanged.
- [ ] Example callouts still visually distinct from the step body (they have the hair-2 border + subtle tint) but no longer steal attention from the verb.

## Out of scope
- Unifying `.verb` class name (could be `.how-step-action` or drop to bare `h3` — separate naming PR under #56).
- Example-quote format inconsistency across the three steps (step 01 tag-delimited, step 02 mixed, step 03 tag-delimited) — copy-only pass, separate.
- Semantic wrapper `<ol>` around `.how-steps` for a11y — separate a11y pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)