### PR TITLE
content: rebuild /why-salency as D-architecture thesis page (9 sections)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2602,3 +2602,246 @@ header button:focus:not(:focus-visible){
   .pilot-modal-backdrop,
   .pilot-modal-panel { animation: none; }
 }
+
+/* ═══════════ /why-salency D-refactor ═══════════ */
+
+/* 01 · Thesis hero */
+.thesis-hero {
+  max-width: var(--page-max);
+  margin: 40px auto 0;
+  padding: 20px 40px;
+}
+.thesis-hero-inner h1 {
+  font-family: var(--font-display);
+  font-size: clamp(40px, 5.2vw, 64px);
+  line-height: 1.08;
+  letter-spacing: -.025em;
+  font-weight: 400;
+  color: var(--ink);
+  margin: 16px 0 24px;
+  max-width: 22ch;
+}
+.thesis-hero-inner h1 em { font-style: italic; color: var(--copper); }
+.thesis-hero-inner h1 .soft { color: var(--ink-3); }
+.thesis-hero-inner .lede {
+  font-size: 19px;
+  line-height: 1.6;
+  color: var(--ink-2);
+  max-width: 64ch;
+  margin-bottom: 48px;
+}
+.thesis-hero-meta {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border-top: 1px solid var(--hair-2);
+  border-bottom: 1px solid var(--hair-2);
+}
+.thesis-hero-cell {
+  padding: 24px 24px 24px 0;
+  border-right: 1px solid var(--hair);
+}
+.thesis-hero-cell:last-child { border-right: none; padding-right: 0; }
+.thesis-hero-cell:not(:first-child) { padding-left: 24px; }
+.thesis-hero-cell .label {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: .2em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin-bottom: 10px;
+  display: block;
+}
+.thesis-hero-cell p { font-size: 14.5px; line-height: 1.55; color: var(--ink-2); }
+
+/* 03 · Memory stack */
+.mem-stack { max-width: var(--page-max); margin: 120px auto 0; padding: 0 40px; }
+.mem-stack-head { margin-bottom: 48px; }
+.mem-stack-head h2 {
+  font-family: var(--font-display);
+  font-size: clamp(34px, 3.8vw, 48px);
+  line-height: 1.08;
+  letter-spacing: -.02em;
+  font-weight: 400;
+  color: var(--ink);
+  margin-top: 18px;
+  max-width: 28ch;
+}
+.mem-stack-head h2 em { font-style: italic; color: var(--copper); }
+.mem-stack-rows { border-top: 1px solid var(--hair-2); }
+.mem-stack-row {
+  display: grid;
+  grid-template-columns: 200px 200px 1fr;
+  gap: 32px;
+  padding: 28px 0;
+  border-bottom: 1px solid var(--hair);
+  align-items: baseline;
+}
+.mem-stack-row .layer-label { font-family: var(--font-display); font-size: 22px; font-weight: 500; color: var(--ink); }
+.mem-stack-row .layer-role { font-family: var(--font-mono); font-size: 11px; letter-spacing: .18em; text-transform: uppercase; color: var(--ink-3); }
+.mem-stack-row .layer-desc { font-size: 15.5px; line-height: 1.6; color: var(--ink-2); }
+.mem-stack-row .layer-desc em { color: var(--copper); font-style: italic; }
+.mem-stack-row--accent .layer-label { color: var(--copper); }
+
+/* 04 · Memory enables */
+.mem-enables { max-width: var(--page-max); margin: 120px auto 0; padding: 0 40px; }
+.mem-enables-head { margin-bottom: 48px; }
+.mem-enables-head h2 {
+  font-family: var(--font-display); font-size: clamp(34px, 3.8vw, 48px); line-height: 1.08;
+  letter-spacing: -.02em; font-weight: 400; color: var(--ink); margin-top: 18px;
+}
+.mem-enables-head h2 em { font-style: italic; color: var(--copper); }
+.mem-enables-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 28px; }
+.mem-enables-card {
+  background: rgba(255,255,255,.02);
+  border: 1px solid var(--hair-2);
+  border-radius: 14px;
+  padding: 32px;
+}
+.mem-enables-card .idx { font-family: var(--font-mono); font-size: 11px; letter-spacing: .2em; color: var(--ink-3); margin-bottom: 18px; }
+.mem-enables-card h3 { font-family: var(--font-display); font-size: 22px; font-weight: 500; color: var(--ink); margin-bottom: 14px; }
+.mem-enables-card h3 em { font-style: italic; color: var(--copper); }
+.mem-enables-card p { font-size: 15px; line-height: 1.6; color: var(--ink-2); margin-bottom: 20px; }
+.mem-enables-mock { border-top: 1px solid var(--hair); padding-top: 16px; font-family: var(--font-mono); font-size: 12px; }
+.pp-row { display: grid; grid-template-columns: 1fr 100px 40px; align-items: center; gap: 10px; padding: 8px 0; }
+.pp-row .pp-prod { color: var(--ink-2); }
+.pp-row .pp-bar { height: 4px; background: var(--hair); border-radius: 2px; overflow: hidden; }
+.pp-row .pp-fill { display: block; height: 100%; background: var(--ink-2); }
+.pp-row .pp-conf { color: var(--ink-3); text-align: right; }
+.cx-row { display: grid; grid-template-columns: 60px 1fr; gap: 12px; padding: 6px 0; }
+.cx-row .cx-date { color: var(--ink-3); }
+.cx-row .cx-quote { color: var(--ink); }
+.cx-arrow { color: var(--ink-3); text-align: center; margin: 4px 0; }
+
+/* 05 · Compounds (page visual anchor) */
+.compounds { max-width: var(--page-max); margin: 120px auto 0; padding: 0 40px; }
+.compounds-head { margin-bottom: 64px; }
+.compounds-head h2 {
+  font-family: var(--font-display); font-size: clamp(36px, 4vw, 54px); line-height: 1.06;
+  letter-spacing: -.02em; font-weight: 400; color: var(--ink); margin-top: 18px; max-width: 22ch;
+}
+.compounds-head h2 em { font-style: italic; color: var(--copper); }
+.compounds-timeline { position: relative; display: grid; grid-template-columns: repeat(4, 1fr); gap: 28px; padding-top: 48px; }
+.compounds-rail {
+  position: absolute; top: 24px; left: 0; right: 0; height: 2px;
+  background: linear-gradient(90deg, var(--copper), rgba(254,133,49,0));
+}
+.compounds-step { position: relative; padding-top: 24px; }
+.compounds-marker {
+  position: absolute; top: -32px; left: 0;
+  font-family: var(--font-mono); font-size: 11px; letter-spacing: .2em;
+  color: var(--copper); background: var(--bg); padding: 0 8px 0 0;
+}
+.compounds-step h4 { font-family: var(--font-display); font-size: 18px; font-weight: 500; color: var(--ink); margin-bottom: 10px; }
+.compounds-step p { font-size: 14.5px; line-height: 1.6; color: var(--ink-2); }
+.compounds-foot { margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--hair); font-size: 15px; color: var(--ink-3); max-width: 64ch; }
+
+/* 06 · Five-year bet */
+.fiveyear { max-width: var(--page-max); margin: 120px auto 0; padding: 0 40px; }
+.fiveyear-head { margin-bottom: 48px; }
+.fiveyear-head h2 {
+  font-family: var(--font-display); font-size: clamp(34px, 3.8vw, 48px); line-height: 1.08;
+  letter-spacing: -.02em; font-weight: 400; color: var(--ink); margin-top: 18px; max-width: 30ch;
+}
+.fiveyear-head h2 em { font-style: italic; color: var(--copper); }
+.fiveyear-beats {
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 0;
+  border-top: 1px solid var(--hair-2); border-bottom: 1px solid var(--hair-2);
+}
+.fiveyear-beat { padding: 28px 24px; border-right: 1px solid var(--hair); }
+.fiveyear-beat:last-child { border-right: none; }
+.fiveyear-beat .beat-idx { font-family: var(--font-mono); font-size: 10.5px; letter-spacing: .2em; color: var(--ink-3); margin-bottom: 12px; display: block; }
+.fiveyear-beat h3 { font-family: var(--font-display); font-size: 19px; font-weight: 500; line-height: 1.2; color: var(--ink); margin-bottom: 10px; }
+.fiveyear-beat p { font-size: 14.5px; line-height: 1.6; color: var(--ink-2); }
+.fiveyear-foot { margin-top: 28px; font-family: var(--font-mono); font-size: 13px; line-height: 1.65; color: var(--ink-3); max-width: 78ch; }
+
+/* 07b · Handoff tools comparison */
+.handoff-compare { max-width: var(--page-max); margin: 96px auto 0; padding: 0 40px; }
+.handoff-compare-head { margin-bottom: 32px; }
+.handoff-compare-head h2 {
+  font-family: var(--font-display); font-size: clamp(28px, 3vw, 38px); line-height: 1.1;
+  letter-spacing: -.02em; font-weight: 400; color: var(--ink); margin-top: 14px; max-width: 30ch;
+}
+.handoff-compare-head h2 em { font-style: italic; color: var(--copper); }
+.handoff-table { width: 100%; border-collapse: collapse; font-size: 15px; }
+.handoff-table th, .handoff-table td { text-align: left; padding: 16px 18px; border-bottom: 1px solid var(--hair); }
+.handoff-table th { font-family: var(--font-mono); font-size: 11px; letter-spacing: .18em; text-transform: uppercase; font-weight: 500; color: var(--ink-3); border-bottom: 1px solid var(--hair-2); }
+.handoff-table th .brand { display: block; font-family: var(--font-body); font-size: 11px; letter-spacing: 0; text-transform: none; color: var(--ink-4); margin-top: 3px; }
+.handoff-table td.dim { font-family: var(--font-mono); font-size: 12px; letter-spacing: .12em; text-transform: uppercase; color: var(--ink-3); }
+.handoff-table td .icon { color: var(--ink-3); margin-right: 10px; }
+.handoff-table td.col-s { background: rgba(254,133,49,.03); }
+.handoff-table td.col-s .icon { color: var(--copper); }
+.handoff-table td.col-s strong { color: var(--ink); font-weight: 500; }
+
+/* Gong table takeaway */
+.notetaker-takeaway { margin-top: 28px; font-family: var(--font-display); font-size: 18px; line-height: 1.5; color: var(--ink); max-width: 60ch; }
+.notetaker-takeaway em { font-style: italic; color: var(--copper); }
+
+/* 08 · Not for you */
+.notfor { max-width: var(--page-max); margin: 120px auto 0; padding: 0 40px; }
+.notfor-head { margin-bottom: 40px; }
+.notfor-head h2 { font-family: var(--font-display); font-size: clamp(30px, 3.2vw, 40px); line-height: 1.1; letter-spacing: -.02em; font-weight: 400; color: var(--ink); margin-top: 16px; max-width: 28ch; }
+.notfor-head h2 em { font-style: italic; color: var(--copper); }
+.notfor-list { list-style: none; padding: 0; margin: 0; border-top: 1px solid var(--hair-2); }
+.notfor-list li { display: grid; grid-template-columns: 60px 1fr; gap: 24px; padding: 22px 0; border-bottom: 1px solid var(--hair); align-items: baseline; }
+.notfor-list .notfor-idx { font-family: var(--font-mono); font-size: 11px; letter-spacing: .2em; color: var(--ink-3); }
+.notfor-list .notfor-body { font-size: 15.5px; line-height: 1.65; color: var(--ink-2); }
+.notfor-list .notfor-body strong { color: var(--ink); font-weight: 500; display: block; margin-bottom: 4px; }
+.notfor-foot { margin-top: 28px; font-size: 14.5px; line-height: 1.65; color: var(--ink-3); max-width: 72ch; }
+
+/* 09 · Team strip */
+.team-strip { max-width: var(--page-max); margin: 120px auto 0; padding: 0 40px; }
+.team-strip-head { margin-bottom: 40px; }
+.team-strip-head h2 { font-family: var(--font-display); font-size: clamp(30px, 3.2vw, 42px); line-height: 1.1; letter-spacing: -.02em; font-weight: 400; color: var(--ink); margin-top: 16px; }
+.team-strip-head h2 em { font-style: italic; color: var(--copper); }
+.team-strip-rows { border-top: 1px solid var(--hair-2); }
+.team-strip-row { display: grid; grid-template-columns: 200px 180px 1fr; gap: 28px; padding: 22px 0; border-bottom: 1px solid var(--hair); align-items: baseline; }
+.team-strip-row .ts-name { font-family: var(--font-display); font-size: 18px; font-weight: 500; color: var(--ink); }
+.team-strip-row .ts-role { font-family: var(--font-mono); font-size: 11px; letter-spacing: .18em; text-transform: uppercase; color: var(--ink-3); }
+.team-strip-row .ts-bet { font-size: 14.5px; line-height: 1.6; color: var(--ink-2); }
+.team-strip-foot { margin-top: 24px; font-family: var(--font-mono); font-size: 12px; letter-spacing: .04em; color: var(--ink-3); }
+.team-strip-link { color: var(--copper); text-decoration: none; border-bottom: 1px solid rgba(254,133,49,.3); transition: border-color .18s; }
+.team-strip-link:hover { border-bottom-color: var(--copper); }
+
+/* 10 · Pilot CTA */
+.why-cta { max-width: var(--page-max); margin: 96px auto 120px; padding: 0 40px; text-align: center; }
+.why-cta .eb { letter-spacing: .2em; margin-bottom: 22px; display: block; }
+.why-cta .eb::before { content: none; }
+.why-cta h2 { font-family: var(--font-display); font-size: clamp(34px, 3.8vw, 48px); line-height: 1.1; letter-spacing: -.02em; font-weight: 400; color: var(--ink); margin-bottom: 20px; }
+.why-cta h2 em { font-style: italic; color: var(--copper); }
+.why-cta .sub { font-size: 17px; line-height: 1.6; color: var(--ink-2); max-width: 56ch; margin: 0 auto 28px; }
+
+/* Mobile overrides */
+@media (max-width: 768px) {
+  .thesis-hero { padding: 0 22px; }
+  .thesis-hero-meta { grid-template-columns: 1fr; }
+  .thesis-hero-cell { border-right: none; border-bottom: 1px solid var(--hair); padding: 20px 0; }
+  .thesis-hero-cell:last-child { border-bottom: none; }
+  .thesis-hero-cell:not(:first-child) { padding-left: 0; }
+
+  .mem-stack { margin-top: 72px; padding: 0 22px; }
+  .mem-stack-row { grid-template-columns: 1fr; gap: 8px; }
+
+  .mem-enables { margin-top: 72px; padding: 0 22px; }
+  .mem-enables-grid { grid-template-columns: 1fr; }
+
+  .compounds { margin-top: 72px; padding: 0 22px; }
+  .compounds-timeline { grid-template-columns: 1fr; gap: 40px; padding-top: 8px; }
+  .compounds-rail { display: none; }
+  .compounds-step { padding-top: 0; padding-left: 60px; }
+  .compounds-marker { position: static; display: inline-block; margin-bottom: 8px; }
+
+  .fiveyear { margin-top: 72px; padding: 0 22px; }
+  .fiveyear-beats { grid-template-columns: 1fr; }
+  .fiveyear-beat { border-right: none; border-bottom: 1px solid var(--hair); }
+  .fiveyear-beat:last-child { border-bottom: none; }
+
+  .handoff-compare { margin-top: 64px; padding: 0 22px; }
+
+  .notfor { margin-top: 72px; padding: 0 22px; }
+  .notfor-list li { grid-template-columns: 1fr; gap: 4px; }
+
+  .team-strip { margin-top: 72px; padding: 0 22px; }
+  .team-strip-row { grid-template-columns: 1fr; gap: 4px; padding: 18px 0; }
+
+  .why-cta { margin: 72px auto 72px; padding: 0 22px; }
+}

