### PR TITLE
refactor: copper cleanup on home + /why-salency + notetaker-table mobile

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1078,9 +1078,10 @@ html {
   }
   .prob-card:nth-child(n+2){padding-left:36px}
   .prob-card:last-child{border-right:0}
+  /* Pain-card index "01/02/03" is decorative numbering, not a keyword. */
   .prob-card .idx{
     font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;font-weight:400;
-    font-size:15px;color:var(--copper);letter-spacing:.02em;margin-bottom:10px;
+    font-size:15px;color:var(--ink-3);letter-spacing:.02em;margin-bottom:10px;
     display:flex;align-items:center;gap:10px;
   }
   .prob-card .idx::after{
@@ -1100,9 +1101,10 @@ html {
     display:flex;align-items:baseline;gap:10px;
     padding-top:16px;border-top:1px dashed var(--hair-2);
   }
+  /* "40–50%" style data figures read brightness, not hue. Ink ramp. */
   .prob-card .cost .num{
     font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;font-weight:400;
-    font-size:40px;line-height:1;color:var(--copper);letter-spacing:-.02em;
+    font-size:40px;line-height:1;color:var(--ink);letter-spacing:-.02em;
   }
   .prob-card .cost .label{
     font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
@@ -1312,8 +1314,10 @@ html {
     font-weight:500;text-align:center;
     grid-column:1;
   }
+  /* .check is a positive list marker. Brightness differentiates it
+     from the rust .x; the copper accent is reserved for keywords. */
   .notdo-item .x{color:var(--rust)}
-  .notdo-item .check{color:var(--copper)}
+  .notdo-item .check{color:var(--ink)}
   .notdo-item .title{font-size:14.5px;color:var(--ink);font-weight:400;line-height:1.4;grid-column:2}
   .notdo-item .subtitle{font-size:13px;color:var(--ink-3);line-height:1.5;grid-column:2}
 
@@ -1379,8 +1383,78 @@ html {
     display:inline-block;margin-right:8px;font-family:'Geist Mono',monospace;
     font-size:11px;width:16px;text-align:center;
   }
-  .notetaker-table .col-s .icon{color:var(--copper)}
+  /* Icon markers are list markers, not keywords. Salency column uses
+     bright ink so it's visible against the copper-tinted cell; the
+     column's copper-a03 background + bold strong is the signal. */
+  .notetaker-table .col-s .icon{color:var(--ink-2)}
   .notetaker-table .col-g .icon{color:var(--ink-4)}
+
+  /* Mobile: table → card-per-row. Row-level semantics stay intact,
+     but each row becomes a bordered card with the dimension as a
+     caption and two labeled cells (Notetaker / Salency) underneath.
+     Column headers dissolve; their labels re-materialize as ::before
+     text on each body cell so users can still tell which is which. */
+  @media (max-width: 768px) {
+    .notetaker-table,
+    .notetaker-table thead,
+    .notetaker-table tbody,
+    .notetaker-table tr,
+    .notetaker-table td,
+    .notetaker-table th { display: block; }
+    .notetaker-table { background: transparent; border: 0; border-radius: 0; }
+    .notetaker-table thead { display: none; }
+    .notetaker-table tbody tr {
+      border: 1px solid var(--hair-2);
+      border-radius: 12px;
+      padding: 16px 20px;
+      margin-bottom: 12px;
+      background: #121015;
+    }
+    .notetaker-table tbody tr:last-child { margin-bottom: 0; }
+    .notetaker-table tbody td {
+      border: 0;
+      padding: 8px 0;
+      width: auto;
+    }
+    .notetaker-table tbody td.dim {
+      width: auto;
+      font-size: 10.5px;
+      letter-spacing: .18em;
+      text-transform: uppercase;
+      color: var(--ink-4);
+      font-family: 'Geist Mono', monospace;
+      border-bottom: 1px solid var(--hair);
+      padding-bottom: 10px;
+      margin-bottom: 6px;
+    }
+    .notetaker-table tbody td.col-g { background: transparent; }
+    .notetaker-table tbody td.col-g::before {
+      content: "Notetaker";
+      display: block;
+      font-family: 'Geist Mono', monospace;
+      font-size: 9.5px;
+      letter-spacing: .18em;
+      text-transform: uppercase;
+      color: var(--ink-4);
+      margin-bottom: 4px;
+    }
+    .notetaker-table tbody td.col-s {
+      background: var(--copper-a04);
+      border-radius: 6px;
+      padding: 10px 12px;
+      margin-top: 6px;
+    }
+    .notetaker-table tbody td.col-s::before {
+      content: "Salency";
+      display: block;
+      font-family: 'Geist Mono', monospace;
+      font-size: 9.5px;
+      letter-spacing: .18em;
+      text-transform: uppercase;
+      color: var(--copper);
+      margin-bottom: 4px;
+    }
+  }
 
   /* ═══════════ Investor register ═══════════ */
   .reg-inv{

--- a/components/sections/GongSection.tsx
+++ b/components/sections/GongSection.tsx
@@ -33,7 +33,7 @@ export function GongSection() {
               <span className="icon">—</span>Transcript + call summary
             </td>
             <td className="col-s">
-              <span className="icon">→</span>
+              <span className="icon">✓</span>
               <strong>Structured signals</strong> mapped to your catalog
             </td>
           </tr>
@@ -43,14 +43,13 @@ export function GongSection() {
               <span className="icon">—</span>The call
             </td>
             <td className="col-s">
-              <span className="icon">→</span>The <strong>account</strong> — every
-              pain, promise, stakeholder, across every call
+              <span className="icon">✓</span>The <strong>account</strong>
             </td>
           </tr>
           <tr>
             <td className="dim">Survives rep turnover</td>
             <td className="col-g">
-              <span className="icon">×</span>Transcript survives. Context
+              <span className="icon">—</span>Transcript survives. Context
               doesn&apos;t.
             </td>
             <td className="col-s">
@@ -75,14 +74,14 @@ export function GongSection() {
               moments
             </td>
             <td className="col-s">
-              <span className="icon">→</span>AE, CSM, director — every role on
+              <span className="icon">✓</span>AE, CSM, director — every role on
               the account, on demand
             </td>
           </tr>
           <tr>
             <td className="dim">Handoff artefact</td>
             <td className="col-g">
-              <span className="icon">×</span>None — you still write the handoff
+              <span className="icon">—</span>None — you still write the handoff
               doc by hand
             </td>
             <td className="col-s">
@@ -93,10 +92,10 @@ export function GongSection() {
           <tr>
             <td className="dim">Works alongside</td>
             <td className="col-g">
-              <span className="icon">→</span>Your CRM
+              <span className="icon">—</span>Your CRM
             </td>
             <td className="col-s">
-              <span className="icon">→</span>Your notetaker + your CRM —{' '}
+              <span className="icon">✓</span>Your notetaker + your CRM —{' '}
               <strong>zero rip-and-replace</strong>
             </td>
           </tr>


### PR DESCRIPTION
Combines work under #61 (keywords-only copper cleanup) and #66 (mobile responsive) into one coherent pass over the home + `/why-salency` surfaces.

## What changed

### 1. Copper demotions (4 chrome → ink/hair)

| Selector | Page | Was | Now |
|---|---|---|---|
| `.prob-card .idx` (pain card numbering "01/02/03") | `/why-salency` | `var(--copper)` | `var(--ink-3)` |
| `.prob-card .cost .num` (data figures "40–50%") | `/why-salency` | `var(--copper)` | `var(--ink)` |
| `.notdo-item .check` (positive list markers) | `/` | `var(--copper)` | `var(--ink)` |
| `.notetaker-table .col-s .icon` (row markers in Salency column) | `/why-salency` | `var(--copper)` | `var(--ink-2)` |

Rationale per DESIGN.md §3 keywords-only rule: decorative numbering, data values, list markers, and bullet icons are chrome — they're not the "words users should focus on." The `.notdo-item .check` follows the memory `.stance.champion` precedent (brightness differentiates vs. rust `.x`, no accent hue needed). The `.notetaker-table` Salency column still reads as "the answer" via the `--copper-a04` cell tint + bold `<strong>` + copper column header — icon markers don't need to pile on.

### 2. `.notetaker-table` mobile: card-per-row at ≤768px

Previously the 7-row × 3-col comparison table had no mobile breakpoint. At 375px, the `.dim` column was ~90px (too narrow for "Survives rep turnover") and Salency cells wrapped to 10+ lines. Now:

- Each `<tr>` becomes a bordered card (`--hair-2` border, 12px radius, `#121015` background).
- The dimension label becomes a mono-caps caption above the card body.
- Column headers (`<thead>`) dissolve; their labels re-materialize as `::before` pseudo-labels on each `.col-g` / `.col-s` cell ("Notetaker" in `--ink-4`, "Salency" in `--copper` — the only surviving copper role here since it's an eyebrow-equivalent).
- Salency cells keep `--copper-a04` tint + bordered container treatment so "this is the answer" still reads inside each card.

Pure CSS — no JSX restructuring, no a11y regression (table semantics stay intact).

### 3. GongSection icon-glyph consistency

Previously rows mixed `—` / `×` in the Notetaker column and `→` / `✓` in the Salency column with no semantic split (why arrow vs check? why em dash vs x?). Unified:

- Notetaker column: all rows use `—` (em dash — "stops here").
- Salency column: all rows use `✓` (check — positive assertions).

Also dropped `" — every pain, promise, stakeholder, across every call"` from row 2 Salency cell. Redundant with what the other rows cover; Krug's omit-then-omit rule. Row 2 Salency now reads simply "The account."

## Files

| File | Change |
|---|---|
| `app/globals.css` | 4 one-line demotions + 70-line mobile `@media` block for `.notetaker-table` |
| `components/sections/GongSection.tsx` | 7 icon-glyph consistency edits + 1 copy trim |

## Test plan
- [ ] `npm run build` clean (verified — 14 routes).
- [ ] `/why-salency` at 1280px: the three pain cards look identical except "01/02/03" numbers and "40–50%" figures read in the ink ramp now. Row headline ems + eyebrow stay copper.
- [ ] `/why-salency` at 375px: comparison table stacks as 7 bordered cards, each with a dimension caption + Notetaker + Salency labeled sub-cells.
- [ ] `/` at 375px: "What it is · what it isn't" card items show bright ink checks vs rust x's.
- [ ] `/` at 1280px: notdo check marks are bright ink, still visually distinct from rust x's (brightness + hue diff).
- [ ] No other regressions on `/memory`, `/investors`, `/pilot`, `/pricing`.

## Out of scope
- `.notetaker-table` typography cleanup (`.col-g .brand` sans vs `.col-s .brand` serif mix — P2 polish), padding alignment (22/24 vs 20/24), lede copy tightening, and "Here's where the two diverge" cut — separate copy-polish PR.
- Home hub `.ping` + hover-state copper audit — the hub is the page's single visual anchor, needs its own review.
- Hamburger nav touch-target audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)