### PR TITLE
feat(motion): per-section ScrollReveal on all routes (replaces PR #84)

### DIFF
--- a/app/investors/page.tsx
+++ b/app/investors/page.tsx
@@ -1,4 +1,5 @@
 import { MarketingHeader } from '@/components/MarketingHeader';
+import { ScrollReveal } from '@/components/ScrollReveal';
 import { InvestorsSection } from '@/components/sections/InvestorsSection';
 import { SiteFooter } from '@/components/sections/SiteFooter';
 
@@ -6,7 +7,7 @@ export default function InvestorsPage() {
   return (
     <div className="page">
       <MarketingHeader />
-      <InvestorsSection />
+      <ScrollReveal><InvestorsSection /></ScrollReveal>
       <SiteFooter />
     </div>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import { MarketingHeader } from '@/components/MarketingHeader';
+import { ScrollReveal } from '@/components/ScrollReveal';
 import { HeroSection } from '@/components/sections/HeroSection';
 import { HubSection } from '@/components/sections/HubSection';
 import { HowItWorksSection } from '@/components/sections/HowItWorksSection';
@@ -10,11 +11,11 @@ export default function Home() {
   return (
     <div className="page">
       <MarketingHeader />
-      <HeroSection />
-      <HubSection />
-      <HowItWorksSection />
-      <NotDoSection />
-      <CtaSection />
+      <ScrollReveal><HeroSection /></ScrollReveal>
+      <ScrollReveal><HubSection /></ScrollReveal>
+      <ScrollReveal><HowItWorksSection /></ScrollReveal>
+      <ScrollReveal><NotDoSection /></ScrollReveal>
+      <ScrollReveal><CtaSection /></ScrollReveal>
       <SiteFooter />
     </div>
   );

--- a/app/pilot/page.tsx
+++ b/app/pilot/page.tsx
@@ -1,4 +1,5 @@
 import { MarketingHeader } from '@/components/MarketingHeader';
+import { ScrollReveal } from '@/components/ScrollReveal';
 import { PilotApplication } from '@/components/sections/PilotApplication';
 import { SiteFooter } from '@/components/sections/SiteFooter';
 
@@ -12,7 +13,7 @@ export default function PilotPage() {
   return (
     <div className="page">
       <MarketingHeader />
-      <PilotApplication />
+      <ScrollReveal><PilotApplication /></ScrollReveal>
       <SiteFooter />
     </div>
   );

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,4 +1,5 @@
 import { MarketingHeader } from '@/components/MarketingHeader';
+import { ScrollReveal } from '@/components/ScrollReveal';
 import { PilotApplication } from '@/components/sections/PilotApplication';
 import { SiteFooter } from '@/components/sections/SiteFooter';
 
@@ -12,7 +13,7 @@ export default function PricingPage() {
   return (
     <div className="page">
       <MarketingHeader />
-      <PilotApplication />
+      <ScrollReveal><PilotApplication /></ScrollReveal>
       <SiteFooter />
     </div>
   );

--- a/app/why-salency/page.tsx
+++ b/app/why-salency/page.tsx
@@ -1,4 +1,5 @@
 import { MarketingHeader } from '@/components/MarketingHeader';
+import { ScrollReveal } from '@/components/ScrollReveal';
 import { ProblemSection } from '@/components/sections/ProblemSection';
 import { GongSection } from '@/components/sections/GongSection';
 import { SiteFooter } from '@/components/sections/SiteFooter';
@@ -7,8 +8,8 @@ export default function WhySalencyPage() {
   return (
     <div className="page">
       <MarketingHeader />
-      <ProblemSection />
-      <GongSection />
+      <ScrollReveal><ProblemSection /></ScrollReveal>
+      <ScrollReveal><GongSection /></ScrollReveal>
       <SiteFooter />
     </div>
   );


### PR DESCRIPTION
## Summary
Matches `/memory`'s existing pattern: each top-level section is wrapped in `<ScrollReveal>` so it fades up when it enters the viewport. The first section fades in on initial paint (because it's already in view), which is the "on first load" effect `/memory` has.

Replaces the whole-page `.page` keyframe that shipped briefly in [PR #84](https://github.com/howardhwt/Salency-Landing-Page/pull/84). That fired every section at once, reading as "the page is appearing" instead of "content is arriving as you reach it." Per-section reveal is closer to the Apple-style restraint Brad Holmes described — if you don't notice it, it's working.

No new component, no new CSS. Uses the existing `ScrollReveal` primitive that `/memory` already ships.

## Pages touched
- `app/page.tsx` — wraps `HeroSection`, `HubSection`, `HowItWorksSection`, `NotDoSection`, `CtaSection`
- `app/investors/page.tsx` — wraps `InvestorsSection`
- `app/why-salency/page.tsx` — wraps `ProblemSection`, `GongSection`
- `app/pilot/page.tsx` + `app/pricing/page.tsx` — wraps `PilotApplication`

## Test plan
- [ ] First section on every route fades up on initial load
- [ ] Subsequent sections fade up as you scroll them into view
- [ ] No animation piled on top of per-section reveals (no `.page` keyframe)
- [ ] `prefers-reduced-motion` respected (already handled in `ScrollReveal.tsx`)