### PR TITLE
seo: SoftwareApplication + Person JSON-LD

### DIFF
--- a/app/our-story/page.tsx
+++ b/app/our-story/page.tsx
@@ -3,6 +3,8 @@ import { MarketingHeader } from '@/components/MarketingHeader';
 import { ScrollReveal } from '@/components/ScrollReveal';
 import { OurStorySection } from '@/components/sections/OurStorySection';
 import { SiteFooter } from '@/components/sections/SiteFooter';
+import { JsonLd } from '@/components/JsonLd';
+import { FOUNDERS } from '@/lib/founders';
 
 export const metadata: Metadata = {
   title: 'Our story · Salency',
@@ -11,9 +13,25 @@ export const metadata: Metadata = {
   alternates: { canonical: '/our-story' },
 };
 
+const personSchemas = FOUNDERS.map((f) => ({
+  '@context': 'https://schema.org',
+  '@type': 'Person',
+  name: f.name,
+  jobTitle: f.role,
+  worksFor: {
+    '@type': 'Organization',
+    name: 'Salency',
+    url: 'https://www.salency.ai',
+  },
+  ...(f.linkedin ? { sameAs: [f.linkedin] } : {}),
+}));
+
 export default function OurStoryPage() {
   return (
     <div className="page">
+      {personSchemas.map((schema) => (
+        <JsonLd key={schema.name} data={schema} />
+      ))}
       <MarketingHeader />
       <ScrollReveal>
         <OurStorySection />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,14 +7,40 @@ import { HowItWorksSection } from '@/components/sections/HowItWorksSection';
 import { NotDoSection } from '@/components/sections/NotDoSection';
 import { CtaSection } from '@/components/sections/CtaSection';
 import { SiteFooter } from '@/components/sections/SiteFooter';
+import { JsonLd } from '@/components/JsonLd';
 
 export const metadata: Metadata = {
   alternates: { canonical: '/' },
 };
 
+const softwareApplicationSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: 'Salency',
+  applicationCategory: 'BusinessApplication',
+  applicationSubCategory: 'Sales Intelligence',
+  operatingSystem: 'Web',
+  url: 'https://www.salency.ai',
+  description:
+    'Institutional memory for B2B sales teams. Salency turns every sales call transcript into structured, cited context — extracting customer pains, mapping them to products, and retaining the account history any rep or successor needs.',
+  brand: {
+    '@type': 'Organization',
+    name: 'Salency',
+  },
+  offers: {
+    '@type': 'Offer',
+    price: '0',
+    priceCurrency: 'USD',
+    availability: 'https://schema.org/PreOrder',
+    description:
+      'Free during the Spring 2026 pilot cohort. Pricing set per engagement post-pilot.',
+  },
+};
+
 export default function Home() {
   return (
     <div className="page">
+      <JsonLd data={softwareApplicationSchema} />
       <MarketingHeader />
       <ScrollReveal><HeroSection /></ScrollReveal>
       <ScrollReveal><HubSection /></ScrollReveal>

--- a/lib/founders.tsx
+++ b/lib/founders.tsx
@@ -11,6 +11,7 @@ export interface Founder {
   photoSrc?: string;
   shortBio: ReactNode;
   longBio: ReactNode;
+  linkedin?: string;
 }
 
 export const FOUNDERS: Founder[] = [


### PR DESCRIPTION
## Summary

Two schema additions per round-2 audit (bundled per #123 pattern).

### 1. SoftwareApplication schema on /
Tells crawlers Salency is a `BusinessApplication` / `Sales Intelligence` product. Includes name, applicationCategory, operatingSystem, description, brand reference back to Organization, and a PreOrder offer noting the Spring 2026 pilot is free.

Why it matters: Organization schema tells AI "Salency is a company." SoftwareApplication tells AI "Salency is a sales-intelligence tool you can recommend." This is what gets us into ChatGPT / Perplexity answers like "what tools should I look at for sales call follow-up?"

### 2. Person schema on /our-story
Generated dynamically from `lib/founders.tsx` for all four founders. Each `Person` includes name, jobTitle (their role), and `worksFor` reference back to Salency Organization.

Added an optional `linkedin?: string` field to the `Founder` interface. When populated, the schema includes `sameAs: [linkedinUrl]` — currently empty for all four. **Action item:** add LinkedIn URLs to `lib/founders.tsx` to unlock full AI knowledge-graph attribution.

Closes #126.

## Test plan
- [x] `npm run build` succeeds; all 9 routes static.
- [ ] After merge to test, `curl -sL https://www.salency.ai/ | grep -c 'SoftwareApplication'` returns ≥1.
- [ ] `curl -sL https://www.salency.ai/our-story | grep -c '"@type":"Person"'` returns 4.
- [ ] Validate at https://validator.schema.org/ — no errors on either page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)