### PR TITLE
fix(style): Problem-section cost labels squashed to 113px + dashed dividers misaligned

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -888,6 +888,7 @@ html {
   .prob-card{
     padding:40px 36px 40px 0;border-right:1px solid var(--hair);
     position:relative;
+    display:flex;flex-direction:column;
   }
   .prob-card:nth-child(n+2){padding-left:36px}
   .prob-card:last-child{border-right:0}
@@ -910,18 +911,13 @@ html {
     line-height:1.6;color:var(--ink-2);margin:0 0 24px;max-width:32ch;
   }
   .prob-card .cost{
-    display:flex;align-items:baseline;gap:10px;
     padding-top:16px;border-top:1px dashed var(--hair-2);
-  }
-  /* "40–50%" style data figures read brightness, not hue. Ink ramp. */
-  .prob-card .cost .figure{
-    font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;font-weight:400;
-    font-size:40px;line-height:1;color:var(--ink);letter-spacing:-.02em;
+    margin-top:auto;
   }
   .prob-card .cost .label{
     font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;
     letter-spacing:.12em;text-transform:uppercase;color:var(--ink-3);
-    line-height:1.4;max-width:18ch;
+    line-height:1.5;
   }
 
   .prob-resolve{


### PR DESCRIPTION
**Draft + [skip ci]** to try to avoid burning a Vercel preview slot. If your project doesn't have the Ignored Build Step configured, the preview will build anyway — cancel it in the Vercel dashboard if so.

## Summary

Two visible bugs on the Problem section of /why-salency, both caused by vestigial CSS from the earlier honesty pass that removed the big "40–50%" stat figures from each card.

**Bug 1 — labels squashed:** Cost labels at the bottom of each card rendered as a narrow 113px column on the left, wrapping every ~18 characters. Read almost as rotated text.

**Bug 2 — dividers misaligned:** The dashed separators between `.desc` and `.cost` landed at different vertical positions because the description text lengths varied between cards.

## Cause

`.prob-card .cost` was `display:flex; align-items:baseline; gap:10px` — set up to sit a big italic `.figure` next to the `.label`. The figures got removed, but the flex layout and the label's `max-width:18ch` constraint stayed.

## Fix

CSS-only, no JSX touched:

- Drop `display:flex` + `gap` + `align-items:baseline` from `.cost` (it has one child now)
- Drop `max-width:18ch` from `.cost .label`
- Make `.prob-card` a flex column
- Give `.cost` `margin-top:auto` to pin to the bottom of each card
- Delete orphan `.cost .figure` CSS rule

Since `.prob-row` is a grid with implicit `align-items:stretch`, all three cards share the same height, and all dashed dividers now land at the exact same y-coordinate (verified: all three `.cost` blocks at `topY: 1200`).

## Test plan

- [ ] `/why-salency` Problem section: each cost label reads as normal wrapped text across the card width, not a narrow vertical column
- [ ] All three dashed dividers align horizontally regardless of which card's description is longest
- [ ] Mobile (375px) still stacks to single column with dividers between cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)