### PR TITLE
refactor(investors): PR 2/4 — fold Moat into Platform, reorder, absorb why-now

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1325,35 +1325,11 @@ html {
     }
   }
 
-  /* Moat framing — why the data lives on Salency, not Salesforce (§6 platform-native posture, §8 uncopyable pair) */
-  .moat{
-    max-width:var(--page-max);margin:80px auto 0;padding:0 40px;
-
-    .eb{margin-bottom:28px;display:flex}
-    h2{
-      font-size:clamp(38px,4.2vw,54px);line-height:1.1;color:var(--ink);
-      margin:0 0 28px;max-width:28ch;text-wrap:balance;
-    }
-    p{
-      font-family:var(--font-body), 'Geist', sans-serif;font-weight:300;font-size:18px;
-      color:var(--ink-2);max-width:62ch;margin:0 0 18px;
-
-      em{font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;color:var(--copper);font-size:19px;font-weight:400}
-    }
-    .primitive{
-      margin-top:44px;padding:28px 32px;
-      background:rgba(254,133,49,.05);border:1px solid var(--copper-a18);
-      border-radius:12px;display:grid;grid-template-columns:auto 1fr;gap:28px;align-items:center;
-
-      .label{
-        font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
-        letter-spacing:.18em;text-transform:uppercase;color:var(--copper);
-      }
-      .title{
-        font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;font-size:22px;
-        line-height:1.35;color:var(--ink);max-width:62ch;margin:0;
-      }
-    }
+  /* Platform moat bridge — separates the "what we are" block from the
+     "why the shape defends" block inside the folded Platform section.
+     Mirrors .platform p styling but adds breathing room above. */
+  .platform .platform-moat-bridge{
+    margin-top:44px;
   }
 
   /* TAM — market size strip */
@@ -1667,7 +1643,6 @@ html {
     }
     .inv-intro,
     .platform,
-    .moat,
     .inv-tam,
     .inv-compete,
     .roadmap,
@@ -1676,8 +1651,7 @@ html {
       padding-left: 22px;
       padding-right: 22px;
     }
-    .platform .primitive,
-    .moat .primitive {
+    .platform .primitive {
       /* Stack the "Data primitive" label above the title on narrow screens. */
       grid-template-columns: 1fr;
       gap: 12px;

--- a/components/sections/InvestorsSection.tsx
+++ b/components/sections/InvestorsSection.tsx
@@ -27,7 +27,7 @@ export function InvestorsSection() {
 
         <div className="reg-inv">
           <section className="platform" id="platform">
-            <div className="eb">Platform</div>
+            <div className="eb">Platform &amp; moat</div>
             <h2>
               The <em>structured memory layer</em> for B2B sales accounts.
             </h2>
@@ -51,6 +51,28 @@ export function InvestorsSection() {
                 Structured account memory —{' '}
                 <em>cited, scoped, and compounding</em> — is the input every
                 future revenue tool will be measured against.
+              </p>
+            </div>
+            <p className="platform-moat-bridge">
+              The wedge is the <em>shape of the data.</em> Contradiction pairs,
+              pain evolution over time, confidence-ranked pain → product
+              matches, cross-account pattern graphs. None of these fit a CRM
+              row. Flatten any of them into a field and you kill the thing
+              that makes Salency uncopyable. That&rsquo;s why we sit{' '}
+              <em>on top</em> of your stack, not inside it. Reps live in CRM
+              for pipeline stages. Reps live in Salency for the qualitative
+              layer — what the customer actually said, what contradicts what,
+              which pains map to which products.
+            </p>
+            <div className="primitive">
+              <span className="label">The uncopyable pair</span>
+              <p className="title">
+                Pain-product mapping plus contradiction detection, embedded in
+                product-management workflows.{' '}
+                <em>
+                  Either alone is defensible for 6 to 9 months. Together, with
+                  workflow depth, switching cost is measured in quarters.
+                </em>
               </p>
             </div>
           </section>
@@ -97,40 +119,6 @@ export function InvestorsSection() {
                 70–80% of customers. Autonomous bots without structured
                 customer memory don&rsquo;t hold the relationship. That&rsquo;s
                 the gap we fill.
-              </p>
-            </div>
-          </section>
-
-          <section className="moat" id="moat">
-            <div className="eb">Moat</div>
-            <h2>
-              Why this doesn&apos;t live in <em>Salesforce.</em>
-            </h2>
-            <p>
-              The wedge is the <em>shape of the data</em>. Contradiction pairs,
-              pain evolution over time, confidence-ranked pain → product
-              matches, cross-account pattern graphs. None of these fit a CRM
-              row. Flatten any of them into a field and you kill the thing
-              that makes Salency uncopyable.
-            </p>
-            <p>
-              So Salency sits <em>on top</em> of your stack, not inside it.
-              Linear syncs completion status to GitHub, keeps the ticket
-              experience in Linear. Superhuman reads your Gmail, keeps the
-              triage experience in Superhuman. Reps live in CRM for pipeline
-              stages. Reps live in Salency for the qualitative layer — what
-              the customer actually said, what contradicts what, which pains
-              map to which products.
-            </p>
-            <div className="primitive">
-              <span className="label">The uncopyable pair</span>
-              <p className="title">
-                Pain-product mapping plus contradiction detection, embedded in
-                product-management workflows.{' '}
-                <em>
-                  Either alone is defensible for 6 to 9 months. Together, with
-                  workflow depth, switching cost is measured in quarters.
-                </em>
               </p>
             </div>
           </section>
@@ -197,66 +185,6 @@ export function InvestorsSection() {
                   G2. Doesn&rsquo;t hold state between handoffs, and
                   doesn&rsquo;t map pains to a product catalog.
                 </span>
-              </div>
-            </div>
-          </section>
-
-          <section className="roadmap" id="roadmap">
-            <div className="eb">Roadmap</div>
-            <h2>
-              What ships <em>next.</em>
-            </h2>
-            <div className="horizon-list">
-              <div className="horizon">
-                <div className="horizon-head">
-                  <span className="pill">V1.5 · Q2–Q3 2026</span>
-                  <span className="label">Capture + push</span>
-                </div>
-                <ul className="horizon-body">
-                  <li>
-                    <em>Recall.ai meeting bot</em> — joins Zoom, Meet, Teams
-                    directly. Extraction without a transcript upload step.
-                  </li>
-                  <li>
-                    CRM push to Monday and HubSpot — flat summary fields write
-                    back so reps don&rsquo;t double-enter.
-                  </li>
-                </ul>
-              </div>
-              <div className="horizon">
-                <div className="horizon-head">
-                  <span className="pill">V2 · Q4 2026</span>
-                  <span className="label">Enterprise readiness</span>
-                </div>
-                <ul className="horizon-body">
-                  <li>
-                    Salesforce and HubSpot native sync — the two buyers that
-                    sign the enterprise contract.
-                  </li>
-                  <li>
-                    Gong API transcript pull — turns Salency into the layer
-                    sitting on top of the most-entrenched input pipe.
-                  </li>
-                  <li>
-                    10 paying customers, $50–100K ACV range.
-                  </li>
-                </ul>
-              </div>
-              <div className="horizon">
-                <div className="horizon-head">
-                  <span className="pill">V2.5 · 2027</span>
-                  <span className="label">Scale decision</span>
-                </div>
-                <ul className="horizon-body">
-                  <li>
-                    $10–30M ARR target. Workflow integration depth (Productboard
-                    / Aha / Jira) locks switching cost to quarters, not weeks.
-                  </li>
-                  <li>
-                    Decision point: raise at the category-leader mark, or walk
-                    a profitability path into the expanded surface.
-                  </li>
-                </ul>
               </div>
             </div>
           </section>
@@ -348,9 +276,69 @@ export function InvestorsSection() {
             </div>
           </section>
 
+          <section className="roadmap" id="roadmap">
+            <div className="eb">Roadmap</div>
+            <h2>
+              What ships <em>next.</em>
+            </h2>
+            <div className="horizon-list">
+              <div className="horizon">
+                <div className="horizon-head">
+                  <span className="pill">V1.5 · Q2–Q3 2026</span>
+                  <span className="label">Capture + push</span>
+                </div>
+                <ul className="horizon-body">
+                  <li>
+                    <em>Recall.ai meeting bot</em> — joins Zoom, Meet, Teams
+                    directly. Extraction without a transcript upload step.
+                  </li>
+                  <li>
+                    CRM push to Monday and HubSpot — flat summary fields write
+                    back so reps don&rsquo;t double-enter.
+                  </li>
+                </ul>
+              </div>
+              <div className="horizon">
+                <div className="horizon-head">
+                  <span className="pill">V2 · Q4 2026</span>
+                  <span className="label">Enterprise readiness</span>
+                </div>
+                <ul className="horizon-body">
+                  <li>
+                    Salesforce and HubSpot native sync — the two buyers that
+                    sign the enterprise contract.
+                  </li>
+                  <li>
+                    Gong API transcript pull — turns Salency into the layer
+                    sitting on top of the most-entrenched input pipe.
+                  </li>
+                  <li>
+                    10 paying customers, $50–100K ACV range.
+                  </li>
+                </ul>
+              </div>
+              <div className="horizon">
+                <div className="horizon-head">
+                  <span className="pill">V2.5 · 2027</span>
+                  <span className="label">Scale decision</span>
+                </div>
+                <ul className="horizon-body">
+                  <li>
+                    $10–30M ARR target. Workflow integration depth (Productboard
+                    / Aha / Jira) locks switching cost to quarters, not weeks.
+                  </li>
+                  <li>
+                    Decision point: raise at the category-leader mark, or walk
+                    a profitability path into the expanded surface.
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </section>
+
           <section className="thesis" id="thesis">
             <div className="thesis-card">
-              <div className="eb">Future-fit thesis</div>
+              <div className="eb">Why now</div>
               <h2>
                 The <em>bottleneck</em> is about to shift.
               </h2>
@@ -367,6 +355,12 @@ export function InvestorsSection() {
                 doesn&apos;t know what the buyer has already told you. The rep
                 inheriting the account doesn&apos;t either. The asset that
                 makes either one useful is the same asset.
+              </p>
+              <p>
+                Every LLM commoditizes extraction. What doesn&rsquo;t
+                commoditize is the <em>customer-built graph</em> of pains,
+                products, and contradictions — and that graph compounds per
+                customer, per call. The moat is the data shape, not the model.
               </p>
               <div className="thesis-close">
                 Salency owns that layer. The longer a team runs it,{' '}


### PR DESCRIPTION
## Summary

Part 2 of 4 in the site content-migration arc. /investors goes from 8 sections to 7, but the 7 are denser and better-ordered.

**Before:** intro · platform · tam · moat · competitive · roadmap · team · thesis (8)
**After:**  intro · platform+moat · tam · competitive · team · roadmap · thesis (7)

## Three changes

1. **Fold Moat into Platform.** One richer section covering "what we are" (data primitive) + "why the shape defends" (uncopyable pair). Two primitive cards inside one section, bridged by a paragraph on why flattening the graph kills the wedge. Eyebrow reads "Platform & moat" to signal the widened scope.

2. **Swap Team and Roadmap.** Reader asks "who ships this?" before "where are they going?" — roadmap credibility depends on team credibility. Evidence before prediction.

3. **Absorb FiveYearBet's "moat is the graph, not the model" beat into the Thesis close.** New third paragraph inside the thesis-card. Eyebrow changes from "Future-fit thesis" to "Why now" — punchier, matches the migrated content's intent. /why-salency FiveYearBet removal ships in PR 3.

## Cleanup

Removed the orphan `.moat` rules (~30 lines of CSS) since the section no longer exists. Added a tiny `.platform-moat-bridge` selector for the paragraph between the two primitive cards. Mobile overrides dropped the `.moat` selector too.

## Content-migration arc

- PR 1 (merged): /memory absorbs MemoryStack
- **PR 2 (this):** /investors fold + reorder + absorb
- PR 3 (next): /why-salency trim + reorder
- PR 4: /our-story new page + compress /investors Team section

## Test plan

- [ ] Vercel preview: /investors reads intro → platform (with 2 primitive cards) → TAM → competitive → team → roadmap → thesis
- [ ] Two primitive cards inside Platform stack cleanly with a breathing paragraph between them
- [ ] Team section appears BEFORE Roadmap (evidence before prediction)
- [ ] Thesis close eyebrow reads "Why now" (not "Future-fit thesis")
- [ ] Third thesis paragraph on data-shape moat lands before the "Salency owns that layer" close
- [ ] Mobile: sections stack cleanly at 375px, no broken padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)