### PR TITLE
seo: Organization + WebSite + FAQPage JSON-LD (promote to prod)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,38 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono, Outfit, Instrument_Serif, Instrument_Sans } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
 import { PilotModal } from "@/components/PilotModal";
+import { JsonLd } from "@/components/JsonLd";
 import "./globals.css";
+
+const SITE_URL = "https://salency.ai";
+
+const organizationSchema = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: "Salency",
+  alternateName: "Cerebro",
+  url: SITE_URL,
+  logo: `${SITE_URL}/salency-mark.svg`,
+  description:
+    "Institutional memory for B2B sales teams. Salency turns every call into structured, cited context — so reps stop losing deals to forgotten signals and any successor inherits full account history.",
+  email: "founders@salency.ai",
+  sameAs: [
+    "https://www.linkedin.com/company/salency",
+  ],
+};
+
+const websiteSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: "Salency",
+  url: SITE_URL,
+  description:
+    "AI that remembers every customer pain your sales reps forget.",
+  publisher: {
+    "@type": "Organization",
+    name: "Salency",
+  },
+};
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -64,6 +95,8 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${outfit.variable} ${instrumentSerif.variable} ${instrumentSans.variable} antialiased`}
       >
+        <JsonLd data={organizationSchema} />
+        <JsonLd data={websiteSchema} />
         {children}
         <PilotModal />
         <Analytics />

--- a/app/why-salency/page.tsx
+++ b/app/why-salency/page.tsx
@@ -7,10 +7,51 @@ import { GongSection } from '@/components/sections/GongSection';
 import { NotForYouSection } from '@/components/sections/NotForYouSection';
 import { PilotCtaSection } from '@/components/sections/PilotCtaSection';
 import { SiteFooter } from '@/components/sections/SiteFooter';
+import { JsonLd } from '@/components/JsonLd';
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'How is Salency different from Gong?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Gong records your calls. Salency solves what happens after — extracting customer pains, mapping them to your products, and retaining the structured context any rep or successor needs to keep the deal moving.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Is Salency a good fit for my sales team?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Salency fits teams that record calls (Zoom, Meet, Teams), run deals across multiple calls, and pass accounts between people — AE to CSM, new reps inheriting books, expansion teams taking over.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'When is Salency not a good fit?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Salency is not a fit if you do not record your calls (transcripts are the input), if your sales motion is one call to signature with no handoff, or if you are the only one selling — institutional memory does not apply when one head holds it all.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Does Salency replace my CRM?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'No. Salency sits on top of your CRM, not in place of it. It is the layer between the call transcript and the rep who inherits the account.',
+      },
+    },
+  ],
+};
 
 export default function WhySalencyPage() {
   return (
     <div className="page">
+      <JsonLd data={faqSchema} />
       <MarketingHeader />
       <ThesisSection />
       <ScrollReveal><ProblemSection /></ScrollReveal>

--- a/components/JsonLd.tsx
+++ b/components/JsonLd.tsx
@@ -1,0 +1,12 @@
+type JsonLdProps = {
+  data: Record<string, unknown> | Array<Record<string, unknown>>;
+};
+
+export function JsonLd({ data }: JsonLdProps) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
Promotes `feat/gh-114/json-ld-schema` from `test` (merged in #117) to `main` for production.

- New `<JsonLd />` server component for safe `application/ld+json` injection.
- Site-wide `Organization` + `WebSite` JSON-LD in `app/layout.tsx` so AI assistants (ChatGPT, Perplexity, Google AI Overviews) can attribute Salency as a structured entity.
- `FAQPage` JSON-LD on `/why-salency`, with 4 Q&As sourced from the existing for-you-if / not-for-you-if and Gong positioning content. Eligible for FAQ rich results in Google.

Closes #114.

## Test plan
- [x] `npm run build` succeeds.
- [x] Verified on staging (`test` branch deploy).
- [ ] After production deploy, view-source on `/` and `/why-salency` and confirm `<script type="application/ld+json">` blocks render.
- [x] Validate at https://validator.schema.org/ — no errors on Organization, WebSite, or FAQPage.
- [ ] Validate FAQPage at https://search.google.com/test/rich-results.

## Notes
- LinkedIn URL in `Organization.sameAs` is set to `https://www.linkedin.com/company/salency` — confirm this is the correct slug or update before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)