### PR TITLE
feat(mobile): .mem-table card-stack + .prob-head responsive

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1054,7 +1054,7 @@ html {
   }
   .prob-head h2{
     font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;
-    font-size:clamp(48px,5.4vw,76px);line-height:1.02;letter-spacing:-.025em;
+    font-size:clamp(36px,5.4vw,76px);line-height:1.02;letter-spacing:-.025em;
     margin:0;color:var(--ink);max-width:18ch;text-wrap:balance;
   }
   .prob-head h2 em{font-style:italic;color:var(--copper)}
@@ -1066,6 +1066,17 @@ html {
   .prob-head .lede em{
     font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;color:var(--ink);
     font-size:19px;font-weight:400;
+  }
+  /* .prob-head mobile: 2-col headline+lede grid stacks, gap tightens,
+     margin below head reduces. h2 clamp already handles the font
+     scale-down on narrow viewports. */
+  @media (max-width: 768px) {
+    .prob-head {
+      grid-template-columns: 1fr;
+      gap: 24px;
+      margin-bottom: 40px;
+      align-items: start;
+    }
   }
 
   .prob-row{
@@ -2792,10 +2803,71 @@ header button:focus:not(:focus-visible){
     .mem-hero-bridge { flex-direction: column; gap: 8px; }
 
     .mem-compare { margin-top: 72px; padding: 0 22px; }
-    .mem-table { font-size: 13px; }
-    .mem-table thead th { padding: 14px 16px; }
-    .mem-table td { padding: 14px 16px; font-size: 13px; }
-    .mem-table td:nth-child(1) { width: 30%; }
+
+    /* Table → card-per-row. Signal (col 1) becomes the card caption,
+       CRM and Salency cells label themselves via ::before pseudo-
+       labels so users still know which column is which. Salency cell
+       keeps the brighter ink + subtle copper tint to signal answer. */
+    .mem-table,
+    .mem-table thead,
+    .mem-table tbody,
+    .mem-table tr,
+    .mem-table td,
+    .mem-table th { display: block; }
+    .mem-table { background: transparent; border: 0; border-radius: 0; }
+    .mem-table thead { display: none; }
+    .mem-table tbody tr {
+      border: 1px solid var(--hair-2);
+      border-radius: 12px;
+      padding: 14px 18px;
+      margin-bottom: 12px;
+      background: rgba(255, 255, 255, 0.02);
+    }
+    .mem-table tbody tr:last-child { margin-bottom: 0; }
+    .mem-table tbody td {
+      border: 0;
+      padding: 6px 0;
+      width: auto;
+      font-size: 13.5px;
+    }
+    .mem-table tbody td:nth-child(1) {
+      width: auto;
+      font-size: 10.5px;
+      letter-spacing: .18em;
+      text-transform: uppercase;
+      color: var(--ink-4);
+      font-family: 'Geist Mono', monospace;
+      border-bottom: 1px solid var(--hair);
+      padding-bottom: 10px;
+      margin-bottom: 4px;
+      font-weight: 500;
+    }
+    .mem-table tbody td:nth-child(2)::before {
+      content: "In your CRM";
+      display: block;
+      font-family: 'Geist Mono', monospace;
+      font-size: 9.5px;
+      letter-spacing: .18em;
+      text-transform: uppercase;
+      color: var(--ink-4);
+      margin-bottom: 3px;
+    }
+    .mem-table tbody td:nth-child(3) {
+      background: var(--copper-a04);
+      border-radius: 6px;
+      padding: 10px 12px;
+      margin-top: 6px;
+    }
+    .mem-table tbody td:nth-child(3)::before {
+      content: "In Salency";
+      display: block;
+      font-family: 'Geist Mono', monospace;
+      font-size: 9.5px;
+      letter-spacing: .18em;
+      text-transform: uppercase;
+      color: var(--copper);
+      margin-bottom: 3px;
+    }
 
     .mem-compat { margin-top: 72px; padding: 24px 22px; }
     .mem-compat-line { font-size: 15px; }


### PR DESCRIPTION
Two more P0 mobile fixes under #66, folded into one PR.

## 1. `.mem-table` — table → card-per-row at ≤720px

Previously the `/memory` comparison table's only mobile override just shrunk padding and set the first column to 30% — the 3-col layout itself didn't collapse. At 375px the dimension column was still crushing "Contradiction between calls" to wraps and the Salency cells (long sentences like "Live graph query, 'handoff loses context' lights up 7 accounts") broke to 10+ lines.

Applied the same card-per-row pattern that just landed on `.notetaker-table` in PR #70:

- Each `<tr>` becomes a bordered card (`--hair-2` border, 12px radius, `rgba(255,255,255,.02)` bg).
- First td (Signal) becomes the card caption — mono-caps in `--ink-4` with a bottom hair divider.
- Second and third td label themselves via `::before` pseudo-labels ("In your CRM" in `--ink-4`, "In Salency" in `--copper` — only surviving copper role in the mobile view, functioning as an eyebrow equivalent).
- Salency cell keeps `--copper-a04` tint + rounded container so the "this is the answer" signal still reads inside each card.

Pure CSS. No JSX change.

## 2. `.prob-head` — responsive headline + lede

- `globals.css:1044` `grid-template-columns: 1fr 1.1fr; gap: 64px` had no mobile override. Stacks to 1-col at ≤768px, gap tightens 64 → 24, `margin-bottom` shrinks 72 → 40.
- `globals.css:1057` h2 clamp floor lowered from 48px → 36px. The previous floor (48px) was too big for phone portrait — the headline "Knowledge walks out *the door* every quarter." wrapped to 4 lines at 375px. The 36px floor lets it breathe.

Didn't touch the h2's copy taste call (the `<em>` "the door" + `.soft` "every quarter" triple-treatment) — that's a separate decision.

## Files
- `app/globals.css` +77, −5. Two logical blocks: the rewritten `.mem-table` mobile inside the existing `@media (max-width: 720px)` block, and a new `@media (max-width: 768px)` block for `.prob-head`.

## Test plan
- [ ] `npm run build` clean (verified — 14 routes).
- [ ] `/memory` at 375px: comparison table stacks as bordered cards with mono-caps Signal captions and labeled CRM / Salency sub-cells. Salency cells keep their copper tint.
- [ ] `/memory` at 720–1280px: table renders as before (desktop view unchanged).
- [ ] `/why-salency` at 375px: prob-head stacks eyebrow+h2 on top, lede below, with clean 24px gap. h2 scales down to 36px.
- [ ] `/why-salency` at 1280px: 2-col prob-head layout unchanged.

## Out of scope
- `.prob-head` h2 copy taste pass (em on "the door" vs "every quarter", `.soft` on "every quarter") — separate decision.
- Body-em color consistency (`prob-head .lede em` and `how-head .lede em` still `--ink` while investor body ems are `--copper`) — site-wide policy call, separate PR.
- Hub `.ping` + hover-state copper audit on `/`.
- Hamburger nav touch-target audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)