### PR TITLE
design: fix hero backdrop + reorder team strip on /why-salency

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -759,13 +759,13 @@ html {
      (which clips the pseudo below the element's own paint layer). */
   .hero,
   .mem-intro,
-  .prob,
+  .thesis-hero,
   .apply-page{
     position:relative;
   }
   .hero::before,
   .mem-intro::before,
-  .prob::before,
+  .thesis-hero::before,
   .apply-page::before{
     content:"";
     position:absolute;top:-200px;left:50%;transform:translateX(-50%);
@@ -774,7 +774,7 @@ html {
   }
   .hero > *,
   .mem-intro > *,
-  .prob > *,
+  .thesis-hero > *,
   .apply-page > *{
     position:relative;z-index:1;
   }

--- a/app/why-salency/page.tsx
+++ b/app/why-salency/page.tsx
@@ -23,10 +23,10 @@ export default function WhySalencyPage() {
       <ScrollReveal><MemoryEnablesSection /></ScrollReveal>
       <ScrollReveal><CompoundsSection /></ScrollReveal>
       <ScrollReveal><FiveYearBetSection /></ScrollReveal>
+      <ScrollReveal><TeamStripSection /></ScrollReveal>
       <ScrollReveal><GongSection /></ScrollReveal>
       <ScrollReveal><HandoffToolsSection /></ScrollReveal>
       <ScrollReveal><NotForYouSection /></ScrollReveal>
-      <ScrollReveal><TeamStripSection /></ScrollReveal>
       <PilotCtaSection />
       <SiteFooter />
     </div>


### PR DESCRIPTION
## Summary

Two post-merge design fixes caught by /design-review on the live Vercel page (PR #91 aftermath).

**Hero backdrop selector fix.** The shared copper-ellipse-glow backdrop (`app/globals.css`, introduced in PR #85) was grouped under `.hero, .mem-intro, .prob, .apply-page`. On the old 2-section /why-salency, `.prob` **was** the top section, so the glow bloomed behind it. The D-refactor in PR #91 added `ThesisSection` (`.thesis-hero`) above `.prob`, leaving the backdrop pinned mid-page. Swap `.prob` → `.thesis-hero` in all three grouped selectors (container, `::before`, `> *` z-lift).

**Team strip reorder.** Bottom-half rhythm monotony flagged by design review — 4 consecutive hairline-row sections (Gong → Handoff → NotForYou → Team). Move TeamStripSection from position 09 to 06.5, right after FiveYearBetSection. New order: Thesis → Problem → Stack → Enables → Compounds → Bet → **Team** → Gong → Handoff → NotForYou → CTA. Better narrative pacing (trust signal lands before comparison beats) and breaks the row cluster.

Zero new components or styles. JSX order shift + 3-char CSS selector swap.

## Test plan

- [ ] Vercel preview: copper ellipse glow visible behind ThesisSection (top of /why-salency), not behind ProblemSection
- [ ] Other backdrop surfaces unaffected: / (`.hero`), /memory (`.mem-intro`), /pilot & /pricing (`.apply-page`)
- [ ] Section order reads: Thesis → Problem → Stack → Enables → Compounds → FiveYearBet → TeamStrip → Gong → Handoff → NotForYou → PilotCta
- [ ] Mobile (375px) still stacks cleanly in the new order
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)