### PR TITLE
content(home + investors): refresh per 2026-04-25 competitive research

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1128,7 +1128,8 @@ html {
     align-items:start;
     padding:8px 0;border-bottom:1px dashed var(--hair);
   }
-  .notdo-item:last-child,.notdo-item:nth-last-child(2){border-bottom:0}
+  .notdo-item:last-child{border-bottom:0}
+  .notdo-item--span{grid-column:1 / -1}
   .notdo-item .x,
   .notdo-item .check{
     font-family:'Geist Mono',monospace;font-size:20px;line-height:1.2;

--- a/components/sections/InvestorsSection.tsx
+++ b/components/sections/InvestorsSection.tsx
@@ -132,10 +132,12 @@ export function InvestorsSection() {
               Closest threats, and <em>where the shape doesn&rsquo;t fit.</em>
             </h2>
             <p className="compete-lede">
-              No single competitor ships pain-product mapping plus
-              contradiction detection plus handoff brief as an integrated
-              stack. The gap is the shape of the join, not the individual
-              capabilities.
+              Pain extraction, pre-call briefing, and handoff briefs are
+              now table-stakes &mdash; Gong, HubSpot Frame AI, and AskElephant
+              ship versions of all three. No single competitor ships
+              pain-product mapping plus contradiction detection as an
+              integrated stack. The gap is the shape of the join, not the
+              individual capabilities.
             </p>
             <div className="compete-table">
               <div className="compete-row compete-row--head">
@@ -146,47 +148,67 @@ export function InvestorsSection() {
               <div className="compete-row">
                 <span className="c-who">Gong</span>
                 <span className="c-threat">
-                  <em>75%</em>
+                  <em>high</em>
                 </span>
                 <span className="c-why">
-                  Could ship &ldquo;Gong Reactivate&rdquo; as a $10–20/seat
-                  add-on. Their focus is forecasting and coaching. Pain-product
-                  mapping is not their customer motion.
-                </span>
-              </div>
-              <div className="compete-row">
-                <span className="c-who">Clari + Salesloft</span>
-                <span className="c-threat">50%</span>
-                <span className="c-why">
-                  $450M combined ARR (merged Dec 2025). Call intelligence plus
-                  forecasting. Pain-timing is their natural expansion, but
-                  their account is stage and number, not qualitative shape.
+                  <strong>12&ndash;18 month window.</strong> Already ships
+                  pain Smart Trackers (pre-2024), AI Briefer for handoffs (May
+                  2025), Account Console (Feb 2026). Doesn&rsquo;t ship pain
+                  &rarr; product matching against a customer-maintained
+                  catalog (no Vault primitive) or cross-call contradiction
+                  detection. Historical base rate ~38% per 12-month window
+                  for competitor-parity ships.
                 </span>
               </div>
               <div className="compete-row">
                 <span className="c-who">HubSpot Breeze</span>
-                <span className="c-threat">50%</span>
+                <span className="c-threat">
+                  <em>mod-high</em>
+                </span>
                 <span className="c-why">
-                  200K customers, freemium. Could bundle pain-product mapping
-                  into Sales Hub — but bundling into a CRM flattens the graph,
-                  which is the thing that defends the wedge.
+                  <strong>12 month window.</strong> Frame AI acquisition (Dec
+                  2024) and Smart Deal Progression (Apr 2026) put them ~12
+                  months from packaging the matching engine. The architecture-
+                  flat moat argument is retracted post-Frame AI. 200K
+                  customers, freemium.
                 </span>
               </div>
               <div className="compete-row">
                 <span className="c-who">Salesforce Einstein</span>
-                <span className="c-threat">45%</span>
+                <span className="c-threat">
+                  <em>wildcard</em>
+                </span>
                 <span className="c-why">
-                  150K customers. Could bundle for free. Slow to move, but
-                  devastating if they do. Same flattening problem as HubSpot.
+                  <strong>18&ndash;24 month window.</strong> Account Research
+                  Agent (Dreamforce 2025), Data 360 customer graph, Agentforce
+                  360. Recipe published in Architect docs but not packaged as
+                  a SKU. 150K customers. One Spring 2027 release-note bullet
+                  erases the wedge for that base.
                 </span>
               </div>
               <div className="compete-row">
                 <span className="c-who">AskElephant</span>
-                <span className="c-threat">35%</span>
+                <span className="c-threat">
+                  <em>moderate</em>
+                </span>
                 <span className="c-why">
-                  Closest on handoff docs. $99/mo anchor, 500+ teams, strong
-                  G2. Doesn&rsquo;t hold state between handoffs, and
-                  doesn&rsquo;t map pains to a product catalog.
+                  <strong>6&ndash;12 month window.</strong> Pre-call briefs
+                  already ship per third-party reviewers. $6M seed (May 2025)
+                  with a scale-AI-agents mandate. $99/mo anchor. Doesn&rsquo;t
+                  ingest a product catalog or do pain-product matching.
+                </span>
+              </div>
+              <div className="compete-row">
+                <span className="c-who">Clari + Salesloft</span>
+                <span className="c-threat">
+                  <em>low</em>
+                </span>
+                <span className="c-why">
+                  <strong>12&ndash;18 month window.</strong> Merged Dec 2025,
+                  $450M combined ARR. Integration paralysis: 2 CI stacks plus
+                  2 engagement stacks to rationalize. CEO Cox&rsquo;s public
+                  language is 100% forecast-execution unification. FAQ says
+                  full unification &ldquo;coming years.&rdquo;
                 </span>
               </div>
             </div>
@@ -240,31 +262,33 @@ export function InvestorsSection() {
               </div>
               <div className="horizon">
                 <div className="horizon-head">
-                  <span className="pill">Following</span>
-                  <span className="label">Enterprise readiness</span>
-                </div>
-                <ul className="horizon-body">
-                  <li>
-                    Native integrations with the tools revenue teams already
-                    live in — scoped once each one ships a stable contract,
-                    not before.
-                  </li>
-                  <li>
-                    Security posture for regulated-vertical buyers (SOC 2 Type
-                    II audit kickoff post-bridge).
-                  </li>
-                </ul>
-              </div>
-              <div className="horizon">
-                <div className="horizon-head">
-                  <span className="pill">Further out</span>
+                  <span className="pill">Following · 2026 H2</span>
                   <span className="label">Workflow depth</span>
                 </div>
                 <ul className="horizon-body">
                   <li>
                     Embedding pain-product mapping into product-management
                     tools (Productboard, Aha, Jira) — where switching cost
-                    compounds into quarters.
+                    compounds into quarters. Pulled forward from 2027 after
+                    competitive-window analysis tightened the high-threat
+                    tier from 18 months to 12.
+                  </li>
+                  <li>
+                    Native integrations with the CRMs revenue teams already
+                    live in — scoped once each one ships a stable contract,
+                    not before.
+                  </li>
+                </ul>
+              </div>
+              <div className="horizon">
+                <div className="horizon-head">
+                  <span className="pill">Further out</span>
+                  <span className="label">Enterprise readiness + vertical expansion</span>
+                </div>
+                <ul className="horizon-body">
+                  <li>
+                    Security posture for regulated-vertical buyers (SOC 2 Type
+                    II audit kickoff post-bridge).
                   </li>
                   <li>
                     Vertical expansion. First vertical: B2B SaaS. Next:

--- a/components/sections/NotDoSection.tsx
+++ b/components/sections/NotDoSection.tsx
@@ -12,11 +12,30 @@ export function NotDoSection() {
             <div className="title">Not a CRM replacement</div>
             <span className="check" aria-label="What it does">✓</span>
             <div className="subtitle">
-              CRM tracks pipeline stages and quotes. Salency tracks what the
-              customer said: pain graph, contradictions, account brief. The
-              memory layer stays on Salency; flat fields export to Salesforce,
-              HubSpot, or Attio as CSV or markdown. Native CRM integration is
-              on the roadmap.
+              CRM tracks pipeline stages, forecast, and quote-to-cash. Salency
+              tracks what the customer said: pain graph, contradictions,
+              account brief. Two layers, no overlap.
+            </div>
+          </div>
+          <div className="notdo-item">
+            <span className="x">×</span>
+            <div className="title">Not a CRM write-back tool today</div>
+            <span className="check" aria-label="What it does">✓</span>
+            <div className="subtitle">
+              Reps export structured fields by hand &mdash; CSV or markdown
+              into HubSpot, Salesforce, Attio. Native sync is on the roadmap,
+              not yet shipped. We don&apos;t commit to a version until the
+              integration ships.
+            </div>
+          </div>
+          <div className="notdo-item">
+            <span className="x">×</span>
+            <div className="title">Not running on your CRM&apos;s data layer</div>
+            <span className="check" aria-label="What it does">✓</span>
+            <div className="subtitle">
+              The pain-product graph, contradictions, and account memory live
+              on Salency by design. Flatten them into CRM rows and the moat
+              dissolves the same day.
             </div>
           </div>
           <div className="notdo-item">
@@ -29,7 +48,7 @@ export function NotDoSection() {
               memory, so the rep walks into the next call already briefed.
             </div>
           </div>
-          <div className="notdo-item">
+          <div className="notdo-item notdo-item--span">
             <span className="x">×</span>
             <div className="title">Not a magic close button</div>
             <span className="check" aria-label="What it does">✓</span>
@@ -38,16 +57,6 @@ export function NotDoSection() {
               lost: the pain a buyer named, the contradiction from last
               week&apos;s call, the next step nobody wrote down. The hour
               before every call goes back to selling.
-            </div>
-          </div>
-          <div className="notdo-item">
-            <span className="x">×</span>
-            <div className="title">Not another call recorder</div>
-            <span className="check" aria-label="What it does">✓</span>
-            <div className="subtitle">
-              Salency sits <em>on top of</em> your notetaker. Gong, Fathom,
-              Fireflies, or raw text go in. A cited, queryable memory layer
-              comes out. Survives rep rotation.
             </div>
           </div>
         </div>

--- a/components/sections/ThesisSection.tsx
+++ b/components/sections/ThesisSection.tsx
@@ -9,7 +9,7 @@ export function ThesisSection() {
         </h1>
         <p className="lede">
           Quarter one, Salency looks like a better handoff doc. By quarter
-          four, it&rsquo;s the only system that knows what your customers
+          four, it&rsquo;s the only system that remembers what your customers
           actually said.
         </p>
       </div>


### PR DESCRIPTION
## Summary
Five coordinated edits across the home page and `/investors` page, all downstream of the strategic decision in the prior `why-salency-competitive-refresh` office-hours session (Reading C, hybrid buyer/investor registers; customer-stated timeline tracking confirmed unshipped and intentionally not surfaced).

### 1. NotDoSection (home) — canonical anti-hype refresh
Refactored to cover all 5 §5 NOT-dos as the single canonical anti-hype surface for the buyer register:
- Not a CRM replacement
- Not a CRM write-back tool today
- Not running on your CRM's data layer
- Not an in-call coach
- Not a magic close button

\"Not another call recorder\" dropped — hero already does that anti-position. 5th item spans full width via new \`.notdo-item--span\` modifier; border rule simplified to just \`:last-child\`.

### 2. InvestorsSection competitive table — threat tiers replace point estimates
Replaced probability point estimates (75% / 50% / etc) with threat tiers grounded in observable signals per §9 base-rate research:
- Gong: high (12–18 mo) — was 75%
- HubSpot Breeze: mod-high (12 mo) — was 50%, raised post-Frame AI
- Salesforce Einstein: wildcard (18–24 mo) — was 45%
- AskElephant: moderate (6–12 mo) — was 35%, pre-call briefs confirmed shipping
- Clari + Salesloft: low (12–18 mo) — was 50%, lowered for integration paralysis

Reasoning per row updated to name what each competitor actually ships vs the durable gap.

### 3. InvestorsSection compete-lede — honest preface
Drops \"plus handoff brief\" from the integrated-stack claim (handoff briefs are table-stakes per Gong AI Briefer May 2025 + AskElephant whole product). Adds preface naming what's now table-stakes.

### 4. InvestorsSection roadmap — workflow integration pulled forward
Workflow integration (Productboard, Aha, Jira) moves from \"Further out\" pill into \"Following · 2026 H2\" pill. Reasoning inline: competitive window tightened from 18 to 12 months for the high-threat tier, so the moat-defending move moves up. Enterprise readiness + vertical expansion shift to \"Further out.\"

### 5. ThesisSection lede — wordsmith
\"...the only system that **knows** what your customers actually said\" → \"...the only system that **remembers** what your customers actually said.\" Removes light overclaim. Memory is the product, not omniscience.

## Why
Prior PR 107 refreshed the `/why-salency` competitive framing per the same 2026-04-25 research. Anti-hype duplication on `/why-salency` was caught and removed in PR 107 commit 2 — this PR is the consolidation half: NotDoSection on the home page becomes the canonical anti-hype surface, and `/investors` gets the matching base-rate-grounded competitive refresh.

## Test plan
- [ ] Open Vercel preview `/`
- [ ] NotDoSection renders 5 items, last one spans full width on desktop
- [ ] Mobile (≤768px) NotDoSection stacks all 5 items in single column
- [ ] Open Vercel preview `/investors`
- [ ] Compete table shows tier text (high / mod-high / wildcard / moderate / low) instead of percentages
- [ ] Roadmap shows workflow integration in \"Following · 2026 H2\" pill, not \"Further out\"
- [ ] Compete-lede preface names table-stakes capabilities
- [ ] Open `/why-salency`, ThesisSection lede reads \"...remembers what your customers actually said\"
- [ ] No console errors, no layout shift on any page

## Out of scope (file edits in Salency directory, not in this PR)
- `/Users/howard/Documents/Salency/company-context.md` §13 risks: \"18 month window\" → \"12 month window for high-threat tier\"
- Same file §19 roadmap: workflow integration year-2 → year-1 H2

I'll write those file edits + a changelog after this PR opens, in your Salency directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)