### PR TITLE
feat(brand-reveal): add forcePlay + onComplete for consumer-triggered splash

### DIFF
--- a/packages/brand-reveal/README.md
+++ b/packages/brand-reveal/README.md
@@ -60,6 +60,45 @@ export default function RootLayout({ children }) {
 
 Copy `public/salency-mark.svg` from the landing-page repo alongside this package (or pass your own via `markSrc`).
 
+### Play on first login (consumer-triggered)
+
+When you want the splash to play once after a user logs in (not on every fresh tab), set a flag in your login-success handler and read it in your authenticated layout. `forcePlay` bypasses the sessionStorage gate so it fires every time you mount it.
+
+```tsx
+// after successful login, before redirect
+sessionStorage.setItem('salency:show-login-splash', '1');
+router.push('/dashboard');
+```
+
+```tsx
+// app/(authed)/layout.tsx
+'use client';
+
+import { useEffect, useState } from 'react';
+import { BrandRevealSplash } from '@salency/brand-reveal';
+import '@salency/brand-reveal/loading-screen.css';
+
+export default function AuthedLayout({ children }: { children: React.ReactNode }) {
+  const [showSplash, setShowSplash] = useState(false);
+
+  useEffect(() => {
+    if (sessionStorage.getItem('salency:show-login-splash') === '1') {
+      sessionStorage.removeItem('salency:show-login-splash');
+      setShowSplash(true);
+    }
+  }, []);
+
+  return (
+    <>
+      {showSplash && (
+        <BrandRevealSplash forcePlay onComplete={() => setShowSplash(false)} />
+      )}
+      {children}
+    </>
+  );
+}
+```
+
 ### Logo lockup (manual composition)
 
 If you want the logo + wordmark without the full splash chrome:
@@ -93,6 +132,8 @@ The `.brand-lockup*` classes are defined in `loading-screen.css`.
 | `markSrc`      | `string \| null`           | `/salency-mark.svg`                                        | SVG mark path. `null` = wordmark only, no logo. |
 | `mission`      | `React.ReactNode \| null`  | `Every call becomes memory. / Every role inherits it.`     | Two-line blurb below the wordmark. `null` = hide. |
 | `loadingLabel` | `string \| null`           | `Loading`                                                  | Uppercase label beneath the rail. `null` = hide. |
+| `forcePlay`    | `boolean`                  | `false`                                                    | Bypass the sessionStorage gate and play immediately on mount. Use when the consumer controls the trigger (e.g. on first login). Still respects `prefers-reduced-motion`. |
+| `onComplete`   | `() => void`               | —                                                          | Fires after the fade-out completes and the splash unmounts. Use to clear a trigger flag or unmount a wrapper. |
 
 ## Replay rule
 

--- a/packages/brand-reveal/src/BrandRevealSplash.tsx
+++ b/packages/brand-reveal/src/BrandRevealSplash.tsx
@@ -36,6 +36,18 @@ export interface BrandRevealSplashProps {
    * Default: `Loading`.
    */
   loadingLabel?: string | null;
+  /**
+   * Bypass the sessionStorage gate and play immediately on mount.
+   * Use when the consumer controls the trigger (e.g. on first login).
+   * Still respects `prefers-reduced-motion`.
+   * Default: `false`.
+   */
+  forcePlay?: boolean;
+  /**
+   * Fired after the fade-out completes and the splash unmounts.
+   * Use to clear the consumer's trigger flag or unmount a wrapper.
+   */
+  onComplete?: () => void;
 }
 
 const DEFAULT_STORAGE_KEY = 'salency_splash_shown';
@@ -67,6 +79,8 @@ export function BrandRevealSplash({
   markSrc = '/salency-mark.svg',
   mission = DEFAULT_MISSION,
   loadingLabel = 'Loading',
+  forcePlay = false,
+  onComplete,
 }: BrandRevealSplashProps = {}) {
   const [mounted, setMounted] = useState(false);
   const [hiding, setHiding] = useState(false);
@@ -77,27 +91,36 @@ export function BrandRevealSplash({
     ).matches;
     if (reducedMotion) {
       sessionStorage.setItem(storageKey, '1');
+      onComplete?.();
       return;
     }
 
-    const navEntry = performance.getEntriesByType(
-      'navigation',
-    )[0] as PerformanceNavigationTiming | undefined;
-    const isReload = navEntry?.type === 'reload';
-    const alreadyShown = sessionStorage.getItem(storageKey) === '1';
+    if (!forcePlay) {
+      const navEntry = performance.getEntriesByType(
+        'navigation',
+      )[0] as PerformanceNavigationTiming | undefined;
+      const isReload = navEntry?.type === 'reload';
+      const alreadyShown = sessionStorage.getItem(storageKey) === '1';
 
-    if (alreadyShown && !isReload) return;
+      if (alreadyShown && !isReload) return;
+    }
 
     sessionStorage.setItem(storageKey, '1');
     setMounted(true);
 
-    const hideTimer = window.setTimeout(() => {
+    const fadeTimer = window.setTimeout(() => {
       setHiding(true);
-      window.setTimeout(() => setMounted(false), 400);
     }, durationMs);
+    const unmountTimer = window.setTimeout(() => {
+      setMounted(false);
+      onComplete?.();
+    }, durationMs + 400);
 
-    return () => window.clearTimeout(hideTimer);
-  }, [storageKey, durationMs]);
+    return () => {
+      window.clearTimeout(fadeTimer);
+      window.clearTimeout(unmountTimer);
+    };
+  }, [storageKey, durationMs, forcePlay, onComplete]);
 
   if (!mounted) return null;
 


### PR DESCRIPTION
## Summary
- `BrandRevealSplash` gains a `forcePlay` prop that bypasses the built-in sessionStorage / navigation-type gate so consuming apps can trigger the splash on their own events (e.g. first login).
- New `onComplete` callback fires after the 400ms fade-out unmounts the splash, so the consumer can clear its trigger flag without guessing timing. Also fires in the `prefers-reduced-motion` early-return path so callers never get stuck.
- README adds a "Play on first login" recipe with a Next.js authenticated-layout example and documents both new props.

## Why
Today the splash self-gates on fresh tab / hard refresh. That's right for marketing surfaces but wrong for an authenticated app where we want the brand moment to land *after* a successful login, not on every tab open. Rather than baking auth assumptions into the package, the consumer owns the trigger and the package gives it a clean API.

## Test plan
- [ ] `npx tsc --noEmit -p packages/brand-reveal/tsconfig.json` passes (verified locally)
- [ ] In a consumer app: set `sessionStorage.setItem('salency:show-login-splash', '1')` before redirecting post-login, mount `<BrandRevealSplash forcePlay onComplete={...} />` from the authed layout, confirm splash plays exactly once per login and unmounts cleanly
- [ ] With `prefers-reduced-motion: reduce`, confirm `onComplete` fires immediately and the splash doesn't render
- [ ] Existing landing-page consumers of `BrandRevealSplash` (if any) keep working unchanged — `forcePlay` defaults to `false`, `onComplete` is optional

🤖 Generated with [Claude Code](https://claude.com/claude-code)