### PR TITLE
feat(our-story): PR 4/4 — new /our-story page, compress /investors Team

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1489,57 +1489,50 @@ html {
     }
   }
 
-  .founder{
-    display:grid;grid-template-columns:128px 1fr;gap:40px;
-    padding-bottom:56px;margin-bottom:56px;border-bottom:1px solid var(--hair);
+  /* Compact team row on /investors — three rows, each is photo + name +
+     role + one-line bet. Full bios live on /our-story (linked below). */
+  .team-compact{
+    border-top:1px solid var(--hair-2);margin-bottom:24px;
+  }
+  .team-compact-row{
+    display:grid;grid-template-columns:72px 1fr;gap:24px;
+    padding:20px 0;border-bottom:1px solid var(--hair);align-items:center;
 
-    &:last-child{border-bottom:0;margin-bottom:0}
-    &.founder--reversed{
-      grid-template-columns:1fr 128px;
-
-      .photo{order:2}
-      .body{order:1;text-align:left}
-    }
+    &:last-child{border-bottom:none}
 
     .photo{
-      width:128px;height:128px;border-radius:14px;
+      width:72px;height:72px;border-radius:10px;
       background:linear-gradient(135deg,var(--copper-a22),rgba(209,60,19,.35));
-      color:#FFEDE8;font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;font-size:52px;
+      color:#FFEDE8;font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;font-size:28px;
       display:flex;align-items:center;justify-content:center;letter-spacing:-.01em;
       border:1px solid var(--copper-a30);
 
       &.photo--violet{background:linear-gradient(135deg,rgba(107,78,255,.22),rgba(42,30,128,.5));border-color:rgba(107,78,255,.3);color:#D8CEFF}
       &.photo--teal{background:linear-gradient(135deg,rgba(0,181,160,.22),rgba(0,107,94,.45));border-color:rgba(0,181,160,.3);color:#B5F0E5}
     }
+  }
+  .team-compact-body{
+    display:grid;grid-template-columns:minmax(180px,220px) auto 1fr;gap:20px;align-items:baseline;
+
     .name{
-      font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;font-size:32px;
-      line-height:1.1;letter-spacing:-.015em;color:var(--ink);margin:0 0 4px;
+      font-family:var(--font-display), 'Instrument Serif', serif;font-weight:500;font-size:20px;color:var(--ink);
     }
     .role{
       font-family:'Geist Mono',monospace;font-size:11px;font-weight:500;
-      letter-spacing:.18em;text-transform:uppercase;color:var(--copper);margin-bottom:18px;
+      letter-spacing:.18em;text-transform:uppercase;color:var(--copper);
     }
-    .bio{
-      font-family:var(--font-body), 'Geist', sans-serif;font-weight:300;font-size:16px;line-height:1.75;
-      color:var(--ink-2);max-width:62ch;margin:0 0 20px;
-
-      em{font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;color:var(--copper);font-size:17px;font-weight:400}
+    .line{
+      font-family:var(--font-body), 'Geist', sans-serif;font-weight:300;font-size:14.5px;
+      line-height:1.55;color:var(--ink-2);margin:0;
     }
-    .founder-fit{
-      padding:14px 18px;border-left:2px solid var(--copper-a40);
-      background:var(--copper-a03);
+  }
+  .team-compact-link{
+    display:inline-block;font-family:'Geist Mono',monospace;font-size:12px;
+    letter-spacing:.12em;color:var(--copper);text-decoration:none;
+    border-bottom:1px solid var(--copper-a35);padding-bottom:2px;
+    transition:border-color .18s,color .18s;
 
-      .label{
-        font-family:'Geist Mono',monospace;font-size:10px;font-weight:500;
-        letter-spacing:.18em;text-transform:uppercase;color:var(--copper);margin-bottom:4px;
-      }
-      p{
-        font-family:var(--font-body), 'Geist', sans-serif;font-size:14.5px;line-height:1.55;color:var(--ink-2);
-        font-weight:300;margin:0;max-width:62ch;
-
-        em{font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;color:var(--copper);font-weight:400}
-      }
-    }
+    &:hover{color:var(--ink);border-bottom-color:var(--ink)}
   }
 
   /* Future-fit thesis */
@@ -1635,6 +1628,122 @@ html {
     }
   }
 
+  /* ═══════════ /our-story ═══════════ */
+  .story{
+    max-width:var(--page-max);margin:40px auto 120px;padding:20px 40px;
+  }
+
+  .story-intro{
+    padding-bottom:56px;border-bottom:1px solid var(--hair);margin-bottom:72px;
+
+    .eb{margin-bottom:28px;display:flex}
+    h1{
+      font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;
+      font-size:clamp(40px,4.8vw,64px);line-height:1.06;letter-spacing:-.025em;
+      color:var(--ink);margin:0 0 28px;max-width:22ch;text-wrap:balance;
+
+      em{font-style:italic;color:var(--copper)}
+    }
+    .lede{
+      font-family:var(--font-body), 'Geist', sans-serif;font-weight:300;font-size:18px;
+      line-height:1.7;color:var(--ink-2);max-width:62ch;margin:0;
+    }
+  }
+
+  .story-origin{
+    padding:32px 40px;border-left:2px solid var(--copper-a40);
+    background:var(--copper-a03);margin-bottom:96px;max-width:68ch;
+
+    .eb{margin-bottom:18px;display:flex}
+    .story-origin-body{
+      font-family:var(--font-body), 'Geist', sans-serif;font-weight:300;font-size:17px;
+      line-height:1.7;color:var(--ink-2);margin:0 0 16px;
+
+      &:last-child{margin-bottom:0}
+      em{font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;
+        color:var(--copper);font-size:18px;font-weight:400}
+    }
+  }
+
+  .story-founders{
+    .eb{margin-bottom:40px;display:flex}
+  }
+
+  .story-founder{
+    display:grid;grid-template-columns:220px 1fr;gap:56px;
+    padding-bottom:64px;margin-bottom:64px;border-bottom:1px solid var(--hair);
+
+    &:last-child{border-bottom:none;margin-bottom:0}
+  }
+
+  .story-founder-meta{
+    display:flex;flex-direction:column;gap:20px;
+
+    .photo{
+      width:128px;height:128px;border-radius:14px;
+      background:linear-gradient(135deg,var(--copper-a22),rgba(209,60,19,.35));
+      color:#FFEDE8;font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;font-size:52px;
+      display:flex;align-items:center;justify-content:center;letter-spacing:-.01em;
+      border:1px solid var(--copper-a30);
+
+      &.photo--violet{background:linear-gradient(135deg,rgba(107,78,255,.22),rgba(42,30,128,.5));border-color:rgba(107,78,255,.3);color:#D8CEFF}
+      &.photo--teal{background:linear-gradient(135deg,rgba(0,181,160,.22),rgba(0,107,94,.45));border-color:rgba(0,181,160,.3);color:#B5F0E5}
+    }
+  }
+
+  .story-founder-name{
+    font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;font-size:32px;
+    line-height:1.1;letter-spacing:-.015em;color:var(--ink);margin:0 0 4px;
+  }
+
+  .story-founder-role{
+    font-family:'Geist Mono',monospace;font-size:11px;font-weight:500;
+    letter-spacing:.18em;text-transform:uppercase;color:var(--copper);
+  }
+
+  .story-founder-body p{
+    font-family:var(--font-body), 'Geist', sans-serif;font-weight:300;font-size:16.5px;
+    line-height:1.75;color:var(--ink-2);max-width:62ch;margin:0 0 18px;
+
+    &:last-child{margin-bottom:0}
+    em{font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;
+      color:var(--copper);font-size:17.5px;font-weight:400}
+  }
+
+  .story-close{
+    margin-top:96px;padding-top:56px;border-top:1px solid var(--hair-2);text-align:center;
+
+    p{
+      font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;
+      font-size:clamp(22px,2.4vw,28px);line-height:1.4;color:var(--ink);
+      max-width:48ch;margin:0 auto 28px;
+
+      em{font-style:italic;color:var(--copper)}
+    }
+  }
+
+  .story-close-link{
+    font-family:'Geist Mono',monospace;font-size:12px;font-weight:500;
+    letter-spacing:.18em;text-transform:uppercase;color:var(--copper);
+    text-decoration:none;border-bottom:1px solid var(--copper-a35);
+    padding-bottom:4px;transition:border-color .18s,color .18s;
+
+    &:hover{color:var(--ink);border-bottom-color:var(--ink)}
+  }
+
+  /* /our-story mobile */
+  @media (max-width:768px){
+    .story{padding:20px 22px;margin-bottom:80px}
+    .story-intro{padding-bottom:40px;margin-bottom:48px}
+    .story-origin{padding:24px 22px;margin-bottom:56px}
+    .story-founder{
+      grid-template-columns:1fr;gap:24px;padding-bottom:40px;margin-bottom:40px;
+    }
+    .story-founder-meta{flex-direction:row;align-items:center;gap:16px}
+    .story-founder-meta .photo{width:72px;height:72px;font-size:28px}
+    .story-close{margin-top:64px;padding-top:40px}
+  }
+
   /* ═══════════ Investor page — mobile overrides ═══════════ */
   @media (max-width: 768px) {
     .investors-register .reg-inv {
@@ -1686,18 +1795,21 @@ html {
       gap: 12px;
       margin-bottom: 40px;
     }
-    .founder,
-    .founder.founder--reversed {
-      /* Photo on top, body below — at 375px the 128px photo + 1fr body
-         cramped the bio to ~12ch per line. Reversed variant collapses
-         to the same stacked layout. */
-      grid-template-columns: 1fr;
-      gap: 20px;
-      padding-bottom: 40px;
-      margin-bottom: 40px;
+    .team-compact-row {
+      /* Narrow screens: shrink the photo cell and stack name/role/line. */
+      grid-template-columns: 56px 1fr;
+      gap: 14px;
+      padding: 16px 0;
 
-      .photo { order: 0; width: 96px; height: 96px; font-size: 40px; }
-      .body { order: 1; text-align: left; }
+      .photo {
+        width: 56px;
+        height: 56px;
+        font-size: 22px;
+      }
+    }
+    .team-compact-body {
+      grid-template-columns: 1fr;
+      gap: 4px;
     }
     .thesis-card {
       /* 56/64 padding was the desktop editorial feel — at mobile that

--- a/app/our-story/page.tsx
+++ b/app/our-story/page.tsx
@@ -1,0 +1,22 @@
+import { MarketingHeader } from '@/components/MarketingHeader';
+import { ScrollReveal } from '@/components/ScrollReveal';
+import { OurStorySection } from '@/components/sections/OurStorySection';
+import { SiteFooter } from '@/components/sections/SiteFooter';
+
+export const metadata = {
+  title: 'Our story · Salency',
+  description:
+    'Why three people bet four months on fixing the handoff layer in B2B sales. The founding moment, the team, and what we believe is about to shift.',
+};
+
+export default function OurStoryPage() {
+  return (
+    <div className="page">
+      <MarketingHeader />
+      <ScrollReveal>
+        <OurStorySection />
+      </ScrollReveal>
+      <SiteFooter />
+    </div>
+  );
+}

--- a/components/MarketingHeader.tsx
+++ b/components/MarketingHeader.tsx
@@ -15,6 +15,7 @@ const links: NavLink[] = [
   { label: 'Products', href: '/' },
   { label: 'Why Salency', href: '/why-salency' },
   { label: 'Memory', href: '/memory' },
+  { label: 'Our story', href: '/our-story' },
   { label: 'Investors', href: '/investors' },
   { label: 'Pricing', href: '/pricing' },
 ];

--- a/components/sections/InvestorsSection.tsx
+++ b/components/sections/InvestorsSection.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 export function InvestorsSection() {
   return (
     <>
@@ -197,83 +199,45 @@ export function InvestorsSection() {
               </h2>
             </div>
 
-            <div className="founder">
-              <div className="photo">HT</div>
-              <div className="body">
-                <div className="name">Howard Tam</div>
-                <div className="role">Co-founder &amp; CEO</div>
-                <p className="bio">
-                  <em>Five founding-AE / BD seats in four years</em> — Dora,
-                  Sequence, Treasure, Nijta, Viggle (a16z-backed). Ran the
-                  HubSpot→Monday CRM migration at Sequence; came out knowing
-                  flat fields can&rsquo;t hold what the customer said. Before
-                  that he led MUFG Hong Kong&apos;s first Panda Bond. MBET,
-                  Waterloo.
-                </p>
-                <div className="founder-fit">
-                  <div className="label">Unfair advantage</div>
-                  <p>
-                    Watched post-sale trust break when handovers didn&rsquo;t
-                    happen — a rep two desks away, a customer repeating
-                    themselves by minute 15.{' '}
-                    <em>
-                      The product spec comes from that, not from a market map.
-                    </em>
+            <div className="team-compact">
+              <div className="team-compact-row">
+                <div className="photo">HT</div>
+                <div className="team-compact-body">
+                  <span className="name">Howard Tam</span>
+                  <span className="role">Co-founder &amp; CEO</span>
+                  <p className="line">
+                    Five founding-AE / BD seats in four years. Ran the
+                    HubSpot→Monday CRM migration at Sequence.
+                  </p>
+                </div>
+              </div>
+              <div className="team-compact-row">
+                <div className="photo photo--violet">NI</div>
+                <div className="team-compact-body">
+                  <span className="name">Nikki Ip</span>
+                  <span className="role">Co-founder &amp; COO</span>
+                  <p className="line">
+                    Runs revenue analytics + operational strategy at
+                    Adaptavist Group.
+                  </p>
+                </div>
+              </div>
+              <div className="team-compact-row">
+                <div className="photo photo--teal">BO</div>
+                <div className="team-compact-body">
+                  <span className="name">Babajide Okusanya</span>
+                  <span className="role">Founding Engineer</span>
+                  <p className="line">
+                    Scaled MakersValley from 0 to $2M ARR (6.5y, NYC). Ships
+                    provenance-tracked AI context systems.
                   </p>
                 </div>
               </div>
             </div>
 
-            <div className="founder founder--reversed">
-              <div className="photo photo--violet">NI</div>
-              <div className="body">
-                <div className="name">Nikki Ip</div>
-                <div className="role">Co-founder &amp; COO</div>
-                <p className="bio">
-                  Runs revenue analytics and operational strategy at{' '}
-                  <em>Adaptavist Group</em>, where she owns the pipeline
-                  instrumentation Salency&apos;s buyers are trying to build
-                  internally. Prior background in institutional client
-                  management and AML/KYC compliance in banking.
-                </p>
-                <div className="founder-fit">
-                  <div className="label">Unfair advantage</div>
-                  <p>
-                    Knows what sales ops <em>actually trusts</em>, how handoffs
-                    break at 50 reps, and which metrics survive a board deck.
-                    She writes the go-to-market motion from the buyer&apos;s
-                    side of the desk.
-                  </p>
-                </div>
-              </div>
-            </div>
-
-            <div className="founder">
-              <div className="photo photo--teal">BO</div>
-              <div className="body">
-                <div className="name">Babajide Okusanya</div>
-                <div className="role">Founding Engineer</div>
-                <p className="bio">
-                  Scaled <em>MakersValley</em> from 0 to $2M ARR (6.5y, NYC)
-                  as an applied-AI operator — not a research hire. Has shipped{' '}
-                  <em>provenance-tracked AI context systems</em> — the exact
-                  technical class Salency runs on. Trained 2,000+ engineers on
-                  AI-assisted workflows.
-                </p>
-                <div className="founder-fit">
-                  <div className="label">Unfair advantage</div>
-                  <p>
-                    The core technical risk in Salency is not &ldquo;can an LLM
-                    summarise a call.&rdquo; It is{' '}
-                    <em>
-                      &ldquo;can extractions stay cited, scoped to a specific
-                      catalog, and trustworthy at volume.&rdquo;
-                    </em>{' '}
-                    He has shipped that class of system before.
-                  </p>
-                </div>
-              </div>
-            </div>
+            <Link href="/our-story" className="team-compact-link">
+              Full bios + founding story on /our-story →
+            </Link>
           </section>
 
           <section className="roadmap" id="roadmap">

--- a/components/sections/OurStorySection.tsx
+++ b/components/sections/OurStorySection.tsx
@@ -1,0 +1,150 @@
+import Link from 'next/link';
+
+export function OurStorySection() {
+  return (
+    <section className="story">
+      <div className="story-intro">
+        <span className="eb">Our story</span>
+        <h1>
+          Three people. Four months.{' '}
+          <em>One bet about how sales actually works.</em>
+        </h1>
+        <p className="lede">
+          We started Salency because we watched the same thing fail in
+          different rooms — reps inheriting accounts with no memory of what
+          was said, customers repeating themselves, deals losing trust at
+          the handover. Every behavioral fix made it worse. This is the
+          story of what we did instead.
+        </p>
+      </div>
+
+      <div className="story-origin">
+        <span className="eb">The moment</span>
+        <p className="story-origin-body">
+          Late 2024. Howard was helping out on customer success at Sequence.
+          First onboarding call for a new web3 game-studio customer. By
+          minute 15 the customer had said some version of{' '}
+          <em>&ldquo;I already told your colleague this&rdquo;</em> three
+          times. The rep who closed the deal was two desks away. Nobody had
+          asked him to do a handover. The CRM had a stage field and a
+          one-line note.
+        </p>
+        <p className="story-origin-body">
+          Howard stopped thinking of this as a behavior problem. Behavior
+          doesn&rsquo;t fail at that scale. <em>Infrastructure does.</em>
+        </p>
+      </div>
+
+      <div className="story-founders">
+        <span className="eb">Who&rsquo;s building it</span>
+
+        <article className="story-founder">
+          <aside className="story-founder-meta">
+            <div className="photo">HT</div>
+            <div className="story-founder-identity">
+              <h2 className="story-founder-name">Howard Tam</h2>
+              <div className="story-founder-role">Co-founder &amp; CEO</div>
+            </div>
+          </aside>
+          <div className="story-founder-body">
+            <p>
+              Five founding-AE / BD seats in four years —{' '}
+              <em>Dora, Sequence, Treasure, Nijta, Viggle</em> (a16z-backed).
+              Ran the HubSpot→Monday CRM migration at Sequence and came out
+              knowing flat fields can&rsquo;t hold what the customer said.
+            </p>
+            <p>
+              In January 2026 he interviewed a senior relationship manager at
+              a fintech who said 40–50% of her customers get visibly annoyed
+              when asked to repeat themselves. Her verbatim:{' '}
+              <em>
+                &ldquo;I avoid recording my calls because people tense
+                up.&rdquo;
+              </em>{' '}
+              That was the input constraint named by the person Salency was
+              being built for.
+            </p>
+            <p>
+              Before sales, Howard led MUFG Hong Kong&apos;s first Panda
+              Bond issuance. MBET, Waterloo.
+            </p>
+          </div>
+        </article>
+
+        <article className="story-founder">
+          <aside className="story-founder-meta">
+            <div className="photo photo--violet">NI</div>
+            <div className="story-founder-identity">
+              <h2 className="story-founder-name">Nikki Ip</h2>
+              <div className="story-founder-role">Co-founder &amp; COO</div>
+            </div>
+          </aside>
+          <div className="story-founder-body">
+            <p>
+              Runs revenue analytics and operational strategy at{' '}
+              <em>Adaptavist Group</em>, where she owns the pipeline
+              instrumentation Salency&rsquo;s buyers are trying to build for
+              themselves.
+            </p>
+            <p>
+              When Howard showed her the thesis, her first reaction was{' '}
+              <em>
+                &ldquo;I&rsquo;ve been doing this by hand for five
+                years.&rdquo;
+              </em>{' '}
+              She joined as co-founder two weeks later.
+            </p>
+            <p>
+              Background before Adaptavist: institutional client management
+              and AML/KYC compliance in banking. She writes the go-to-market
+              motion from the buyer&rsquo;s side of the desk — knows what
+              sales ops actually trusts, how handoffs break at 50 reps, and
+              which metrics survive a board deck.
+            </p>
+          </div>
+        </article>
+
+        <article className="story-founder">
+          <aside className="story-founder-meta">
+            <div className="photo photo--teal">BO</div>
+            <div className="story-founder-identity">
+              <h2 className="story-founder-name">Babajide Okusanya</h2>
+              <div className="story-founder-role">Founding Engineer</div>
+            </div>
+          </aside>
+          <div className="story-founder-body">
+            <p>
+              Scaled <em>MakersValley</em> from 0 to $2M ARR (6.5y, NYC) as
+              an applied-AI operator — not a research hire. Built
+              Salency&rsquo;s extraction and pain-to-product mapping engine.
+            </p>
+            <p>
+              The core technical risk in Salency isn&rsquo;t &ldquo;can an
+              LLM summarise a call.&rdquo; It&rsquo;s{' '}
+              <em>
+                &ldquo;can extractions stay cited, scoped to a specific
+                catalog, and trustworthy at volume.&rdquo;
+              </em>{' '}
+              He has shipped that class of system before —
+              provenance-tracked AI context systems in production.
+            </p>
+            <p>
+              Along the way he trained 2,000+ engineers on AI-assisted
+              workflows.
+            </p>
+          </div>
+        </article>
+      </div>
+
+      <div className="story-close">
+        <p>
+          What we bet on: institutional memory isn&rsquo;t another feature.{' '}
+          <em>It&rsquo;s a layer.</em> And the bottleneck is about to shift.
+        </p>
+        <Link href="/investors" className="story-close-link">
+          Read the full thesis →
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/components/sections/SiteFooter.tsx
+++ b/components/sections/SiteFooter.tsx
@@ -7,6 +7,7 @@ export function SiteFooter() {
       <nav>
         <Link href="/why-salency" className="footer-link">Why Salency</Link>
         <Link href="/memory" className="footer-link">Memory</Link>
+        <Link href="/our-story" className="footer-link">Our story</Link>
         <Link href="/pricing" className="footer-link">Pricing</Link>
         <Link href="/investors" className="footer-link">Investors</Link>
         <Link href="/privacy" className="footer-link">Privacy</Link>


### PR DESCRIPTION
## Summary

Closes the content-migration arc. New `/our-story` page with rich narrative bios + origin moment; `/investors` Team section compresses to a compact row pointing there.

## New page: /our-story

**Structure (4 beats):**
1. **Intro hero** — "Three people. Four months. One bet about how sales actually works."
2. **The moment** — the Sequence onboarding call: customer saying "I already told your colleague this" by minute 15, rep two desks away, no handover, CRM had a stage field and a one-line note. This is the scar tissue that spec'd the product.
3. **Who's building it** — 3 founder narrative sections. Each ~3 paragraphs combining personal arc + professional evidence. Richer than the old team strip.
4. **Close** — "Institutional memory isn't another feature. It's a layer. And the bottleneck is about to shift." Link out to `/investors` for the full thesis.

Files:
- `app/our-story/page.tsx` (route)
- `components/sections/OurStorySection.tsx` (content)

## /investors Team section compression

Replaced the three expanded `.founder` blocks (~100 lines JSX, photo + bio + "unfair advantage" sub-card each) with a compact `team-compact` layout: **photo + name + role + one-line bet per row, plus "Full bios + founding story on /our-story →" link out.**

Saves ~30% vertical height on /investors. Investor reader gets the fast scan; anyone who wants the story clicks through.

## Nav

- **MarketingHeader:** added "Our story" link (6 items total)
- **SiteFooter:** added "Our story" link

## CSS

- Added ~140 lines for `.story-*` selectors (intro, origin, founders, founder-meta, body, close, link) + mobile overrides
- Added ~50 lines for `.team-compact*` selectors
- Removed ~52 lines of orphan `.founder` / `.founder-fit` / `founder--reversed` CSS + its mobile overrides
- Net +140 CSS lines, all earning their place on the new page

## Content-migration arc — done

- PR 1 (merged): /memory absorbs MemoryStack
- PR 2 (merged): /investors fold + reorder + absorb why-now
- PR 3 (merged): /why-salency trim + reorder to 6 sections
- **PR 4 (this):** /our-story new + compress /investors Team

## Test plan

- [ ] Vercel preview: /our-story renders hero → origin → 3 founders → close
- [ ] Mobile /our-story: founder meta row stacks photo horizontally at 375px, 3-column body becomes 1-col
- [ ] /investors Team section now shows 3 compact rows + link, no more "Unfair advantage" sub-cards
- [ ] MarketingHeader shows "Our story" link between "Memory" and "Investors"
- [ ] Footer lists "Our story" as link
- [ ] ScrollReveal on /our-story fires on load (above-fold content) via the mount-check hotfix from PR #94
- [ ] No console errors, no broken references to deleted .founder class

🤖 Generated with [Claude Code](https://claude.com/claude-code)