### PR TITLE
content: refresh Howard bio + drop retracted flat-fields framing

### DIFF
--- a/components/sections/CompoundsSection.tsx
+++ b/components/sections/CompoundsSection.tsx
@@ -47,7 +47,7 @@ export function CompoundsSection() {
       </div>
 
       <p className="compounds-foot">
-        Flatten the graph into flat fields and you kill the thing. The memory
+        Flatten the graph into a CRM row and you kill the thing. The memory
         layer has to live on Salency, or it isn&rsquo;t memory.
       </p>
     </section>

--- a/lib/founders.tsx
+++ b/lib/founders.tsx
@@ -23,17 +23,20 @@ export const FOUNDERS: Founder[] = [
     photoVariant: '',
     shortBio: (
       <>
-        Four founding-AE / BD seats in five years. Ran the HubSpot→Monday CRM
-        migration at Sequence.
+        Founding AE at Viggle. 2+ years at Sequence as BD &amp; Partnerships
+        Manager &mdash; ran the HubSpot&rarr;Monday CRM migration there.
       </>
     ),
     longBio: (
       <>
-        Four founding-AE/BD seats in five years —{' '}
-        <em>Sequence, Treasure, Nijta, Viggle</em> (a16z). Same handoff
-        failure on every team. Ran the HubSpot→Monday CRM migration at
-        Sequence. MBET, Waterloo. Earlier: MUFG HK, led their first Panda
-        Bond issuance.
+        Founding AE at <em>Viggle</em> (a16z-backed) &mdash; pilot-to-paid
+        motions with the exact B2B buyers Salency sells to today. Four
+        early-stage GTM seats in five years across{' '}
+        <em>Sequence, Treasure, Nijta, Viggle</em>, including 2+ years at
+        Sequence as BD &amp; Partnerships Manager. Ran the HubSpot&rarr;Monday
+        CRM migration there &mdash; came out knowing the rep&rsquo;s actual
+        context lives in the call, not the CRM row. Earlier: MUFG HK, led
+        their first Panda Bond issuance. MBET, Waterloo.
       </>
     ),
   },


### PR DESCRIPTION
## Summary
Two related copy changes that both drop the retracted "structured-data-vs-flat-fields" moat framing from user-facing surfaces, and refresh Howard's bio with concrete buyer-fit signal.

## Files changed
- `lib/founders.tsx` — Howard `shortBio` + `longBio` refreshed.
  - Adds founding AE at Viggle (a16z-backed) — pilot-to-paid motions with the exact B2B buyers Salency sells to today.
  - Adds 2+ years at Sequence as BD & Partnerships Manager.
  - Replaces "flat fields can't hold what the customer said" with "the rep's actual context lives in the call, not the CRM row."
- `components/sections/CompoundsSection.tsx` — `/why-salency` foot copy.
  - Replaces "Flatten the graph into flat fields and you kill the thing" with "Flatten the graph into a CRM row and you kill the thing."
  - Same shape argument, drops the loaded term.

## Why drop "flat fields"
Per `competitor.md` (2026-04-25 base-rate research wave):
- "All three [Gong / HubSpot / Salesforce] have graph foundations now. Pure 'structured-data-vs-flat-fields' moat claim is dishonest."
- "HubSpot Breeze... Architecture-flat moat argument retracted."

Sharp investor reading the bio + `/why-salency` + then `competitor.md` catches the contradiction. The true seam Salency sits on (per `/investors` Platform & moat section) is call-vs-CRM-row — that holds up post-Frame AI / Data 360 / revenue-graph ships.

## Surface coverage
- `/our-story` renders the new Howard `longBio`.
- `/investors` team strip uses name + role only (longBio not shown there) — unaffected.
- `/why-salency` renders the new compounds foot.

## Test plan
- [ ] Vercel preview: `/our-story` shows new Howard `longBio` with Viggle role + Sequence tenure + new framing
- [ ] Vercel preview: `/investors` team-strip still shows "Howard Tam · Co-founder & CEO" (no regression)
- [ ] Vercel preview: `/why-salency` foot reads "Flatten the graph into a CRM row..."
- [ ] Mobile: longBio reflows cleanly

## Companion PR
- #133 — switches contact email `founders@` → `hello@salency.ai` (separate logical change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)