### PR TITLE
fix(typography): Instrument Sans actually renders site-wide (P0 from design audit)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -47,7 +47,11 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
+  /* Brand typeface goes first so Tailwind Preflight's ui-sans-serif
+     default can't win the cascade. Instrument Sans loads via next/font
+     in app/layout.tsx; --font-instrument-sans is scoped to <body>
+     through the className. Geist + system-ui are hard fallbacks. */
+  font-family: var(--font-instrument-sans), var(--font-geist-sans), 'Instrument Sans', system-ui, sans-serif;
   overflow-x: hidden;
 }
 
@@ -185,7 +189,11 @@ html {
   }
   *{box-sizing:border-box}
   html,body{margin:0;background:var(--bg);color:var(--ink);-webkit-font-smoothing:antialiased}
-  body{font-family:var(--font-body), 'Geist','Outfit',system-ui,sans-serif;font-size:15px;line-height:1.55;font-weight:400}
+  /* Reference --font-instrument-sans directly (skipping --font-body
+     indirection) because --font-body's declaration has trouble
+     resolving through Tailwind's theme layer. Instrument Sans is
+     the canonical brand typeface; Geist stays as a hard fallback. */
+  body{font-family:var(--font-instrument-sans), 'Instrument Sans', var(--font-geist-sans), 'Geist', system-ui, sans-serif;font-size:15px;line-height:1.55;font-weight:400}
   a{color:inherit;text-decoration:none}
 
   /* ambient glow removed — Anthropic-style clean hero */
@@ -1567,8 +1575,12 @@ html {
   }
 
 /* ═══════════ Marketing font mapping ═══════════ */
-/* Bind --font-body / --font-display to next/font variables. */
-:root{
+/* Bind --font-body / --font-display to next/font variables.
+   These live on body (not :root) because --font-instrument-sans is
+   scoped to <body> through the className next/font injects — at
+   :root, var(--font-instrument-sans) resolves to invalid and the
+   whole --font-body chain collapses to the browser default. */
+body {
   --font-body: var(--font-instrument-sans), 'Instrument Sans', system-ui, sans-serif;
   --font-display: var(--font-instrument-sans), 'Instrument Sans', system-ui, sans-serif;
 }


### PR DESCRIPTION
P0 finding from the live-browser design audit under #81. The site was rendering in `ui-sans-serif` (macOS SF Pro / Windows Segoe UI) on every page, every heading, every paragraph — even though Instrument Sans loads via `next/font` and DESIGN.md calls it the brand typeface. Everyone looking at the live site has been seeing the system sans-serif default.

## What was broken

Three interacting bugs, all cascade-level:

1. `app/globals.css:47` body rule referenced `var(--font-geist-sans)` as primary — not wrong as a fallback, but wrong as the first choice given Instrument Sans is the brand face.
2. `app/globals.css:192` marketing body rule referenced `var(--font-body)`, which pointed at `var(--font-instrument-sans)` via an intermediate `:root` declaration. But `--font-instrument-sans` is scoped to `<body>` (that's how `next/font` works — the font variable goes on the className added to `<body>`, not `<html>`), so when `:root` tried to resolve `var(--font-instrument-sans)`, it got invalid/empty. The whole `--font-body` chain collapsed to the browser default.
3. Combined effect: Tailwind v4's Preflight base `body { font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif) }` was the last rule that actually computed to anything valid, and it resolved to `ui-sans-serif` (since `--default-font-family` went through the same broken chain).

## Three fixes

### 1. `body` font-family at line 47 now references `--font-instrument-sans` first

```css
body {
  font-family: var(--font-instrument-sans), var(--font-geist-sans), 'Instrument Sans', system-ui, sans-serif;
}
```

Wins the cascade against Tailwind Preflight's default.

### 2. Marketing body rule at line 192 now references `--font-instrument-sans` directly

Was: `font-family: var(--font-body), 'Geist', 'Outfit', system-ui, sans-serif`.
Now: `font-family: var(--font-instrument-sans), 'Instrument Sans', var(--font-geist-sans), 'Geist', system-ui, sans-serif`.

Bypasses the broken `--font-body` indirection. Direct reference resolves at body scope where `--font-instrument-sans` is actually defined.

### 3. `--font-body` + `--font-display` declarations moved from `:root` to `body`

```css
/* Before — broken at :root because --font-instrument-sans is scoped to <body> */
:root {
  --font-body: var(--font-instrument-sans), 'Instrument Sans', system-ui, sans-serif;
  --font-display: var(--font-instrument-sans), 'Instrument Sans', system-ui, sans-serif;
}

/* After — works because the dependency is in scope */
body {
  --font-body: var(--font-instrument-sans), 'Instrument Sans', system-ui, sans-serif;
  --font-display: var(--font-instrument-sans), 'Instrument Sans', system-ui, sans-serif;
}
```

~40 rules across the file reference `var(--font-body)` for body-weight text; they all pick up the correct Instrument Sans stack now.

## Verified in live browser

`getComputedStyle(document.body).fontFamily` on each route now returns:

```
"Instrument Sans", "Instrument Sans Fallback", "Instrument Sans", Geist, "Geist Fallback", Geist, system-ui, sans-serif
```

Confirmed on `/`, `/why-salency`, `/memory`, `/investors`, `/pilot`, `/pricing`.

Headings (`h1`, `h2`, `h3`) all render Instrument Sans as first choice.
`.eb` eyebrows still render `Geist Mono` (unaffected).
`em` copper accents still render italic copper (unaffected).
Everything else that used `var(--font-body)` now resolves correctly.

## Impact

The whole brand typography — copper em accents, serif display ems, mono-caps eyebrows, the editorial feel of the whole site — now layers on top of Instrument Sans as designed, instead of looking like it was layered on top of the default OS sans.

If you've been doing design review, visual QA, or just squinting at the live site over the past N days thinking "something feels off" — this is probably it. Load the preview and the whole site snaps into place.

## Test plan
- [ ] `npm run build` clean (verified).
- [ ] Visit Vercel preview on desktop Safari/Chrome — headlines render in Instrument Sans, not SF Pro.
- [ ] Visit on Windows Edge — renders in Instrument Sans, not Segoe UI.
- [ ] Visit on iOS Safari — renders in Instrument Sans, not SF Pro.
- [ ] No regression on `.eb` (Geist Mono) or `em` (copper italic).

## Next up from the audit
- P0-2 `/pricing` shows "Join the pilot" as headline — product decision, awaiting your call.
- P1 items: EmailForm focus-ring, "Request a pilot →" height 42px, body-em color unification. Separate PR when approved.

**Not auto-merging. Awaiting your review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)