### PR TITLE
feat(motion): page first-load fade-up on all routes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -134,6 +134,22 @@ h6 {
   }
 }
 
+/* Page first-load fade-up — fires on initial paint + client-side nav (element remounts) */
+@keyframes page-reveal {
+  from { opacity: 0; transform: translateY(24px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.page {
+  animation: page-reveal 0.7s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .page {
+    animation: none;
+  }
+}
+
 html {
   scroll-behavior: smooth;
   scroll-padding-top: 100px; /* sticky header (~76px) + breathing room for hash-anchor jumps */


### PR DESCRIPTION
## Summary
- Extends the `/memory` entrance animation (ScrollReveal) to every route via a single `.page` keyframe.
- Fires on initial SSR paint and on client-side nav (`.page` remounts per route).
- Respects `prefers-reduced-motion`.

Single CSS-only change in `app/globals.css`. No React or page-component edits.

## Test plan
- [ ] `/`, `/memory`, `/investors`, `/why-salency`, `/pilot`, `/pricing` all fade up on first load
- [ ] Client-side nav between routes replays the fade
- [ ] With OS "reduce motion" on, no animation fires