### PR TITLE
content(investors): PR3 — TAM, competitive, roadmap, bio honesty

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1356,24 +1356,143 @@ html {
     }
   }
 
-  /* V1.5 roadmap */
+  /* TAM — market size strip */
+  .inv-tam{
+    max-width:var(--page-max);margin:80px auto 0;padding:0 40px;
+
+    .eb{margin-bottom:28px;display:flex}
+    h2{
+      font-size:clamp(38px,4.2vw,54px);line-height:1.1;color:var(--ink);
+      margin:0 0 36px;max-width:32ch;text-wrap:balance;
+    }
+    .tam-grid{
+      display:grid;grid-template-columns:repeat(3,1fr);
+      border-top:1px solid var(--hair-2);border-bottom:1px solid var(--hair-2);
+
+      .cell{padding:32px 28px;border-right:1px solid var(--hair)}
+      .cell:last-child{border-right:none}
+
+      .label{
+        font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
+        letter-spacing:.2em;text-transform:uppercase;color:var(--ink-3);
+        margin-bottom:16px;display:block;
+      }
+      .figure{
+        font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;
+        font-size:34px;line-height:1.05;letter-spacing:-.02em;color:var(--ink);margin-bottom:10px;
+
+        em{font-style:italic;color:var(--copper)}
+      }
+      .desc{
+        font-family:var(--font-body), 'Geist', sans-serif;font-size:14.5px;
+        line-height:1.6;color:var(--ink-2);font-weight:300;
+
+        strong{color:var(--ink);font-weight:500}
+      }
+    }
+    .tam-counter{
+      margin-top:28px;padding-top:20px;max-width:68ch;
+
+      .label{
+        display:block;font-family:'Geist Mono',monospace;font-size:11px;
+        letter-spacing:.18em;text-transform:uppercase;color:var(--ink-3);margin-bottom:8px;
+      }
+      p{
+        font-family:var(--font-body), 'Geist', sans-serif;font-size:14.5px;
+        line-height:1.7;color:var(--ink-2);font-weight:300;max-width:68ch;
+
+        em{color:var(--ink);font-style:normal;font-weight:500}
+      }
+    }
+  }
+
+  /* Competitive landscape — threat table */
+  .inv-compete{
+    max-width:var(--page-max);margin:80px auto 0;padding:0 40px;
+
+    .eb{margin-bottom:28px;display:flex}
+    h2{
+      font-size:clamp(38px,4.2vw,54px);line-height:1.1;color:var(--ink);
+      margin:0 0 20px;max-width:32ch;text-wrap:balance;
+    }
+    .compete-lede{
+      font-family:var(--font-body), 'Geist', sans-serif;font-weight:300;font-size:17px;
+      line-height:1.7;color:var(--ink-2);max-width:62ch;margin:0 0 36px;
+    }
+    .compete-table{
+      border-top:1px solid var(--hair-2);
+    }
+    .compete-row{
+      display:grid;grid-template-columns:180px 100px 1fr;gap:28px;
+      padding:18px 0;border-bottom:1px solid var(--hair);align-items:baseline;
+
+      &--head{
+        padding:14px 0;border-bottom:1px solid var(--hair-2);
+
+        .c-who,.c-threat,.c-why{
+          font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
+          letter-spacing:.2em;text-transform:uppercase;color:var(--ink-3);
+        }
+      }
+    }
+    .c-who{
+      font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;
+      font-size:19px;color:var(--ink);letter-spacing:-.01em;
+    }
+    .c-threat{
+      font-family:'Geist Mono',monospace;font-size:13px;font-weight:500;color:var(--ink-2);
+
+      em{font-style:italic;color:var(--copper);font-size:14px}
+    }
+    .c-why{
+      font-family:var(--font-body), 'Geist', sans-serif;font-size:14.5px;line-height:1.65;
+      color:var(--ink-2);font-weight:300;
+    }
+  }
+
+  /* Roadmap — V1.5 / V2 / V2.5 horizons */
   .roadmap{
     max-width:var(--page-max);margin:80px auto 0;padding:0 40px;
 
-    .roadmap-card{
-      padding:22px 28px;border:1px solid var(--hair-2);border-radius:10px;
+    .eb{margin-bottom:28px;display:flex}
+    h2{
+      font-size:clamp(38px,4.2vw,54px);line-height:1.1;color:var(--ink);
+      margin:0 0 36px;max-width:22ch;text-wrap:balance;
+    }
+    .horizon-list{display:grid;grid-template-columns:1fr;gap:20px}
+    .horizon{
+      padding:26px 28px;border:1px solid var(--hair-2);border-radius:10px;
       background:rgba(255,255,255,.02);
-      display:grid;grid-template-columns:auto 1fr;gap:24px;align-items:center;
 
-      .pill{
-        font-family:'Geist Mono',monospace;font-size:11px;font-weight:500;letter-spacing:.18em;
-        text-transform:uppercase;color:var(--copper);padding:6px 12px;
-        border:1px solid rgba(254,133,49,.28);border-radius:999px;
+      .horizon-head{
+        display:flex;align-items:center;gap:16px;margin-bottom:14px;flex-wrap:wrap;
+
+        .pill{
+          font-family:'Geist Mono',monospace;font-size:11px;font-weight:500;letter-spacing:.18em;
+          text-transform:uppercase;color:var(--copper);padding:6px 12px;
+          border:1px solid rgba(254,133,49,.28);border-radius:999px;
+        }
+        .label{
+          font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
+          letter-spacing:.2em;text-transform:uppercase;color:var(--ink-3);
+        }
       }
-      .body{
-        font-family:var(--font-body), 'Geist', sans-serif;font-size:15.5px;color:var(--ink);font-weight:400;
+      .horizon-body{
+        list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:10px;
 
-        em{font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;color:var(--copper);font-size:16.5px;font-weight:400}
+        li{
+          font-family:var(--font-body), 'Geist', sans-serif;font-size:15px;line-height:1.65;
+          color:var(--ink-2);font-weight:300;padding-left:16px;position:relative;
+
+          &::before{
+            content:"";position:absolute;left:0;top:.8em;width:6px;height:1px;
+            background:var(--copper-a40);
+          }
+          em{
+            font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;
+            color:var(--copper);font-size:16px;font-weight:400;
+          }
+        }
       }
     }
   }
@@ -1548,23 +1667,45 @@ html {
     }
     .inv-intro,
     .platform,
+    .moat,
+    .inv-tam,
+    .inv-compete,
     .roadmap,
     .team,
     .thesis {
       padding-left: 22px;
       padding-right: 22px;
     }
-    .platform .primitive {
+    .platform .primitive,
+    .moat .primitive {
       /* Stack the "Data primitive" label above the title on narrow screens. */
       grid-template-columns: 1fr;
       gap: 12px;
       padding: 22px 22px;
     }
-    .roadmap-card {
-      /* Same for the "On the roadmap" pill + body. */
+    .inv-tam .tam-grid {
+      /* 3-cell horizontal strip collapses to stacked rows. */
       grid-template-columns: 1fr;
-      gap: 12px;
-      padding: 18px 22px;
+    }
+    .inv-tam .tam-grid .cell {
+      border-right: none;
+      border-bottom: 1px solid var(--hair);
+      padding: 24px 0;
+    }
+    .inv-tam .tam-grid .cell:last-child {
+      border-bottom: none;
+    }
+    .inv-compete .compete-row {
+      /* Threat table stacks: who on its own line, threat+why below. */
+      grid-template-columns: 1fr;
+      gap: 6px;
+      padding: 16px 0;
+    }
+    .inv-compete .compete-row--head {
+      display: none;
+    }
+    .roadmap .horizon {
+      padding: 22px 22px;
     }
     .team .sect-head {
       grid-template-columns: 1fr;

--- a/components/sections/InvestorsSection.tsx
+++ b/components/sections/InvestorsSection.tsx
@@ -55,6 +55,52 @@ export function InvestorsSection() {
             </div>
           </section>
 
+          <section className="inv-tam" id="tam">
+            <div className="eb">Market</div>
+            <h2>
+              A <em>$100M ARR</em> opportunity, on a graph we own.
+            </h2>
+            <div className="tam-grid">
+              <div className="cell">
+                <span className="label">Bottom-up</span>
+                <div className="figure">~50K</div>
+                <p className="desc">
+                  Enterprise B2B sales teams running AI notetakers today. Every
+                  one has a memory problem.
+                </p>
+              </div>
+              <div className="cell">
+                <span className="label">Capture target</span>
+                <div className="figure">
+                  <em>0.5–1%</em> in 3 years
+                </div>
+                <p className="desc">
+                  250–1,000 teams × $50–100K ACV ={' '}
+                  <strong>$12M–$100M ARR</strong>.
+                </p>
+              </div>
+              <div className="cell">
+                <span className="label">Validation</span>
+                <div className="figure">
+                  Clay: <em>$1M → $100M</em>
+                </div>
+                <p className="desc">
+                  AI sales tooling category proves the scale. Clay hit $100M
+                  ARR in 2 years (a16z-led Series C, $3.1B valuation).
+                </p>
+              </div>
+            </div>
+            <div className="tam-counter">
+              <span className="label">Counterexample</span>
+              <p>
+                11x.ai raised <em>$74M</em> on autonomous AI SDRs and lost
+                70–80% of customers. Autonomous bots without structured
+                customer memory don&rsquo;t hold the relationship. That&rsquo;s
+                the gap we fill.
+              </p>
+            </div>
+          </section>
+
           <section className="moat" id="moat">
             <div className="eb">Moat</div>
             <h2>
@@ -89,14 +135,129 @@ export function InvestorsSection() {
             </div>
           </section>
 
-          <section className="roadmap">
-            <div className="roadmap-card">
-              <span className="pill">On the roadmap</span>
-              <span className="body">
-                A <em>Recall.ai meeting bot</em> that joins Zoom, Meet, and
-                Teams calls directly — feeding the extraction pipeline without
-                a transcript upload step.
-              </span>
+          <section className="inv-compete" id="competitive">
+            <div className="eb">Competitive landscape</div>
+            <h2>
+              Closest threats, and <em>where the shape doesn&rsquo;t fit.</em>
+            </h2>
+            <p className="compete-lede">
+              No single competitor ships pain-product mapping plus
+              contradiction detection plus handoff brief as an integrated
+              stack. The gap is the shape of the join, not the individual
+              capabilities.
+            </p>
+            <div className="compete-table">
+              <div className="compete-row compete-row--head">
+                <span className="c-who">Who</span>
+                <span className="c-threat">Threat</span>
+                <span className="c-why">Why they&rsquo;re not there yet</span>
+              </div>
+              <div className="compete-row">
+                <span className="c-who">Gong</span>
+                <span className="c-threat">
+                  <em>75%</em>
+                </span>
+                <span className="c-why">
+                  Could ship &ldquo;Gong Reactivate&rdquo; as a $10–20/seat
+                  add-on. Their focus is forecasting and coaching. Pain-product
+                  mapping is not their customer motion.
+                </span>
+              </div>
+              <div className="compete-row">
+                <span className="c-who">Clari + Salesloft</span>
+                <span className="c-threat">50%</span>
+                <span className="c-why">
+                  $450M combined ARR (merged Dec 2025). Call intelligence plus
+                  forecasting. Pain-timing is their natural expansion, but
+                  their account is stage and number, not qualitative shape.
+                </span>
+              </div>
+              <div className="compete-row">
+                <span className="c-who">HubSpot Breeze</span>
+                <span className="c-threat">50%</span>
+                <span className="c-why">
+                  200K customers, freemium. Could bundle pain-product mapping
+                  into Sales Hub — but bundling into a CRM flattens the graph,
+                  which is the thing that defends the wedge.
+                </span>
+              </div>
+              <div className="compete-row">
+                <span className="c-who">Salesforce Einstein</span>
+                <span className="c-threat">45%</span>
+                <span className="c-why">
+                  150K customers. Could bundle for free. Slow to move, but
+                  devastating if they do. Same flattening problem as HubSpot.
+                </span>
+              </div>
+              <div className="compete-row">
+                <span className="c-who">AskElephant</span>
+                <span className="c-threat">35%</span>
+                <span className="c-why">
+                  Closest on handoff docs. $99/mo anchor, 500+ teams, strong
+                  G2. Doesn&rsquo;t hold state between handoffs, and
+                  doesn&rsquo;t map pains to a product catalog.
+                </span>
+              </div>
+            </div>
+          </section>
+
+          <section className="roadmap" id="roadmap">
+            <div className="eb">Roadmap</div>
+            <h2>
+              What ships <em>next.</em>
+            </h2>
+            <div className="horizon-list">
+              <div className="horizon">
+                <div className="horizon-head">
+                  <span className="pill">V1.5 · Q2–Q3 2026</span>
+                  <span className="label">Capture + push</span>
+                </div>
+                <ul className="horizon-body">
+                  <li>
+                    <em>Recall.ai meeting bot</em> — joins Zoom, Meet, Teams
+                    directly. Extraction without a transcript upload step.
+                  </li>
+                  <li>
+                    CRM push to Monday and HubSpot — flat summary fields write
+                    back so reps don&rsquo;t double-enter.
+                  </li>
+                </ul>
+              </div>
+              <div className="horizon">
+                <div className="horizon-head">
+                  <span className="pill">V2 · Q4 2026</span>
+                  <span className="label">Enterprise readiness</span>
+                </div>
+                <ul className="horizon-body">
+                  <li>
+                    Salesforce and HubSpot native sync — the two buyers that
+                    sign the enterprise contract.
+                  </li>
+                  <li>
+                    Gong API transcript pull — turns Salency into the layer
+                    sitting on top of the most-entrenched input pipe.
+                  </li>
+                  <li>
+                    10 paying customers, $50–100K ACV range.
+                  </li>
+                </ul>
+              </div>
+              <div className="horizon">
+                <div className="horizon-head">
+                  <span className="pill">V2.5 · 2027</span>
+                  <span className="label">Scale decision</span>
+                </div>
+                <ul className="horizon-body">
+                  <li>
+                    $10–30M ARR target. Workflow integration depth (Productboard
+                    / Aha / Jira) locks switching cost to quarters, not weeks.
+                  </li>
+                  <li>
+                    Decision point: raise at the category-leader mark, or walk
+                    a profitability path into the expanded surface.
+                  </li>
+                </ul>
+              </div>
             </div>
           </section>
 
@@ -114,19 +275,22 @@ export function InvestorsSection() {
                 <div className="name">Howard Tam</div>
                 <div className="role">Co-founder &amp; CEO</div>
                 <p className="bio">
-                  Founding account executive at <em>Viggle</em> (a16z-backed),
-                  where he ran
-                  pilot-to-paid motions with the exact B2B buyers Salency sells
-                  to today. Before that, he led MUFG Hong Kong&apos;s first
-                  Panda Bond and handled business development at Sequence and
-                  Treasure. MBET, Waterloo.
+                  <em>Five founding-AE / BD seats in four years</em> — Dora,
+                  Sequence, Treasure, Nijta, Viggle (a16z-backed). Ran the
+                  HubSpot→Monday CRM migration at Sequence; came out knowing
+                  flat fields can&rsquo;t hold what the customer said. Before
+                  that he led MUFG Hong Kong&apos;s first Panda Bond. MBET,
+                  Waterloo.
                 </p>
                 <div className="founder-fit">
                   <div className="label">Unfair advantage</div>
                   <p>
-                    Has <em>lost deals to forgotten context personally</em>, in
-                    rooms where the budget was real. The product spec comes
-                    from that scar tissue — not from a market-map.
+                    Watched post-sale trust break when handovers didn&rsquo;t
+                    happen — a rep two desks away, a customer repeating
+                    themselves by minute 15.{' '}
+                    <em>
+                      The product spec comes from that, not from a market map.
+                    </em>
                   </p>
                 </div>
               </div>
@@ -160,12 +324,13 @@ export function InvestorsSection() {
               <div className="photo photo--teal">BO</div>
               <div className="body">
                 <div className="name">Babajide Okusanya</div>
-                <div className="role">Technical Lead</div>
+                <div className="role">Founding Engineer</div>
                 <p className="bio">
-                  Built Salency&apos;s{' '}
-                  <em>extraction and pain-to-product mapping engine</em>.
-                  Previously scaled a B2B marketplace to meaningful ARR as an
-                  applied-AI operator — not a research hire.
+                  Scaled <em>MakersValley</em> from 0 to $2M ARR (6.5y, NYC)
+                  as an applied-AI operator — not a research hire. Has shipped{' '}
+                  <em>provenance-tracked AI context systems</em> — the exact
+                  technical class Salency runs on. Trained 2,000+ engineers on
+                  AI-assisted workflows.
                 </p>
                 <div className="founder-fit">
                   <div className="label">Unfair advantage</div>


### PR DESCRIPTION
## Summary

PR 3 of the /why-salency → /investors strategic real-estate split. Adds the three missing investor-page signals and applies the bio honesty pass we locked in the last session.

**Sections added**
- `#tam` — market size strip: ~50K bottom-up, 0.5–1% capture target ($12M–$100M ARR), Clay validation ($1M → $100M in 2 years), 11x.ai counterexample
- `#competitive` — threat table with Gong (75%), Clari+Salesloft (50%), HubSpot Breeze (50%), Salesforce Einstein (45%), AskElephant (35%) and one-line "why they're not there yet" per row
- `#roadmap` — expanded from single V1.5 card to 3-horizon timeline (V1.5 capture+push, V2 enterprise readiness, V2.5 scale decision)

**Bio honesty pass**
- **Howard** — leads with the pattern: "Five founding-AE / BD seats in four years — Dora, Sequence, Treasure, Nijta, Viggle." Adds HubSpot→Monday CRM migration detail. Softens the "lost deals to forgotten context personally" overclaim to the observed post-sale trust break from the Sequence onboarding incident (option B from last session).
- **Babajide** — Technical Lead → Founding Engineer. Adds MakersValley 0→$2M ARR specifics (6.5y, NYC). Keeps the Orumilos IP-sensitive project name off the public page via the generic "provenance-tracked AI context systems" phrasing we agreed on last session.
- **Nikki** — unchanged.

**company-context.md sync**
- §3 Howard bio + §18 "why Howard" reason #1 updated to match Option B framing
- §3 Babajide bio + §18 "why Babajide" updated to Founding Engineer + MakersValley specifics
- Staged-ladder rule lines updated: public title reads "Founding Engineer" (still NOT "Co-founder" until Stage 3 triggers)

## Test plan
- [ ] Vercel preview: /investors renders TAM → Moat → Competitive → Roadmap → Team → Thesis
- [ ] TAM 3-cell grid collapses to stacked rows on mobile
- [ ] Competitive threat table readable at 375px (row header hidden, stacked layout)
- [ ] Roadmap horizon cards stack cleanly, copper pills render
- [ ] Howard bio + founder-fit card read the new pattern framing
- [ ] Babajide title reads "Founding Engineer" everywhere
- [ ] No copper-scope regression (eyebrows + h2 em + 1 anchor per strip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)