### PR TITLE
content: expand "AE" → "account executive" in marketing copy (closes #78)

### DIFF
--- a/components/sections/CtaSection.tsx
+++ b/components/sections/CtaSection.tsx
@@ -12,9 +12,9 @@ export function CtaSection() {
           Stop paying the <em>ramp-time tax.</em>
         </h2>
         <p className="sub">
-          Most AEs take months to ramp. Every week of that is revenue on the
-          floor. A memory layer that outlasts any rep, so the next hire
-          inherits a Day-1 brief instead of starting from zero.
+          Most account executives take months to ramp. Every week of that is
+          revenue on the floor. A memory layer that outlasts any rep, so the
+          next hire inherits a Day-1 brief instead of starting from zero.
         </p>
         <div className="btns">
           <button

--- a/components/sections/GongSection.tsx
+++ b/components/sections/GongSection.tsx
@@ -74,8 +74,8 @@ export function GongSection() {
               moments
             </td>
             <td className="col-s">
-              <span className="icon">✓</span>AE, CSM, director — every role on
-              the account, on demand
+              <span className="icon">✓</span>Account executive, customer success
+              manager, director — every role on the account, on demand
             </td>
           </tr>
           <tr>

--- a/components/sections/HubSection.tsx
+++ b/components/sections/HubSection.tsx
@@ -251,12 +251,14 @@ export function HubSection() {
           <div className="hub-outcome-eb">Outcome</div>
           <div className="hub-outcome-grid">
             <div className="hub-outcome-row">
-              <div className="hub-outcome-role">New AE</div>
+              {/* Kept abbreviated for diagram density. aria-label gives
+                  screen readers the spelled-out role. */}
+              <div className="hub-outcome-role" aria-label="New account executive">New AE</div>
               <div className="hub-outcome-role-title">Inherits the account</div>
               <div className="hub-outcome-role-summary">Every pain, objection, and commitment from prior calls</div>
             </div>
             <div className="hub-outcome-row">
-              <div className="hub-outcome-role">CSM</div>
+              <div className="hub-outcome-role" aria-label="Customer success manager">CSM</div>
               <div className="hub-outcome-role-title">Picks up the relationship</div>
               <div className="hub-outcome-role-summary">Cited pain-to-product mappings, no re-asking</div>
             </div>

--- a/components/sections/InvestorsSection.tsx
+++ b/components/sections/InvestorsSection.tsx
@@ -114,7 +114,8 @@ export function InvestorsSection() {
                 <div className="name">Howard Tam</div>
                 <div className="role">Co-founder &amp; CEO</div>
                 <p className="bio">
-                  Founding AE at <em>Viggle</em> (a16z-backed), where he ran
+                  Founding account executive at <em>Viggle</em> (a16z-backed),
+                  where he ran
                   pilot-to-paid motions with the exact B2B buyers Salency sells
                   to today. Before that, he led MUFG Hong Kong&apos;s first
                   Panda Bond and handled business development at Sequence and

--- a/components/sections/MemorySection.tsx
+++ b/components/sections/MemorySection.tsx
@@ -104,8 +104,9 @@ export function MemorySection() {
           <p className="lede">
             Every call your team runs becomes{' '}
             <em>structured, cited, queryable</em> context, mapped to your product
-            catalog and tied to the rep who heard it. The new AE inherits a Day-1
-            brief. The CS director picks up mid-story. Nothing is re-asked.
+            catalog and tied to the rep who heard it. The new account executive
+            inherits a Day-1 brief. The CS director picks up mid-story. Nothing
+            is re-asked.
           </p>
         </section>
       </ScrollReveal>
@@ -216,7 +217,7 @@ export function MemorySection() {
               </h3>
               <p className="support-desc">
                 Every extracted pain ranked against your catalog, confidence-scored.
-                Three upsells queued before the AE has ended the call.
+                Three upsells queued before the account executive has ended the call.
               </p>
               <div className="support-mock pp-mock">
                 <div className="pp-row">
@@ -276,8 +277,9 @@ export function MemorySection() {
                 <em>Handoff export</em>
               </h3>
               <p className="support-desc">
-                One-click markdown. The new AE gets a brief. The CS director gets
-                a handoff. Nobody gets &ldquo;I wasn&rsquo;t in that call.&rdquo;
+                One-click markdown. The new account executive gets a brief.
+                The CS director gets a handoff. Nobody gets &ldquo;I wasn&rsquo;t
+                in that call.&rdquo;
               </p>
               <div className="support-mock hx-mock">
                 <div className="hx-line"># Acme Corp — handoff</div>

--- a/components/sections/ProblemSection.tsx
+++ b/components/sections/ProblemSection.tsx
@@ -44,7 +44,8 @@ export function ProblemSection() {
             Every handoff restarts from <em>zero.</em>
           </h3>
           <p className="desc">
-            A new AE picks up the account. A CS director inherits at renewal.
+            A new account executive picks up the account. A CS director
+            inherits at renewal.
             Neither gets the pain history, the stakeholder map, or the promises
             made. They rebuild the relationship by calling the customer and
             asking again.


### PR DESCRIPTION
Closes #78. Prospects reading the site include VP Sales, CS directors, ops leaders, and investors — not every reader parses "AE" instantly, and the abbreviation reads as inside-baseball alongside spelled-out role names like "CS director" and "VP Sales." Spell it out in body copy; keep abbreviations only where they're in-character or where the layout needs them.

## Expansions (7 edits)

| File | Line | Before | After |
|---|---|---|---|
| `CtaSection.tsx` | 15 | "Most **AEs** take months to ramp" | "Most **account executives** take months to ramp" |
| `ProblemSection.tsx` | 47 | "A new **AE** picks up the account" | "A new **account executive** picks up the account" |
| `MemorySection.tsx` | 107 | "The new **AE** inherits a Day-1 brief" | "The new **account executive** inherits a Day-1 brief" |
| `MemorySection.tsx` | 220 | "before the **AE** has ended the call" | "before the **account executive** has ended the call" |
| `MemorySection.tsx` | 280 | "The new **AE** gets a brief" | "The new **account executive** gets a brief" |
| `GongSection.tsx` | 77 | "**AE, CSM,** director" | "**Account executive, customer success manager,** director" |
| `InvestorsSection.tsx` | 117 | "Founding **AE** at Viggle" | "Founding **account executive** at Viggle" |

`CSM` in GongSection row expanded alongside AE for row consistency — mixing one spelled-out + one abbreviated + one spelled-out (director) read as drift.

## Intentional exceptions (kept abbreviated)

- **`MemorySection.tsx:28`** — the PEOPLE data quote from Priya Shah, VP Sales. It's dialogue attributed to a persona; salespeople actually say "AE." Spelling it out breaks the voice.
- **`HubSection.tsx:254-261`** — the hub-outcome role chips ("New AE", "CSM") are small mono-caps diagram labels with `.2em` letter-spacing. Spelling out would ~3× the width and break the 3-col grid. Added `aria-label="New account executive"` / `aria-label="Customer success manager"` so screen readers still get the full term. Sighted users see the tight chip; assistive tech gets the semantic role.

## Test plan
- [ ] `npm run build` clean (verified — 14 routes).
- [ ] Spot-check `/` hero+CTA+how-it-works+not-strip+hub, `/memory` lede + support cards, `/investors` founder bio, `/why-salency` prob-card desc + notetaker table row. All renders of "AE" in body copy are expanded.
- [ ] `/` hub diagram: role chips still fit their columns at 1280px (no wrapping or overflow into adjacent cells).
- [ ] Screen reader pass on the hub outcome area: "New account executive, inherits the account..." / "Customer success manager, picks up..."
- [ ] In-character quote on `/memory` first brief block reads "Handoff loses context every time an AE rotates off." — still "AE" (deliberate).

## Out of scope
- Email templates in `app/api/send/route.ts` — 1-to-1 transactional messages, not marketing.
- README / internal docs — not user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)