### PR TITLE
feat(mobile): stack .prob-row + .prob-resolve + .notdo-card at ≤768px

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1131,6 +1131,28 @@ html {
   }
   .prob-resolve .link:hover{color:#FE9F5B}
 
+  /* Problem section mobile: 3-col pain grid stacks, vertical dividers
+     become horizontal, asymmetric left/right padding resets, and the
+     .prob-resolve 3-cell row (label + text + link) stacks to 1 col. */
+  @media (max-width: 768px) {
+    .prob-row { grid-template-columns: 1fr; }
+    .prob-card {
+      padding: 32px 0;
+      border-right: 0;
+      border-bottom: 1px solid var(--hair);
+    }
+    .prob-card:nth-child(n+2) { padding-left: 0; }
+    .prob-card:last-child { border-bottom: 0; padding-bottom: 8px; }
+    .prob-card .title { max-width: none; }
+    .prob-card .desc  { max-width: none; }
+    .prob-resolve {
+      padding: 24px 22px;
+      grid-template-columns: 1fr;
+      gap: 14px;
+    }
+    .prob-resolve .link { white-space: normal; }
+  }
+
   /* ═══════════ CTA ═══════════ */
   .cta-section{
     max-width:1280px;margin:140px auto 0;padding:0 40px 120px;
@@ -1294,6 +1316,18 @@ html {
   .notdo-item .check{color:var(--copper)}
   .notdo-item .title{font-size:14.5px;color:var(--ink);font-weight:400;line-height:1.4;grid-column:2}
   .notdo-item .subtitle{font-size:13px;color:var(--ink-3);line-height:1.5;grid-column:2}
+
+  /* "NOT strip" mobile: card header stacks above the 2-col item list,
+     and the item list itself collapses to one column. */
+  @media (max-width: 768px) {
+    .notdo-card {
+      grid-template-columns: 1fr;
+      gap: 24px;
+      padding: 24px 22px;
+    }
+    .notdo-card .header { max-width: none; }
+    .notdo-list { grid-template-columns: 1fr; gap: 14px; }
+  }
 
   /* ═══════════ Notetaker comparison table ═══════════ */
   .notetaker{max-width:1280px;margin:140px auto 0;padding:0 40px}


### PR DESCRIPTION
Next mobile chunk under #66. Three more P0 fixed-column grids stack at ≤768px.

## What changed

`app/globals.css`, +34 lines, 0 deletions. All mobile overrides added as `@media (max-width: 768px)` blocks at the end of each component's existing selectors. No desktop values touched.

| Section | Page | Before (desktop, unchanged) | After (≤768px) |
|---|---|---|---|
| `.prob-row` | `/why-salency` | 3-col grid, vertical dividers between cards | 1-col stack, horizontal dividers |
| `.prob-card` padding | `/why-salency` | `40 36 40 0` + `:nth-child(n+2){padding-left:36px}` | uniform `32 0` |
| `.prob-card .title / .desc` | `/why-salency` | `max-width:14ch / 32ch` | max-width removed |
| `.prob-resolve` | `/why-salency` | 3-cell row: label + text + link (`auto 1fr auto`) | 1-col stack |
| `.prob-resolve .link` | `/why-salency` | `white-space:nowrap` | wraps when needed |
| `.notdo-card` | `/` | 2-col: header + list (`auto 1fr`) | 1-col stack |
| `.notdo-list` | `/` | 2-col item grid (`1fr 1fr`) | 1-col |
| Card paddings | `/` | `32 40` | `24 22` on both `.notdo-card` and `.prob-resolve` |

## Test plan
- [ ] `npm run build` clean (verified — 14 routes).
- [ ] `/why-salency` at 375px: three pain cards stack vertically with clean horizontal separators, no horizontal overflow, title and description fill the column. The `.prob-resolve` band below stacks label → text → link with the copper anchor treatment preserved.
- [ ] `/` at 375px: the "What it is · what it isn't" card stacks its header above the 6-item list, and each item list stays 1-col.
- [ ] `/` and `/why-salency` at 1280px: layout identical to main — desktop 3-col and 2-col grids unchanged.
- [ ] No change to the copper treatment anywhere; that's a separate cleanup.

## Out of scope
- Copper-keywords audit on `.prob-card .idx` (step label), `.prob-card .cost .num` (data figure), `.notdo-item .check` (list marker) — tracked in #61 as the /why-salency + / copper cleanup.
- `.mem-table` and `.notetaker-table` horizontal-scroll-vs-stack behavior on mobile — separate PR.
- Hamburger nav touch-target audit — separate PR.
- `.hub-wrap` interactive diagram narrow-viewport audit — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)