### PR TITLE
content(why-salency): pair "For you if" + "Not for you if" filter

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2952,6 +2952,10 @@ header button:focus:not(:focus-visible){
 .notfor-list .notfor-body { font-size: 15.5px; line-height: 1.65; color: var(--ink-2); }
 .notfor-list .notfor-body strong { color: var(--ink); font-weight: 500; display: block; margin-bottom: 4px; }
 .notfor-foot { margin-top: 28px; font-size: 14.5px; line-height: 1.65; color: var(--ink-3); max-width: 72ch; }
+.notfor-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 56px; margin-top: 8px; }
+.notfor-col-head { font-family: var(--font-mono); font-size: 11px; letter-spacing: .2em; text-transform: uppercase; color: var(--ink-3); margin: 0 0 16px; font-weight: 400; }
+.notfor-list--paired li { grid-template-columns: 1fr; gap: 0; }
+@media (max-width: 768px) { .notfor-grid { grid-template-columns: 1fr; gap: 40px; } }
 
 /* Pilot CTA */
 .why-cta { max-width: var(--page-max); margin: 96px auto 120px; padding: 0 40px; text-align: center; }

--- a/components/sections/NotForYouSection.tsx
+++ b/components/sections/NotForYouSection.tsx
@@ -2,33 +2,63 @@ export function NotForYouSection() {
   return (
     <section className="notfor">
       <div className="notfor-head">
-        <span className="eb">Not for you if</span>
+        <span className="eb">Who it&rsquo;s for</span>
         <h2>
-          Salency is the <em>wrong tool</em> in two cases.
+          Salency fits a <em>specific shape</em> of sales motion.
         </h2>
       </div>
-      <ul className="notfor-list">
-        <li>
-          <span className="notfor-idx">01</span>
-          <div className="notfor-body">
-            <strong>Transactional, one-touch sales.</strong> If your deal cycle
-            is a single call and no handoff happens, the memory layer has
-            nothing to compound.
-          </div>
-        </li>
-        <li>
-          <span className="notfor-idx">02</span>
-          <div className="notfor-body">
-            <strong>Solo operator, no rep turnover.</strong> The scar tissue
-            Salency fixes is institutional. Solo founders keep it in their
-            head.
-          </div>
-        </li>
-      </ul>
+      <div className="notfor-grid">
+        <div className="notfor-col">
+          <h3 className="notfor-col-head">For you if</h3>
+          <ul className="notfor-list notfor-list--paired">
+            <li>
+              <div className="notfor-body">
+                <strong>Your calls get recorded.</strong> Zoom, Meet, Teams.
+                Whatever your reps already use.
+              </div>
+            </li>
+            <li>
+              <div className="notfor-body">
+                <strong>Deals span multiple calls.</strong> Pain raised in
+                call 1 should answer in call 5.
+              </div>
+            </li>
+            <li>
+              <div className="notfor-body">
+                <strong>Accounts pass between people.</strong> AE to CSM,
+                new rep on inherited book, expansion team taking over.
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div className="notfor-col">
+          <h3 className="notfor-col-head">Not for you if</h3>
+          <ul className="notfor-list notfor-list--paired">
+            <li>
+              <div className="notfor-body">
+                <strong>You don&rsquo;t record calls.</strong> Transcripts are
+                the input. No recording, no Salency.
+              </div>
+            </li>
+            <li>
+              <div className="notfor-body">
+                <strong>Sales is one call, then signature.</strong> No
+                handoff means no scar tissue to compound.
+              </div>
+            </li>
+            <li>
+              <div className="notfor-body">
+                <strong>You&rsquo;re the only one selling.</strong>{' '}
+                Institutional memory doesn&rsquo;t apply when one head holds
+                it all.
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
       <p className="notfor-foot">
-        And Salency is not a CRM replacement, not a coaching tool, and not
-        another tab. It&rsquo;s the layer between the transcript and the rep
-        who inherits the account.
+        Salency sits on top of your CRM, not in place of it. It&rsquo;s the
+        layer between the transcript and the rep who inherits the account.
       </p>
     </section>
   );


### PR DESCRIPTION
## Summary
- Converts the `/why-salency` disqualifier section into a symmetric fit-filter (qualifiers + disqualifiers, side by side)
- New eyebrow ("Who it's for"), new H2 ("Salency fits a specific shape of sales motion"), three qualifiers + three refined disqualifiers
- Foot trimmed: dropped "not a CRM, not coaching, not another tab" trio; kept positioning sentence + one CRM-defense line ("Salency sits on top of your CRM, not in place of it")
- Disqualifier copy now in buyer-language (e.g., "You don't record calls" instead of "the memory layer has nothing to compound")

## Why
Office-hours review on /why-salency: the existing two-disqualifier section read defensive and only filtered out ~10% of readers. Pairing with "For you if" turns it from disclaimer into confidence move and gives the reader both halves of the fit signal in one glance.

## Test plan
- [ ] Open Vercel preview `/why-salency`, scroll to "Who it's for" section
- [ ] Desktop (≥769px): two columns side-by-side
- [ ] Mobile (≤768px): columns stack
- [ ] Eyebrow + H2 hierarchy reads cleanly above the grid
- [ ] No console errors, no layout shift
- [ ] Other sections on `/why-salency` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)