### PR TITLE
hotfix(css): restore .page em base rule

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -222,6 +222,8 @@ html {
      (e.g. .h1 em { font-style: normal }, .how-head .lede em { color:
      var(--ink) }) win by specificity where they need a different
      treatment. */
+  .page em { font-style: italic; color: var(--copper); }
+
   /* ═══════════ Hub diagram (replaces product mock) ═══════════ */
   .hub-wrap{
     max-width:1280px;margin:72px auto 0;padding:0 40px;


### PR DESCRIPTION
Critical hotfix. PR #74's bulk-delete regex for identical em one-liners matched the new `.page em` base rule itself and deleted it along with the 23 duplicates. Every emphasized word across the site lost its italic + copper accent. One-line restoration.