### PR TITLE
refactor(css): cryptic class rename pass (#56 chunk D)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -339,6 +339,40 @@ Hero cards (`.thesis-card`, `.cta-card`) add a 2px left gradient via `::before`:
 
 ## 6 · Conventions
 
+### Naming convention
+
+One pattern across the codebase:
+
+| Layer | Pattern | Example |
+|---|---|---|
+| Block (component root) | kebab-case noun | `.founder`, `.thesis-card`, `.apply-card`, `.how-step`, `.mem-hero-frame` |
+| Element (child of block) | nested under block | `.founder .bio`, `.how-step .desc`, `.mem-hero-head .mem-hero-title` |
+| Modifier (variant of block/element) | `--suffix` | `.founder--reversed`, `.photo--violet`, `.photo--teal` |
+| State | `.is-*` / `.has-*` | `.is-open`, `.has-image` |
+| Utility / primitive (documented short alias) | 2–3 letter alias, widely understood | `.eb`, `.sep`, `.sub`, `.pill`, `.dim` |
+
+**Renames applied 2026-04-23** (cryptic short forms → scoped, descriptive):
+
+| Was | Now | Why |
+|---|---|---|
+| `.fit` | `.founder-fit` | didn't say what the block was in isolation |
+| `.rev` | `.founder--reversed` | BEM-style modifier on `.founder` |
+| `.p2` | `.photo--violet` | hue-named; the number was meaningless |
+| `.p3` | `.photo--teal` | same |
+| `.num` (two roles) | `.figure` (data value on `.prob-card .cost`) + `.section-num` (index on `.team .sect-head`) | one alias was pulling double duty |
+| `.close` | `.thesis-close` | scoped to its parent `.thesis-card` |
+| `.verb` | `.how-step-action` | names the role of the h3 inside each how-step |
+| CSS `.arr` | CSS `.arrow` | JSX always used `.arrow`; CSS was wrong |
+
+**Short aliases kept as intentional domain jargon** (whitelisted; don't invent new ones):
+- `.eb` — eyebrow (mono-caps + copper + dash signature treatment)
+- `.sep` — separator (inline `·` or similar)
+- `.sub` — subline / subtitle
+- `.pill` — small pill badge
+- `.dim` — muted row in a table or list
+
+When adding a new class, default to scoped descriptive names. Only use a short alias if the term is already in this list OR if you add a new entry here with justification.
+
 ### Native CSS nesting is the convention
 
 `globals.css` migrates flat selectors to native CSS nesting. Existing nested blocks: `.hub-wrap`, `.loading-screen`, `.btn-submit`, `.apply-page`, `.coming-soon`, `.reg-inv`, `.platform`, `.roadmap`, `.team`, `.founder`, `.thesis-card`, `.investors-register`, `.inv-intro`, `header`, `footer`.

--- a/app/globals.css
+++ b/app/globals.css
@@ -248,10 +248,10 @@ html {
       .eb{
         font-size:10.5px;display:inline;gap:0;
 
-        .arr{color:var(--ink-4);margin:0 4px}
+        .arrow{color:var(--ink-4);margin:0 4px}
         &.r{
           color:var(--copper);
-          .arr{color:var(--ink-4)}
+          .arrow{color:var(--ink-4)}
         }
       }
     }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1393,7 +1393,7 @@ html {
 
       em{font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;color:var(--copper);font-size:17px;font-weight:400}
     }
-    .fit{
+    .founder-fit{
       padding:14px 18px;border-left:2px solid var(--copper-a40);
       background:var(--copper-a03);
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -1019,7 +1019,7 @@ html {
     display:flex;align-items:center;gap:10px;margin-bottom:18px;
   }
   .how-step .idx::after{content:"";flex:1;height:1px;background:var(--hair)}
-  .how-step .verb{
+  .how-step .how-step-action{
     font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;
     font-size:clamp(26px, 5vw, 34px);
     line-height:1.1;letter-spacing:-.02em;color:var(--ink);margin:0 0 14px;

--- a/app/globals.css
+++ b/app/globals.css
@@ -1376,8 +1376,8 @@ html {
       display:flex;align-items:center;justify-content:center;letter-spacing:-.01em;
       border:1px solid var(--copper-a30);
 
-      &.p2{background:linear-gradient(135deg,rgba(107,78,255,.22),rgba(42,30,128,.5));border-color:rgba(107,78,255,.3);color:#D8CEFF}
-      &.p3{background:linear-gradient(135deg,rgba(0,181,160,.22),rgba(0,107,94,.45));border-color:rgba(0,181,160,.3);color:#B5F0E5}
+      &.photo--violet{background:linear-gradient(135deg,rgba(107,78,255,.22),rgba(42,30,128,.5));border-color:rgba(107,78,255,.3);color:#D8CEFF}
+      &.photo--teal{background:linear-gradient(135deg,rgba(0,181,160,.22),rgba(0,107,94,.45));border-color:rgba(0,181,160,.3);color:#B5F0E5}
     }
     .name{
       font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;font-size:32px;

--- a/app/globals.css
+++ b/app/globals.css
@@ -1362,7 +1362,7 @@ html {
     padding-bottom:56px;margin-bottom:56px;border-bottom:1px solid var(--hair);
 
     &:last-child{border-bottom:0;margin-bottom:0}
-    &.rev{
+    &.founder--reversed{
       grid-template-columns:1fr 128px;
 
       .photo{order:2}
@@ -1535,7 +1535,7 @@ html {
       margin-bottom: 40px;
     }
     .founder,
-    .founder.rev {
+    .founder.founder--reversed {
       /* Photo on top, body below — at 375px the 128px photo + 1fr body
          cramped the bio to ~12ch per line. Reversed variant collapses
          to the same stacked layout. */

--- a/app/globals.css
+++ b/app/globals.css
@@ -1431,7 +1431,7 @@ html {
 
       em{font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;color:var(--copper);font-size:18px;font-weight:400}
     }
-    .close{
+    .thesis-close{
       margin-top:28px;padding-top:24px;border-top:1px solid var(--hair);
       font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;font-size:22px;
       line-height:1.35;color:var(--ink);max-width:52ch;
@@ -1555,7 +1555,7 @@ html {
     .thesis-card h2 {
       font-size: clamp(28px, 7vw, 40px);
     }
-    .thesis-card .close {
+    .thesis-card .thesis-close {
       font-size: 18px;
     }
   }

--- a/app/globals.css
+++ b/app/globals.css
@@ -877,7 +877,7 @@ html {
     padding-top:16px;border-top:1px dashed var(--hair-2);
   }
   /* "40–50%" style data figures read brightness, not hue. Ink ramp. */
-  .prob-card .cost .num{
+  .prob-card .cost .figure{
     font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;font-weight:400;
     font-size:40px;line-height:1;color:var(--ink);letter-spacing:-.02em;
   }
@@ -1348,7 +1348,7 @@ html {
     .sect-head{
       margin-bottom:64px;display:grid;grid-template-columns:auto 1fr;gap:28px;align-items:baseline;
 
-      .num{
+      .section-num{
         font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;font-size:22px;color:var(--copper);
       }
       h2{

--- a/components/sections/HowItWorksSection.tsx
+++ b/components/sections/HowItWorksSection.tsx
@@ -17,7 +17,7 @@ export function HowItWorksSection() {
       <div className="how-steps">
         <div className="how-step">
           <div className="idx">Step 01</div>
-          <h3 className="verb">
+          <h3 className="how-step-action">
             <em>Extract</em>
           </h3>
           <p className="desc">
@@ -36,7 +36,7 @@ export function HowItWorksSection() {
         </div>
         <div className="how-step">
           <div className="idx">Step 02</div>
-          <h3 className="verb">
+          <h3 className="how-step-action">
             <em>Map</em>
           </h3>
           <p className="desc">
@@ -56,7 +56,7 @@ export function HowItWorksSection() {
         </div>
         <div className="how-step">
           <div className="idx">Step 03</div>
-          <h3 className="verb">
+          <h3 className="how-step-action">
             <em>Remember</em>
           </h3>
           <p className="desc">

--- a/components/sections/InvestorsSection.tsx
+++ b/components/sections/InvestorsSection.tsx
@@ -131,7 +131,7 @@ export function InvestorsSection() {
               </div>
             </div>
 
-            <div className="founder rev">
+            <div className="founder founder--reversed">
               <div className="photo p2">NI</div>
               <div className="body">
                 <div className="name">Nikki Ip</div>

--- a/components/sections/InvestorsSection.tsx
+++ b/components/sections/InvestorsSection.tsx
@@ -132,7 +132,7 @@ export function InvestorsSection() {
             </div>
 
             <div className="founder founder--reversed">
-              <div className="photo p2">NI</div>
+              <div className="photo photo--violet">NI</div>
               <div className="body">
                 <div className="name">Nikki Ip</div>
                 <div className="role">Co-founder &amp; COO</div>
@@ -156,7 +156,7 @@ export function InvestorsSection() {
             </div>
 
             <div className="founder">
-              <div className="photo p3">BO</div>
+              <div className="photo photo--teal">BO</div>
               <div className="body">
                 <div className="name">Babajide Okusanya</div>
                 <div className="role">Technical Lead</div>

--- a/components/sections/InvestorsSection.tsx
+++ b/components/sections/InvestorsSection.tsx
@@ -102,7 +102,7 @@ export function InvestorsSection() {
 
           <section className="team" id="team">
             <div className="sect-head">
-              <span className="num">03.</span>
+              <span className="section-num">03.</span>
               <h2>
                 Why <em>this team,</em> on this problem, now.
               </h2>

--- a/components/sections/InvestorsSection.tsx
+++ b/components/sections/InvestorsSection.tsx
@@ -202,7 +202,7 @@ export function InvestorsSection() {
                 inheriting the account doesn&apos;t either. The asset that
                 makes either one useful is the same asset.
               </p>
-              <div className="close">
+              <div className="thesis-close">
                 Salency owns that layer. The longer a team runs it,{' '}
                 <em>the more context compounds</em> — and the harder it is to
                 rip out.

--- a/components/sections/InvestorsSection.tsx
+++ b/components/sections/InvestorsSection.tsx
@@ -120,7 +120,7 @@ export function InvestorsSection() {
                   Panda Bond and handled business development at Sequence and
                   Treasure. MBET, Waterloo.
                 </p>
-                <div className="fit">
+                <div className="founder-fit">
                   <div className="label">Unfair advantage</div>
                   <p>
                     Has <em>lost deals to forgotten context personally</em>, in
@@ -143,7 +143,7 @@ export function InvestorsSection() {
                   internally. Prior background in institutional client
                   management and AML/KYC compliance in banking.
                 </p>
-                <div className="fit">
+                <div className="founder-fit">
                   <div className="label">Unfair advantage</div>
                   <p>
                     Knows what sales ops <em>actually trusts</em>, how handoffs
@@ -166,7 +166,7 @@ export function InvestorsSection() {
                   Previously scaled a B2B marketplace to meaningful ARR as an
                   applied-AI operator — not a research hire.
                 </p>
-                <div className="fit">
+                <div className="founder-fit">
                   <div className="label">Unfair advantage</div>
                   <p>
                     The core technical risk in Salency is not &ldquo;can an LLM

--- a/components/sections/ProblemSection.tsx
+++ b/components/sections/ProblemSection.tsx
@@ -50,7 +50,7 @@ export function ProblemSection() {
             asking again.
           </p>
           <div className="cost">
-            <span className="num">40–50%</span>
+            <span className="figure">40–50%</span>
             <span className="label">
               of customers visibly frustrated when asked to repeat themselves ·
               Customer interview, Jan 2026


### PR DESCRIPTION
Chunk D from #56 — cryptic 2-3 letter class aliases renamed to scoped descriptive names. Eight commits, per-concern. Zero visual change; every change is either a rename or an alignment of a JSX/CSS mismatch.

## The renames

| Commit | Was | Now | Where |
|---|---|---|---|
| `4521c01` | `.fit` | `.founder-fit` | `/investors` founder "Unfair advantage" block |
| `f2b56d1` | `.rev` | `.founder--reversed` | `/investors` alternating founder layout |
| `03cec36` | `.p2` | `.photo--violet` | `/investors` founder 2 photo hue |
| `03cec36` | `.p3` | `.photo--teal` | `/investors` founder 3 photo hue |
| `35421ff` | `.num` (data figure) | `.figure` | `.prob-card .cost` ("40-50%") |
| `35421ff` | `.num` (section index) | `.section-num` | `.team .sect-head` ("03.") |
| `b4fabb6` | `.close` | `.thesis-close` | `/investors` thesis card closer |
| `8cfd2db` | `.verb` | `.how-step-action` | `.how-step` h3 (Extract / Map / Remember) |
| `ca01736` | CSS `.arr` | CSS `.arrow` | hub breadcrumb — JSX always used `.arrow`; CSS was wrong (same bug pattern as `.hub-input-lbl` fix in PR #73) |

`.num` was pulling double duty on two different semantic roles. Split.

The hub `.arr` / `.arrow` mismatch meant the ink-4 styling on the breadcrumb arrows between "Inputs" and "Outputs" never applied. The arrows inherited parent color, which was copper — making them visually identical to the surrounding text. Now they're the muted ink-4 they were supposed to be.

## Short aliases kept as intentional domain jargon (whitelisted)

`.eb`, `.sep`, `.sub`, `.pill`, `.dim` — widely understood in this codebase, documented in DESIGN.md §6. New cryptic aliases shouldn't be invented; if one is genuinely needed, add it to the whitelist with justification.

## DESIGN.md §6 — naming convention

Commit `c45b3a9` adds the naming convention table + rename log to DESIGN.md:
- Block (`.founder`)
- Element (`.founder .bio`, nested under block)
- Modifier (`.founder--reversed`, BEM-style `--suffix`)
- State (`.is-open`, `.has-image`)
- Utility / primitive (short alias, whitelisted only)

Going forward: scoped descriptive names by default. Short aliases only from the whitelist or with a new justified entry.

## Files
| File | Change |
|---|---|
| `app/globals.css` | 8 rename/mismatch fixes across the file |
| `components/sections/InvestorsSection.tsx` | `className` renames: `fit → founder-fit`, `rev → founder--reversed`, `p2 → photo--violet`, `p3 → photo--teal`, `num → section-num`, `close → thesis-close` |
| `components/sections/HowItWorksSection.tsx` | 3 `verb → how-step-action` |
| `components/sections/ProblemSection.tsx` | 1 `num → figure` |
| `DESIGN.md` | §6 naming convention + rename log |

## Test plan
- [ ] `npm run build` clean (verified — 14 routes per commit).
- [ ] `/investors` at 1280px: founder cards render identically — photos still show copper/violet/teal gradients in order, reversed layout still flips founder 2, "Unfair advantage" blocks still have the copper left-border, "03." section index still shows copper italic serif, thesis card closing line still has its top-border divider.
- [ ] `/why-salency`: "40-50%" data figure still in ink (demoted from copper in a prior PR — that still holds).
- [ ] `/` hub diagram: breadcrumb arrows `Inputs → Outputs` now render at muted ink-4 color instead of inheriting parent copper (visible fix).
- [ ] `/` how-it-works: three step verbs (Extract / Map / Remember) render with the same 34px clamped serif + copper em as before.

## Remaining #56 chunks
- Chunk E — section-container consolidation (`max-width:1280px; margin:... auto ...; padding:0 40px` repeats across `.how`, `.notdo`, `.notetaker`, `.cta-section`, `.prob`, `.mem-*`). Next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)