### PR TITLE
style(design): shared hero backdrop on all routes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -756,6 +756,32 @@ html {
     }
   }
 
+  /* ═══════════ Shared hero backdrop (copper ellipse glow) ═══════════
+     Mirrors the investor register pattern: pseudo at z-index:0, children
+     lifted to z-index:1. Avoids `isolation: isolate` + negative z-index
+     (which clips the pseudo below the element's own paint layer). */
+  .hero,
+  .mem-intro,
+  .prob,
+  .apply-page{
+    position:relative;
+  }
+  .hero::before,
+  .mem-intro::before,
+  .prob::before,
+  .apply-page::before{
+    content:"";
+    position:absolute;top:-200px;left:50%;transform:translateX(-50%);
+    width:1400px;height:900px;pointer-events:none;z-index:0;
+    background:radial-gradient(ellipse at center, var(--copper-a14) 0%, var(--copper-a04) 30%, transparent 60%);
+  }
+  .hero > *,
+  .mem-intro > *,
+  .prob > *,
+  .apply-page > *{
+    position:relative;z-index:1;
+  }
+
   /* ═══════════ Hero ═══════════ */
   .hero{
     max-width:var(--page-max);margin:0 auto;


### PR DESCRIPTION
## Summary
- Lifts the investor-register copper ellipse glow to a grouped selector so `/`, `/memory`, `/why-salency`, `/pilot`, `/pricing` share the same ambient hero light.
- Uses the investor pattern (pseudo `z-index:0` + children `z-index:1`) instead of `isolation: isolate` + negative z-index. The latter clipped the pseudo below the hero's own paint layer on `/`.
- CSS-only. No JSX touched.

## Test plan
- [ ] `/investors` unchanged (baseline)
- [ ] `/` hero shows warm copper glow behind "Institutional memory for revenue teams."
- [ ] `/memory` intro + Day-1 brief card carry the glow once ScrollReveal fade completes
- [ ] `/why-salency` "Knowledge walks out the door" hero carries the glow
- [ ] `/pilot` and `/pricing` hero areas carry the glow
- [ ] Mobile: glow centered, clipped by `.page { overflow-x: clip }`, no horizontal scroll