--- a/app/why-salency/page.tsx
+++ b/app/why-salency/page.tsx
@@ -1,15 +1,33 @@
 import { MarketingHeader } from '@/components/MarketingHeader';
 import { ScrollReveal } from '@/components/ScrollReveal';
+import { ThesisSection } from '@/components/sections/ThesisSection';
 import { ProblemSection } from '@/components/sections/ProblemSection';
+import { MemoryStackSection } from '@/components/sections/MemoryStackSection';
+import { MemoryEnablesSection } from '@/components/sections/MemoryEnablesSection';
+import { CompoundsSection } from '@/components/sections/CompoundsSection';
+import { FiveYearBetSection } from '@/components/sections/FiveYearBetSection';
 import { GongSection } from '@/components/sections/GongSection';
+import { HandoffToolsSection } from '@/components/sections/HandoffToolsSection';
+import { NotForYouSection } from '@/components/sections/NotForYouSection';
+import { TeamStripSection } from '@/components/sections/TeamStripSection';
+import { PilotCtaSection } from '@/components/sections/PilotCtaSection';
 import { SiteFooter } from '@/components/sections/SiteFooter';
 
 export default function WhySalencyPage() {
   return (
     <div className="page">
       <MarketingHeader />
+      <ThesisSection />
       <ScrollReveal><ProblemSection /></ScrollReveal>
+      <ScrollReveal><MemoryStackSection /></ScrollReveal>
+      <ScrollReveal><MemoryEnablesSection /></ScrollReveal>
+      <ScrollReveal><CompoundsSection /></ScrollReveal>
+      <ScrollReveal><FiveYearBetSection /></ScrollReveal>
       <ScrollReveal><GongSection /></ScrollReveal>
+      <ScrollReveal><HandoffToolsSection /></ScrollReveal>
+      <ScrollReveal><NotForYouSection /></ScrollReveal>
+      <ScrollReveal><TeamStripSection /></ScrollReveal>
+      <PilotCtaSection />
       <SiteFooter />
     </div>
   );

--- a/components/sections/CompoundsSection.tsx
+++ b/components/sections/CompoundsSection.tsx
@@ -29,18 +29,19 @@ export function CompoundsSection() {
         </div>
         <div className="compounds-step">
           <span className="compounds-marker">M6</span>
-          <h4>Cross-account patterns emerge</h4>
+          <h4>Cross-account patterns begin to surface</h4>
           <p>
-            &ldquo;Handoff loses context&rdquo; lights up seven accounts. Your
-            pipeline review stops starting from zero.
+            A single pain query starts returning every account where it
+            appears. Pipeline review stops starting from zero.
           </p>
         </div>
         <div className="compounds-step">
           <span className="compounds-marker">M12</span>
-          <h4>Moat, measured in quarters</h4>
+          <h4>The moat is measured in quarters</h4>
           <p>
-            Rip it out at month twelve and you lose what nobody wrote down.
-            That&rsquo;s the switching cost.
+            By year one, ripping Salency out means losing what nobody wrote
+            down. That&rsquo;s the design &mdash; not a promise, a structural
+            consequence of how memory compounds.
           </p>
         </div>
       </div>

--- a/components/sections/CompoundsSection.tsx
+++ b/components/sections/CompoundsSection.tsx
@@ -1,0 +1,54 @@
+export function CompoundsSection() {
+  return (
+    <section className="compounds" id="compounds">
+      <div className="compounds-head">
+        <span className="eb">The switching cost</span>
+        <h2>
+          Month one is the handoff.{' '}
+          <em>Month twelve is the moat.</em>
+        </h2>
+      </div>
+
+      <div className="compounds-timeline">
+        <div className="compounds-rail" aria-hidden="true" />
+        <div className="compounds-step">
+          <span className="compounds-marker">M1</span>
+          <h4>First calls indexed</h4>
+          <p>
+            Transcripts from the first two weeks establish the baseline. Every
+            rep&rsquo;s account starts to fill in.
+          </p>
+        </div>
+        <div className="compounds-step">
+          <span className="compounds-marker">M3</span>
+          <h4>Pain graphs fill</h4>
+          <p>
+            Each account&rsquo;s pain landscape stabilizes. Contradictions
+            start surfacing across calls on the same account.
+          </p>
+        </div>
+        <div className="compounds-step">
+          <span className="compounds-marker">M6</span>
+          <h4>Cross-account patterns emerge</h4>
+          <p>
+            &ldquo;Handoff loses context&rdquo; lights up seven accounts. Your
+            pipeline review stops starting from zero.
+          </p>
+        </div>
+        <div className="compounds-step">
+          <span className="compounds-marker">M12</span>
+          <h4>Moat, measured in quarters</h4>
+          <p>
+            Rip it out at month twelve and you lose what nobody wrote down.
+            That&rsquo;s the switching cost.
+          </p>
+        </div>
+      </div>
+
+      <p className="compounds-foot">
+        Flatten the graph into flat fields and you kill the thing. The memory
+        layer has to live on Salency, or it isn&rsquo;t memory.
+      </p>
+    </section>
+  );
+}

--- a/components/sections/FiveYearBetSection.tsx
+++ b/components/sections/FiveYearBetSection.tsx
@@ -1,0 +1,48 @@
+export function FiveYearBetSection() {
+  return (
+    <section className="fiveyear">
+      <div className="fiveyear-head">
+        <span className="eb">Why now</span>
+        <h2>
+          The reps are the <em>first</em> users. The AI agents are the{' '}
+          <em>second.</em>
+        </h2>
+      </div>
+
+      <div className="fiveyear-beats">
+        <div className="fiveyear-beat">
+          <span className="beat-idx">01</span>
+          <h3>Sales teams are consolidating</h3>
+          <p>
+            Surviving reps own more accounts with less tribal knowledge. The
+            handoff problem gets worse, not better.
+          </p>
+        </div>
+        <div className="fiveyear-beat">
+          <span className="beat-idx">02</span>
+          <h3>AI SDRs are drafting outreach</h3>
+          <p>
+            Autonomous agents inside the next 18 months. They all need
+            structured account memory as input &mdash; not a raw transcript
+            pile, not another CRM field.
+          </p>
+        </div>
+        <div className="fiveyear-beat">
+          <span className="beat-idx">03</span>
+          <h3>The moat is the graph, not the model</h3>
+          <p>
+            Every LLM commoditizes extraction. What doesn&rsquo;t commoditize
+            is the customer-built graph of pains, products, and contradictions.
+            That compounds per customer, per call.
+          </p>
+        </div>
+      </div>
+
+      <p className="fiveyear-foot">
+        Counterexample: 11x.ai raised $74M on autonomous AI SDRs and lost
+        70&ndash;80% of customers. Autonomous bots without customer memory
+        don&rsquo;t hold the relationship. That&rsquo;s the gap we fill.
+      </p>
+    </section>
+  );
+}

--- a/components/sections/GongSection.tsx
+++ b/components/sections/GongSection.tsx
@@ -68,25 +68,27 @@ export function GongSection() {
             </td>
           </tr>
           <tr>
-            <td className="dim">Who reads it</td>
+            <td className="dim">When it&rsquo;s used</td>
             <td className="col-g">
-              <span className="icon">—</span>Managers, spot-checking coaching
-              moments
+              <span className="icon">—</span>During the call &mdash; managers
+              spot-check coaching moments
             </td>
             <td className="col-s">
-              <span className="icon">✓</span>Account executive, customer success
-              manager, director — every role on the account, on demand
+              <span className="icon">✓</span>
+              <strong>After every call, and every handoff</strong> &mdash; AE,
+              CSM, director, on demand
             </td>
           </tr>
           <tr>
-            <td className="dim">Handoff artefact</td>
+            <td className="dim">Handoff artifact</td>
             <td className="col-g">
-              <span className="icon">—</span>None — you still write the handoff
-              doc by hand
+              <span className="icon">—</span>None &mdash; you still write the
+              handoff doc by hand
             </td>
             <td className="col-s">
-              <span className="icon">✓</span>Handoff doc is the{' '}
-              <strong>live memory layer</strong> itself
+              <span className="icon">✓</span>
+              <strong>Auto-generated, always current</strong> &mdash; the graph
+              regenerates the doc
             </td>
           </tr>
           <tr>
@@ -101,6 +103,10 @@ export function GongSection() {
           </tr>
         </tbody>
       </table>
+      <p className="notetaker-takeaway">
+        Gong tells you <em>what happened.</em> Salency tells you{' '}
+        <em>what to do next.</em>
+      </p>
     </section>
   );
 }

--- a/components/sections/HandoffToolsSection.tsx
+++ b/components/sections/HandoffToolsSection.tsx
@@ -1,0 +1,61 @@
+export function HandoffToolsSection() {
+  return (
+    <section className="handoff-compare">
+      <div className="handoff-compare-head">
+        <span className="eb">vs handoff tools</span>
+        <h2>
+          AskElephant hands off <em>one deal.</em> We remember{' '}
+          <em>every account.</em>
+        </h2>
+      </div>
+
+      <table className="handoff-table">
+        <thead>
+          <tr>
+            <th>Dimension</th>
+            <th className="col-g">
+              <span>AskElephant / CRM notes</span>
+              <span className="brand">Handoff tools</span>
+            </th>
+            <th className="col-s">
+              <span>Salency</span>
+              <span className="brand">Institutional memory</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td className="dim">Scope</td>
+            <td className="col-g">
+              <span className="icon">—</span>One-off handoff doc per deal
+            </td>
+            <td className="col-s">
+              <span className="icon">✓</span>
+              <strong>Every account, continuously</strong>
+            </td>
+          </tr>
+          <tr>
+            <td className="dim">Pain &rarr; product mapping</td>
+            <td className="col-g">
+              <span className="icon">—</span>Not modeled
+            </td>
+            <td className="col-s">
+              <span className="icon">✓</span>
+              <strong>Confidence-ranked, top-N per pain</strong>
+            </td>
+          </tr>
+          <tr>
+            <td className="dim">Contradictions across calls</td>
+            <td className="col-g">
+              <span className="icon">—</span>Overwritten silently
+            </td>
+            <td className="col-s">
+              <span className="icon">✓</span>
+              <strong>Flagged with both citations</strong>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  );
+}

--- a/components/sections/MemoryEnablesSection.tsx
+++ b/components/sections/MemoryEnablesSection.tsx
@@ -1,0 +1,74 @@
+export function MemoryEnablesSection() {
+  return (
+    <section className="mem-enables">
+      <div className="mem-enables-head">
+        <span className="eb">Two capabilities no notetaker ships</span>
+        <h2>
+          What only <em>memory</em> enables.
+        </h2>
+      </div>
+
+      <div className="mem-enables-grid">
+        <article className="mem-enables-card">
+          <div className="idx">01</div>
+          <h3>
+            Pain <em>&rarr;</em> product, ranked
+          </h3>
+          <p>
+            Every customer pain gets scored against your product catalog, top-N
+            ranked by confidence. Three upsells queued before the rep ends the
+            call. Einstein scores leads. We score pains.
+          </p>
+          <div className="mem-enables-mock">
+            <div className="pp-row">
+              <span className="pp-prod">Memory Layer</span>
+              <span className="pp-bar">
+                <span className="pp-fill" style={{ width: '92%' }} />
+              </span>
+              <span className="pp-conf">0.92</span>
+            </div>
+            <div className="pp-row">
+              <span className="pp-prod">Contradiction Detection</span>
+              <span className="pp-bar">
+                <span className="pp-fill" style={{ width: '74%' }} />
+              </span>
+              <span className="pp-conf">0.74</span>
+            </div>
+            <div className="pp-row">
+              <span className="pp-prod">Account Pattern Search</span>
+              <span className="pp-bar">
+                <span className="pp-fill" style={{ width: '61%' }} />
+              </span>
+              <span className="pp-conf">0.61</span>
+            </div>
+          </div>
+        </article>
+
+        <article className="mem-enables-card">
+          <div className="idx">02</div>
+          <h3>
+            <em>Contradictions</em> flagged across calls
+          </h3>
+          <p>
+            When the customer&rsquo;s story shifts between calls, we flag it
+            with both citations. The rep stops re-pitching the wrong number, or
+            the wrong decision-maker.
+          </p>
+          <div className="mem-enables-mock">
+            <div className="cx-row">
+              <span className="cx-date">Apr 07</span>
+              <span className="cx-quote">&ldquo;budget is fifty.&rdquo;</span>
+            </div>
+            <div className="cx-arrow">&darr;</div>
+            <div className="cx-row">
+              <span className="cx-date">Apr 14</span>
+              <span className="cx-quote">
+                &ldquo;budget&rsquo;s tight, maybe twenty.&rdquo;
+              </span>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+  );
+}

--- a/components/sections/MemoryStackSection.tsx
+++ b/components/sections/MemoryStackSection.tsx
@@ -1,0 +1,37 @@
+export function MemoryStackSection() {
+  return (
+    <section className="mem-stack" id="memory-stack">
+      <div className="mem-stack-head">
+        <span className="eb">Where Salency lives</span>
+        <h2>
+          Same transcripts, same CRM.{' '}
+          <em>New layer between them.</em>
+        </h2>
+      </div>
+      <div className="mem-stack-rows">
+        <div className="mem-stack-row">
+          <span className="layer-label">CRM</span>
+          <span className="layer-role">Pipeline layer</span>
+          <p className="layer-desc">
+            Stages, quotas, forecasts. What the deal <em>is.</em>
+          </p>
+        </div>
+        <div className="mem-stack-row">
+          <span className="layer-label">Notetaker</span>
+          <span className="layer-role">Capture layer</span>
+          <p className="layer-desc">
+            Transcript, summary, coaching snippets. What was <em>said.</em>
+          </p>
+        </div>
+        <div className="mem-stack-row mem-stack-row--accent">
+          <span className="layer-label">Salency</span>
+          <span className="layer-role">Memory layer</span>
+          <p className="layer-desc">
+            Pains, product matches, contradictions, stakeholder graph. What it{' '}
+            <em>means</em>, across every call.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/sections/NotForYouSection.tsx
+++ b/components/sections/NotForYouSection.tsx
@@ -1,0 +1,42 @@
+export function NotForYouSection() {
+  return (
+    <section className="notfor">
+      <div className="notfor-head">
+        <span className="eb">Not for you if</span>
+        <h2>
+          Salency is the <em>wrong tool</em> in three cases.
+        </h2>
+      </div>
+      <ul className="notfor-list">
+        <li>
+          <span className="notfor-idx">01</span>
+          <div className="notfor-body">
+            <strong>Transactional, one-touch sales.</strong> If your deal cycle
+            is a single call and no handoff happens, the memory layer has
+            nothing to compound.
+          </div>
+        </li>
+        <li>
+          <span className="notfor-idx">02</span>
+          <div className="notfor-body">
+            <strong>Solo operator, no rep turnover.</strong> The scar tissue
+            Salency fixes is institutional. Solo founders keep it in their
+            head.
+          </div>
+        </li>
+        <li>
+          <span className="notfor-idx">03</span>
+          <div className="notfor-body">
+            <strong>Under ~50 calls per quarter.</strong> The graph thrives on
+            density. A handful of calls per month won&rsquo;t fill it in.
+          </div>
+        </li>
+      </ul>
+      <p className="notfor-foot">
+        And Salency is not a CRM replacement, not a coaching tool, and not
+        another tab. It&rsquo;s the layer between the transcript and the rep
+        who inherits the account.
+      </p>
+    </section>
+  );
+}

--- a/components/sections/NotForYouSection.tsx
+++ b/components/sections/NotForYouSection.tsx
@@ -4,7 +4,7 @@ export function NotForYouSection() {
       <div className="notfor-head">
         <span className="eb">Not for you if</span>
         <h2>
-          Salency is the <em>wrong tool</em> in three cases.
+          Salency is the <em>wrong tool</em> in two cases.
         </h2>
       </div>
       <ul className="notfor-list">
@@ -22,13 +22,6 @@ export function NotForYouSection() {
             <strong>Solo operator, no rep turnover.</strong> The scar tissue
             Salency fixes is institutional. Solo founders keep it in their
             head.
-          </div>
-        </li>
-        <li>
-          <span className="notfor-idx">03</span>
-          <div className="notfor-body">
-            <strong>Under ~50 calls per quarter.</strong> The graph thrives on
-            density. A handful of calls per month won&rsquo;t fill it in.
           </div>
         </li>
       </ul>

--- a/components/sections/PilotCtaSection.tsx
+++ b/components/sections/PilotCtaSection.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { openPilotModal } from '@/components/PilotModal';
+
+export function PilotCtaSection() {
+  return (
+    <section className="why-cta">
+      <span className="eb">Pilot cohort &middot; Spring 2026</span>
+      <h2>
+        Start the memory. <em>Inherit it forever.</em>
+      </h2>
+      <p className="sub">
+        First account memory stands up in a week. By month two, the rep
+        inheriting it reads the story, not a notes field.
+      </p>
+      <button
+        type="button"
+        className="btn btn-primary"
+        onClick={() => openPilotModal()}
+      >
+        Request a pilot &rarr;
+      </button>
+    </section>
+  );
+}

--- a/components/sections/ProblemSection.tsx
+++ b/components/sections/ProblemSection.tsx
@@ -28,12 +28,14 @@ export function ProblemSection() {
           </h3>
           <p className="desc">
             Conversation intelligence gives you 90 minutes of searchable
-            transcript. Nobody reads 90 minutes of transcript. The real insight
-            — the unprompted pain at minute 42 — stays locked in the audio.
+            transcript. Nobody reads 90 minutes of transcript. The unprompted
+            pain, the offhand competitor mention, the stakeholder aside — they
+            stay locked in the audio.
           </p>
           <div className="cost">
+            <span className="figure">&lt; 4%</span>
             <span className="label">
-              Transcripts are the artifact no one scrubs after the handoff.
+              of transcripts get re-read after the handoff &middot; internal estimate, AE/CS interviews
             </span>
           </div>
         </div>
@@ -53,8 +55,7 @@ export function ProblemSection() {
           <div className="cost">
             <span className="figure">40–50%</span>
             <span className="label">
-              of customers visibly frustrated when asked to repeat themselves ·
-              Customer interview, Jan 2026
+              of customers visibly frustrated when asked to repeat themselves &middot; AE/CS interviews, Q1 2026
             </span>
           </div>
         </div>
@@ -70,8 +71,9 @@ export function ProblemSection() {
             re-encoding information the system already has.
           </p>
           <div className="cost">
+            <span className="figure">3–5 hrs</span>
             <span className="label">
-              Hours spent re-encoding what the recording already captured.
+              per rep per week re-encoding what the recording already captured &middot; AE interviews, Q1 2026
             </span>
           </div>
         </div>
@@ -85,7 +87,7 @@ export function ProblemSection() {
           from every call, keeping it current as the account evolves, and
           surfacing it the moment someone new picks up the relationship.
         </p>
-        <Link href="/" className="link">
+        <Link href="#memory-stack" className="link">
           See how it works →
         </Link>
       </div>

--- a/components/sections/ProblemSection.tsx
+++ b/components/sections/ProblemSection.tsx
@@ -12,8 +12,8 @@ export function ProblemSection() {
           </h2>
         </div>
         <p className="lede">
-          Your reps sit through four discovery calls a week. Your AI notetaker
-          captures the audio. Your CRM captures the stage change.{' '}
+          Your reps run discovery calls every week. Your AI notetaker captures
+          the audio. Your CRM captures the stage change.{' '}
           <em>Nothing captures what was actually learned</em> — the pains, the
           politics, the promises. So when a rep rotates, the account restarts
           from zero.
@@ -33,9 +33,8 @@ export function ProblemSection() {
             stay locked in the audio.
           </p>
           <div className="cost">
-            <span className="figure">&lt; 4%</span>
             <span className="label">
-              of transcripts get re-read after the handoff &middot; internal estimate, AE/CS interviews
+              Transcripts are the artifact no one scrubs after the handoff.
             </span>
           </div>
         </div>
@@ -53,9 +52,9 @@ export function ProblemSection() {
             asking again.
           </p>
           <div className="cost">
-            <span className="figure">40–50%</span>
             <span className="label">
-              of customers visibly frustrated when asked to repeat themselves &middot; AE/CS interviews, Q1 2026
+              The customer pays the cost &mdash; they&rsquo;re the ones asked
+              to repeat themselves.
             </span>
           </div>
         </div>
@@ -71,9 +70,8 @@ export function ProblemSection() {
             re-encoding information the system already has.
           </p>
           <div className="cost">
-            <span className="figure">3–5 hrs</span>
             <span className="label">
-              per rep per week re-encoding what the recording already captured &middot; AE interviews, Q1 2026
+              Hours spent re-encoding what the recording already captured.
             </span>
           </div>
         </div>

--- a/components/sections/TeamStripSection.tsx
+++ b/components/sections/TeamStripSection.tsx
@@ -1,0 +1,48 @@
+import Link from 'next/link';
+
+export function TeamStripSection() {
+  return (
+    <section className="team-strip">
+      <div className="team-strip-head">
+        <span className="eb">Who&rsquo;s building this</span>
+        <h2>
+          Three people, <em>four months,</em> V1 shipped.
+        </h2>
+      </div>
+      <div className="team-strip-rows">
+        <div className="team-strip-row">
+          <span className="ts-name">Howard Tam</span>
+          <span className="ts-role">Co-founder &amp; CEO</span>
+          <p className="ts-bet">
+            Five founding-AE / BD seats in four years. Ran the
+            HubSpot&rarr;Monday CRM migration at Sequence. Knows what flat
+            fields can&rsquo;t hold.
+          </p>
+        </div>
+        <div className="team-strip-row">
+          <span className="ts-name">Nikki Ip</span>
+          <span className="ts-role">Co-founder &amp; COO</span>
+          <p className="ts-bet">
+            Runs revenue analytics and operational strategy at Adaptavist
+            Group. Knows what sales ops actually trusts.
+          </p>
+        </div>
+        <div className="team-strip-row">
+          <span className="ts-name">Babajide Okusanya</span>
+          <span className="ts-role">Technical Lead</span>
+          <p className="ts-bet">
+            Scaled MakersValley from 0 to $2M ARR (6.5y, NYC). Has shipped
+            provenance-tracked AI context systems &mdash; the exact technical
+            class Salency runs on.
+          </p>
+        </div>
+      </div>
+      <p className="team-strip-foot">
+        Full bios on{' '}
+        <Link href="/investors" className="team-strip-link">
+          /investors &rarr;
+        </Link>
+      </p>
+    </section>
+  );
+}

--- a/components/sections/TeamStripSection.tsx
+++ b/components/sections/TeamStripSection.tsx
@@ -29,7 +29,7 @@ export function TeamStripSection() {
         </div>
         <div className="team-strip-row">
           <span className="ts-name">Babajide Okusanya</span>
-          <span className="ts-role">Technical Lead</span>
+          <span className="ts-role">Founding Engineer</span>
           <p className="ts-bet">
             Scaled MakersValley from 0 to $2M ARR (6.5y, NYC). Has shipped
             provenance-tracked AI context systems &mdash; the exact technical

--- a/components/sections/ThesisSection.tsx
+++ b/components/sections/ThesisSection.tsx
@@ -12,20 +12,6 @@ export function ThesisSection() {
           four, it&rsquo;s the only system that knows what your customers
           actually said. The longer it runs, the harder it is to rip out.
         </p>
-        <div className="thesis-hero-meta">
-          <div className="thesis-hero-cell">
-            <span className="label">Month 1</span>
-            <p>First calls indexed. Day-1 brief stands up.</p>
-          </div>
-          <div className="thesis-hero-cell">
-            <span className="label">Month 3</span>
-            <p>Pain graphs fill in. Contradictions surface across calls.</p>
-          </div>
-          <div className="thesis-hero-cell">
-            <span className="label">Month 12</span>
-            <p>Cross-account patterns auto-emerge. Memory outlasts any rep.</p>
-          </div>
-        </div>
       </div>
     </section>
   );

--- a/components/sections/ThesisSection.tsx
+++ b/components/sections/ThesisSection.tsx
@@ -1,0 +1,32 @@
+export function ThesisSection() {
+  return (
+    <section className="thesis-hero">
+      <div className="thesis-hero-inner">
+        <span className="eb">Why Salency</span>
+        <h1>
+          Memory <em>compounds.</em>{' '}
+          <span className="soft">Notetakers don&rsquo;t.</span>
+        </h1>
+        <p className="lede">
+          Quarter one, Salency looks like a better handoff doc. By quarter
+          four, it&rsquo;s the only system that knows what your customers
+          actually said. The longer it runs, the harder it is to rip out.
+        </p>
+        <div className="thesis-hero-meta">
+          <div className="thesis-hero-cell">
+            <span className="label">Month 1</span>
+            <p>First calls indexed. Day-1 brief stands up.</p>
+          </div>
+          <div className="thesis-hero-cell">
+            <span className="label">Month 3</span>
+            <p>Pain graphs fill in. Contradictions surface across calls.</p>
+          </div>
+          <div className="thesis-hero-cell">
+            <span className="label">Month 12</span>
+            <p>Cross-account patterns auto-emerge. Memory outlasts any rep.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Scrap the existing 2-section /why-salency (Problem + Gong) and rebuild as a **9-section thesis pillar page** per CEO review decision D (selective expansion). The new page runs: Thesis → Problem → Stack → Memory enables (pain-product + contradictions) → Compounds (visual anchor) → Why-now → vs Gong → vs handoff tools → Disqualify → Team → Pilot.

**New sections (8):**
- `ThesisSection` — hero H1 "Memory compounds. Notetakers don't."
- `MemoryStackSection` — 3-row CRM / Notetaker / Salency stack (vertical, no card-grid AI slop)
- `MemoryEnablesSection` — two-card wedge: pain→product mapping (ConfBar mock) + contradictions (cx-mock)
- `CompoundsSection` — M1/M3/M6/M12 timeline. Copper horizontal gradient rail = page's single visual anchor per DESIGN.md §3
- `FiveYearBetSection` — 3-beat why-now + 11x.ai counterexample proof line
- `HandoffToolsSection` — 3-row vs AskElephant/CRM-notes table (supplements kept GongSection)
- `NotForYouSection` — 2-bullet disqualification (transactional, solo-operator)
- `TeamStripSection` — light trust strip, links to /investors for full bios
- `PilotCtaSection` — reuses mem-cta pattern

**Section polish on existing (kept):**
- `ProblemSection` — CTA retargeted `/` → `#memory-stack`, "minute 42" speculation → concrete signal list
- `GongSection` — "Who reads it" → "When it's used" (post-handoff temporal framing), "artefact" → "artifact" spelling, row 6 phrase-reuse rewritten, added takeaway line *"Gong tells you what happened. Salency tells you what to do next."*

**Honesty pass (second commit):**
- Stripped 3 fabricated stats in ProblemSection (no formal customer interviews exist yet — the wedge is founder-lived, not research-backed)
- Removed "four discovery calls a week" fabricated number from lede
- Reframed CompoundsSection M6/M12 from stated outcomes to forward trajectory ("begin to surface," "structural consequence, not a promise")
- Removed arbitrary "50 calls/quarter" disqualification threshold from NotForYou
- Removed Section 01 3-cell time strip (duplicated CompoundsSection timeline)
- Babajide title: Founding Engineer (clearer commitment signal vs generic "Technical Lead")

**CSS:** ~340 lines added to `app/globals.css` covering all 9 sections + 768px mobile overrides. All sections reuse the 1280px standalone-page container per DESIGN.md §4. Copper scope audited per §3 (keywords-only rule): each section runs eyebrow + headline em + one optional accent.

## Test Coverage

No test suite configured (per CLAUDE.md). Marketing content change — visual QA on Vercel preview.

## Pre-Landing Review

Lint clean. 3 pre-existing `<img>` warnings in HubSection, MarketingHeader, loading.tsx — untouched by this diff.

No new dependencies. No API/auth/data changes. Content + CSS only.

## Design Review

Design-review-lite checks per DESIGN.md §3/§4:
- Copper budget per section: ≤3 hits (eyebrow + em + optional accent). Compliant.
- No 3-column feature grids (MemoryStackSection uses vertical rows with hairlines, not horizontal cards).
- No system-ui / default font stacks as primary. Uses Instrument Sans tokens throughout.
- No decorative blobs, purple gradients, emoji, or bubbly-radius uniformity.
- Single visual anchor = CompoundsSection copper horizontal rail.
- Mobile overrides at 768px for all new sections (single-column stacks, tightened padding).

Full /design-review recommended on Vercel preview post-deploy.

## Scope Drift

**Scope Check: CLEAN**
Intent: Rebuild /why-salency as thesis-first 9-section pillar page per CEO review decision D
Delivered: Exactly that, plus honesty pass removing fabricated claims before landing

## Plan Completion

No formal plan file for this branch. Decisions logged inline via `/plan-ceo-review` + `/plan-design-review` + `/office-hours` skill outputs across 2 sessions.

Sections delivered matches the D architecture agreed in plan-ceo-review session.

## Verification Results

Cannot run local dev server (Node 18 < required 20). Vercel preview will surface any rendering issues. Visual QA required post-deploy.

## TODOS

No TODOS.md in repo. Session assignments tracked outside this PR:
- Howard: conversation with Babajide on public title / Orumilos IP boundary (blocks /investors PR 2)
- Howard: Assignment B — re-engage Erica at Zerohash for real customer signal (feeds future /investors traction strip update)

## Test plan

- [ ] Vercel preview loads /why-salency without errors
- [ ] All 9 sections render in D order: Thesis → Problem → Stack → Enables → Compounds → FiveYear → Gong → Handoff → NotForYou → Team → Pilot
- [ ] ProblemSection fix-paragraph CTA links to #memory-stack anchor and scrolls correctly
- [ ] CompoundsSection copper gradient rail renders as single visual anchor on desktop
- [ ] All sections stack cleanly at 768px viewport
- [ ] MemoryEnablesSection ConfBar mock renders at correct widths (92%/74%/61%)
- [ ] MemoryEnablesSection cx-mock (Apr 07 → Apr 14 quotes) renders with correct arrow + dates
- [ ] TeamStripSection /investors link works + hover states correct
- [ ] PilotCtaSection "Request a pilot" button opens PilotModal
- [ ] GongSection table takeaway line appears below table
- [ ] No copper overspend per section (eyebrow + em + ≤1 anchor)
- [ ] Run `/design-review` on Vercel preview for full visual audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)