### PR TITLE
content: polish memory page footer sections

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -212,14 +212,11 @@ html {
      breadcrumb (inherits smaller font + no decoration from parent);
      the CTA card (centered layout, decoration would offset text);
      the NOT-strip dim header label (uses its own muted treatment);
-     the mem-cta (centered block eyebrow above the final CTA); and
-     the mem-compat strip (small muted ink eyebrow centered above
-     the transcript-sources line). */
+     the mem-cta (centered block eyebrow above the final CTA). */
   .hub-head .eb::before,
   .cta-card .eb::before,
   .notdo-card .header .eb::before,
-  .mem-cta .eb::before,
-  .mem-compat .eb::before{content:none}
+  .mem-cta .eb::before{content:none}
 
   /* Canonical em accent — display headings and body copy inside any
      .page root render em italic copper by default. Scoped overrides
@@ -2403,44 +2400,6 @@ header button:focus:not(:focus-visible){
     a:hover { border-bottom-color: var(--copper); }
   }
 
-  /* ── Transcript sources ── */
-  .mem-compat {
-    max-width:var(--page-max);
-    margin: 96px auto 0;
-    padding: 32px 40px;
-    border-top: 1px solid var(--hair);
-    border-bottom: 1px solid var(--hair);
-    text-align: center;
-
-    /* Muted centered eyebrow: overrides copper → ink-4, tracking
-       → .2em (vs canonical .18em), layout → block. */
-    .eb {
-      font-size: 10.5px;
-      letter-spacing: .2em;
-      color: var(--ink-4);
-      margin-bottom: 16px;
-      display: block;
-    }
-  }
-
-  .mem-compat-line {
-    font-family: var(--font-body), 'Instrument Sans', system-ui, sans-serif;
-    font-weight: 400;
-    font-size: 16px;
-    line-height: 1.6;
-    color: var(--ink-2);
-    max-width: 68ch;
-    margin: 0 auto;
-
-    em {
-      font-family: var(--font-display), 'Instrument Sans', system-ui, sans-serif;
-      font-style: italic;
-      color: var(--ink);
-      font-size: 17px;
-      font-weight: 400;
-    }
-  }
-
   /* ── Pilot CTA ── */
   .mem-cta {
     max-width:var(--page-max);
@@ -2561,10 +2520,6 @@ header button:focus:not(:focus-visible){
       color: var(--copper);
       margin-bottom: 3px;
     }
-
-    .mem-compat { margin-top: 72px; padding: 24px 22px; }
-    .mem-compat-line { font-size: 15px; }
-    .mem-compat-line em { font-size: 16px; }
 
     .mem-cta { margin: 72px auto 72px; padding: 0 22px; }
   }

--- a/components/sections/MemorySection.tsx
+++ b/components/sections/MemorySection.tsx
@@ -330,38 +330,24 @@ export function MemorySection() {
         </section>
       </ScrollReveal>
 
-      {/* ─── Transcript sources ─── */}
-      <ScrollReveal>
-        <section className="mem-compat">
-          <span className="eb">Transcript sources</span>
-          <p className="mem-compat-line">
-            Bring transcripts from{' '}
-            <em>Gong, Fathom, Fireflies, Otter, Zoom</em>, or raw .vtt / .txt.
-            Paste or upload &mdash; takes about a minute per call.
-          </p>
-        </section>
-      </ScrollReveal>
-
       {/* ─── Pilot CTA ─── */}
-      <ScrollReveal>
-        <section className="mem-cta">
-          <span className="eb">Pilot cohort &middot; Spring 2026</span>
-          <h2>
-            Inherit every account&rsquo;s <em>memory</em> from Day 1.
-          </h2>
-          <p className="sub">
-            We&rsquo;re onboarding a small group of revenue teams this cohort.
-            Tell us about your team and we&rsquo;ll scope the fit together.
-          </p>
-          <button
-            type="button"
-            className="btn btn-primary"
-            onClick={() => openPilotModal()}
-          >
-            Request a pilot &rarr;
-          </button>
-        </section>
-      </ScrollReveal>
+      <section className="mem-cta">
+        <span className="eb">Pilot cohort &middot; Spring 2026</span>
+        <h2>
+          Inherit every account&rsquo;s <em>memory</em> from Day 1.
+        </h2>
+        <p className="sub">
+          First account memory stands up in a week. By month two, the rep
+          inheriting it reads the story, not a notes field.
+        </p>
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={() => openPilotModal()}
+        >
+          Request a pilot &rarr;
+        </button>
+      </section>
     </>
   );
 }


### PR DESCRIPTION
## Summary

Trim the memory page tail so it ends on the moat argument, not on pipeline mechanics.

**Content**
- Rewrite `mem-cta` sub to close the memory narrative: *"First account memory stands up in a week. By month two, the rep inheriting it reads the story, not a notes field."* Replaces the generic cohort pitch.
- Remove the `mem-compat` transcript-sources section. After the CRM-vs-Salency table (row 4 is the pattern-across-accounts moat beat), dropping into a file-format list broke the proof-page voice.

**UI**
- Drop `ScrollReveal` wrapping from `mem-cta`. Conversion surface shouldn't fade-in delay the button.
- (`mem-compat` reveal removed with the section.)

**Cleanup**
- Delete orphaned `.mem-compat` / `.mem-compat-line` rules, mobile overrides, and eyebrow-list entry from `app/globals.css`.

## Test plan
- [ ] Vercel preview: memory page ends on CRM-vs-Salency table + pilot CTA (no transcript-sources strip between).
- [ ] `mem-cta` sub copy reads as specified; CTA button still opens pilot modal.
- [ ] No layout regressions on mobile (72px bottom margin preserved on `.mem-cta`).
- [ ] `grep -r mem-compat` returns zero matches across `components/` and `app/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)