### PR TITLE
fix(motion): reveal above-fold ScrollReveal immediately on mount

### DIFF
--- a/components/ScrollReveal.tsx
+++ b/components/ScrollReveal.tsx
@@ -27,6 +27,17 @@ export function ScrollReveal({
       el.style.transitionDelay = `${delay}ms`;
     }
 
+    // If the element is already in viewport at mount, reveal it immediately.
+    // IntersectionObserver's first callback is async and can race with initial
+    // paint. On pages that wrap the whole body in a single ScrollReveal
+    // (e.g. /investors), the observer sometimes doesn't fire until a scroll
+    // event wakes it up, leaving content stuck at opacity: 0.
+    const rect = el.getBoundingClientRect();
+    if (rect.top < window.innerHeight && rect.bottom > 0) {
+      el.classList.add('is-visible');
+      return;
+    }
+
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {


### PR DESCRIPTION
## Summary

Fixes the blank-page-until-scroll bug on /investors.

**Repro:** fresh load /investors → everything below the header is invisible until you move the scroll wheel a notch. Then the whole page fades in at once.

**Cause:** \`app/investors/page.tsx\` wraps the entire \`<InvestorsSection />\` in a single \`<ScrollReveal>\`. \`.scroll-reveal\` defaults to \`opacity: 0; transform: translateY(24px)\`. The IntersectionObserver is supposed to fire on mount (the element is intersecting the viewport) and add \`.is-visible\`, but the observer's first callback is async and occasionally doesn't fire until a scroll event wakes it up. When that happens the whole page sits at opacity 0.

/why-salency doesn't show this because it was refactored to per-section ScrollReveal (each section wrapped individually, top section always firing reliably). /investors still uses the single-wrap pattern from a45cfdf.

**Fix:** before registering the observer, do a \`getBoundingClientRect()\` check. If the element is already in viewport, add \`is-visible\` immediately and skip the observer entirely. Below-fold elements still go through the observer path unchanged.

Surgical — fixes every page that uses the single-wrap pattern (/investors, /pilot, /pricing), doesn't touch per-section pages.

## Test plan
- [ ] Hard reload /investors → page renders fully on load, no scroll needed
- [ ] Hard reload /why-salency → below-fold sections still fade in as you scroll
- [ ] Hard reload / (landing) → hero + below-fold ScrollReveals behave normally
- [ ] prefers-reduced-motion still bypasses ScrollReveal entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)