### PR TITLE
refactor(css): tokenize 1280px → --page-max (#56 chunk E)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -155,12 +155,12 @@ If it isn't a keyword, it's chrome. Chrome uses `--ink-*` and `--hair*`. Never i
 ### Section container
 
 ```css
-max-width: 1280px;
+max-width: var(--page-max);  /* resolves to 1280px */
 margin: 0 auto;
 padding: 0 40px;
 ```
 
-All investor-page sections (`.inv-intro`, `.platform`, `.roadmap`, `.team`, `.thesis`) share the canonical `1280px` container so every section lines up on one vertical spine. Legal pages use narrower.
+The `--page-max` token (declared in `:root`, currently `1280px`) is the single source of truth for the page-content band. 23 section containers across the site reference it. Change the token to change every container at once. Legal pages use narrower measures via their own rules.
 
 ### Section rhythm
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -178,6 +178,10 @@ html {
     --copper-a40: rgba(254,133,49,.4);
     --copper-a50: rgba(254,133,49,.5);
     --copper-a60: rgba(254,133,49,.6);
+    /* Layout: canonical page-content maximum width. Every section
+       container that centers into the 1280-wide band references this
+       token instead of the literal. */
+    --page-max: 1280px;
   }
   *{box-sizing:border-box}
   html,body{margin:0;background:var(--bg);color:var(--ink);-webkit-font-smoothing:antialiased}
@@ -226,7 +230,7 @@ html {
 
   /* ═══════════ Hub diagram (replaces product mock) ═══════════ */
   .hub-wrap{
-    max-width:1280px;margin:72px auto 0;padding:0 40px;
+    max-width:var(--page-max);margin:72px auto 0;padding:0 40px;
 
     .hub{
       position:relative;height:auto;
@@ -590,7 +594,7 @@ html {
     border-bottom:1px solid var(--hair);
   }
   .nav{
-    max-width:1280px;margin:0 auto;
+    max-width:var(--page-max);margin:0 auto;
     padding:16px 40px;
     display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:48px;
   }
@@ -676,7 +680,7 @@ html {
      viewed through the pricing-page lens. All layout/typography lives
      here so the JSX is semantic (no Tailwind utility soup). */
   .apply-page{
-    max-width:1280px;margin:40px auto 0;padding:20px 40px;
+    max-width:var(--page-max);margin:40px auto 0;padding:20px 40px;
 
     .apply-intro{max-width:48rem;margin-bottom:64px}
 
@@ -746,14 +750,14 @@ html {
 
   /* ═══════════ Hero ═══════════ */
   .hero{
-    max-width:1280px;margin:0 auto;
+    max-width:var(--page-max);margin:0 auto;
     padding:96px 40px 72px;
   }
   @media (max-width: 768px) {
     .hero { padding: 56px 22px 48px; }
   }
   .hero-hairline{
-    max-width:1280px;margin:0 auto;
+    max-width:var(--page-max);margin:0 auto;
     border-top:1px solid var(--hair);
   }
   .h1{
@@ -813,7 +817,7 @@ html {
 
   /* ═══════════ Problem section ═══════════ */
   .prob{
-    max-width:1280px;margin:40px auto 0;padding:20px 40px;
+    max-width:var(--page-max);margin:40px auto 0;padding:20px 40px;
   }
   .prob-head{
     display:grid;grid-template-columns:1fr 1.1fr;gap:64px;align-items:end;
@@ -933,7 +937,7 @@ html {
 
   /* ═══════════ CTA ═══════════ */
   .cta-section{
-    max-width:1280px;margin:140px auto 0;padding:0 40px 120px;
+    max-width:var(--page-max);margin:140px auto 0;padding:0 40px 120px;
   }
   @media (max-width: 768px) {
     .cta-section { margin-top: 80px; padding: 0 22px 64px; }
@@ -977,7 +981,7 @@ html {
   }
 
   /* ═══════════ How it works (Extract · Map · Remember) ═══════════ */
-  .how{max-width:1280px;margin:140px auto 0;padding:0 40px}
+  .how{max-width:var(--page-max);margin:140px auto 0;padding:0 40px}
   @media (max-width: 768px) {
     .how { margin-top: 80px; padding: 0 22px; }
   }
@@ -1071,7 +1075,7 @@ html {
   .how-foot .sep{color:var(--ink-4);margin:0 6px}
 
   /* ═══════════ NOT strip ═══════════ */
-  .notdo{max-width:1280px;margin:56px auto 0;padding:0 40px}
+  .notdo{max-width:var(--page-max);margin:56px auto 0;padding:0 40px}
   @media (max-width: 768px) {
     .notdo { margin-top: 40px; padding: 0 22px; }
   }
@@ -1124,7 +1128,7 @@ html {
   }
 
   /* ═══════════ Notetaker comparison table ═══════════ */
-  .notetaker{max-width:1280px;margin:140px auto 0;padding:0 40px}
+  .notetaker{max-width:var(--page-max);margin:140px auto 0;padding:0 40px}
   @media (max-width: 768px) {
     .notetaker { margin-top: 80px; padding: 0 22px; }
   }
@@ -1261,7 +1265,7 @@ html {
 
   /* Platform framing */
   .platform{
-    max-width:1280px;margin:0 auto;padding:0 40px;
+    max-width:var(--page-max);margin:0 auto;padding:0 40px;
 
     .eb{margin-bottom:28px;display:flex}
     h2{
@@ -1292,7 +1296,7 @@ html {
 
   /* Moat framing — why the data lives on Salency, not Salesforce (§6 platform-native posture, §8 uncopyable pair) */
   .moat{
-    max-width:1280px;margin:80px auto 0;padding:0 40px;
+    max-width:var(--page-max);margin:80px auto 0;padding:0 40px;
 
     .eb{margin-bottom:28px;display:flex}
     h2{
@@ -1323,7 +1327,7 @@ html {
 
   /* V1.5 roadmap */
   .roadmap{
-    max-width:1280px;margin:80px auto 0;padding:0 40px;
+    max-width:var(--page-max);margin:80px auto 0;padding:0 40px;
 
     .roadmap-card{
       padding:22px 28px;border:1px solid var(--hair-2);border-radius:10px;
@@ -1345,7 +1349,7 @@ html {
 
   /* Team */
   .team{
-    max-width:1280px;margin:100px auto 0;padding:0 40px;
+    max-width:var(--page-max);margin:100px auto 0;padding:0 40px;
 
     .sect-head{
       margin-bottom:64px;display:grid;grid-template-columns:auto 1fr;gap:28px;align-items:baseline;
@@ -1413,7 +1417,7 @@ html {
   }
 
   /* Future-fit thesis */
-  .thesis{max-width:1280px;margin:100px auto 0;padding:0 40px 20px}
+  .thesis{max-width:var(--page-max);margin:100px auto 0;padding:0 40px 20px}
   .thesis-card{
     padding:56px 64px;background:rgba(255,255,255,.02);
     border:1px solid var(--hair-2);border-radius:16px;position:relative;overflow:hidden;
@@ -1444,7 +1448,7 @@ html {
   footer{
     border-top:1px solid var(--hair);
     padding:40px;
-    max-width:1280px;margin:0 auto;
+    max-width:var(--page-max);margin:0 auto;
     display:flex;justify-content:space-between;align-items:center;gap:24px;flex-wrap:wrap;
     font-family:'Geist Mono',monospace;font-size:11px;color:var(--ink-4);
     letter-spacing:.04em;
@@ -1478,7 +1482,7 @@ html {
   }
 
   .inv-intro{
-    max-width:1280px;margin:40px auto 0;padding:20px 40px;
+    max-width:var(--page-max);margin:40px auto 0;padding:20px 40px;
     border-bottom:1px solid var(--hair);position:relative;
 
     &::after{
@@ -1658,7 +1662,7 @@ header button:focus:not(:focus-visible){
 
 /* ═══════════ Coming-soon stub pages ═══════════ */
 .coming-soon{
-  max-width:1280px;margin:80px auto 0;padding:20px 40px;
+  max-width:var(--page-max);margin:80px auto 0;padding:20px 40px;
 }
 .coming-soon-inner{max-width:780px}
 .coming-soon .eb{margin-bottom:24px}
@@ -1777,7 +1781,7 @@ header button:focus:not(:focus-visible){
 .memory-page {
   /* ── Intro (matches standalone canonical per DESIGN.md §4) ── */
   .mem-intro {
-    max-width: 1280px;
+    max-width:var(--page-max);
     margin: 40px auto 0;
     padding: 20px 40px;
 
@@ -2105,7 +2109,7 @@ header button:focus:not(:focus-visible){
 
   /* ── Supporting surfaces 02 / 03 / 04 ── */
   .mem-supporting {
-    max-width: 1280px;
+    max-width:var(--page-max);
     margin: 120px auto 0;
     padding: 0 40px;
   }
@@ -2291,7 +2295,7 @@ header button:focus:not(:focus-visible){
 
   /* ── CRM vs Salency compare ── */
   .mem-compare {
-    max-width: 1280px;
+    max-width:var(--page-max);
     margin: 120px auto 0;
     padding: 0 40px;
   }
@@ -2367,7 +2371,7 @@ header button:focus:not(:focus-visible){
 
   /* ── Transcript sources ── */
   .mem-compat {
-    max-width: 1280px;
+    max-width:var(--page-max);
     margin: 96px auto 0;
     padding: 32px 40px;
     border-top: 1px solid var(--hair);
@@ -2405,7 +2409,7 @@ header button:focus:not(:focus-visible){
 
   /* ── Pilot CTA ── */
   .mem-cta {
-    max-width: 1280px;
+    max-width:var(--page-max);
     margin: 96px auto 120px;
     padding: 0 40px;
     text-align: center;


### PR DESCRIPTION
Final chunk under #56 CSS consolidation work.

## What changed

23 section containers across \`globals.css\` used the literal \`max-width: 1280px\`. Extract to a single \`--page-max\` token in \`:root\` alongside the \`--copper-*\` ladder. Every container now references the token.

**Before:**
\`\`\`css
.hub-wrap  { max-width: 1280px; ... }
.hero      { max-width: 1280px; ... }
.how       { max-width: 1280px; ... }
/* ... 20 more ... */
\`\`\`

**After:**
\`\`\`css
:root { --page-max: 1280px; }

.hub-wrap  { max-width: var(--page-max); ... }
.hero      { max-width: var(--page-max); ... }
.how       { max-width: var(--page-max); ... }
/* ... 20 more ... */
\`\`\`

Change the token to shift every section's content band at once. Source of truth moved from 23 literals to one declaration.

Zero visual change — every resolved value is still 1280px.

## DESIGN.md

§4 "Section container" block updated to reference the token:
\`\`\`css
max-width: var(--page-max);  /* resolves to 1280px */
\`\`\`

## Files
- \`app/globals.css\` +1 token declaration, 23 literal replacements (net -25/+29 lines due to formatting).
- \`DESIGN.md\` §4 reference updated.

## Test plan
- [ ] \`npm run build\` clean (verified — 14 routes).
- [ ] Every page at 1440px+: content bands are unchanged. Hero, sections, intros all hit 1280px max-width and center.
- [ ] Mobile (≤768px) still hits viewport edge minus gutter as before.

## Chunk status (#56 tracking)
- ✅ Chunk A — Copper-alpha tokens + dead CSS sweep (PR #57 + #73)
- ✅ Chunk apply-page — naming + layout-to-CSS (PR #59)
- ✅ Chunk B — \`.eb\` + em consolidation (PR #74, hotfix #76)
- ✅ Chunk C — PageClient extraction + 10 dead components deleted (PR #73)
- ✅ Chunk D — cryptic rename pass (\`.fit\`, \`.rev\`, \`.p2\`, \`.p3\`, \`.num\`, \`.close\`, \`.verb\`, \`.arr\`) + DESIGN.md §6 naming convention (PR #75)
- ✅ Chunk E — section-container tokenization (this PR)

#56 can close after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)