### PR TITLE
content: switch contact email founders@ → hello@salency.ai (→ main)

### DIFF
--- a/app/api/send/route.ts
+++ b/app/api/send/route.ts
@@ -107,7 +107,7 @@ export async function POST(request: Request) {
 
         const adminEmailFn = resend.emails.send({
             from: 'Salency Admin <onboarding@resend.dev>',
-            to: ['founders@salency.ai'],
+            to: ['hello@salency.ai'],
             subject: `New Pilot Request: ${escapeHtml(name)} · ${escapeHtml(website)}`,
             html: `
         <h1>New Pilot Request</h1>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,7 @@ const organizationSchema = {
   logo: `${SITE_URL}/salency-mark.svg`,
   description:
     "Institutional memory for B2B sales teams. Salency turns every call into structured, cited context — so reps stop losing deals to forgotten signals and any successor inherits full account history.",
-  email: "founders@salency.ai",
+  email: "hello@salency.ai",
   sameAs: [
     "https://www.linkedin.com/company/salency",
   ],

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -31,13 +31,13 @@ export default function Privacy() {
           <p>Form submissions are sent via Resend (our email provider) and stored in our internal systems. We do not store credit card information or sensitive financial data.</p>
 
           <h2 className="text-lg font-bold text-white mt-8 mb-3">Your Rights</h2>
-          <p>You may request access to, correction of, or deletion of your personal data at any time by emailing <a href="mailto:founders@salency.ai" className="text-accent-warm hover:underline">founders@salency.ai</a>.</p>
+          <p>You may request access to, correction of, or deletion of your personal data at any time by emailing <a href="mailto:hello@salency.ai" className="text-accent-warm hover:underline">hello@salency.ai</a>.</p>
 
           <h2 className="text-lg font-bold text-white mt-8 mb-3">Changes</h2>
           <p>We may update this policy from time to time. Changes will be posted on this page with an updated effective date.</p>
 
           <h2 className="text-lg font-bold text-white mt-8 mb-3">Contact</h2>
-          <p>Questions? Email us at <a href="mailto:founders@salency.ai" className="text-accent-warm hover:underline">founders@salency.ai</a>.</p>
+          <p>Questions? Email us at <a href="mailto:hello@salency.ai" className="text-accent-warm hover:underline">hello@salency.ai</a>.</p>
         </div>
       </main>
       <SiteFooter />

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -37,7 +37,7 @@ export default function Terms() {
           <p>We may update these terms from time to time. Continued use of the site constitutes acceptance of the revised terms.</p>
 
           <h2 className="text-lg font-bold text-white mt-8 mb-3">Contact</h2>
-          <p>Questions? Email us at <a href="mailto:founders@salency.ai" className="text-accent-warm hover:underline">founders@salency.ai</a>.</p>
+          <p>Questions? Email us at <a href="mailto:hello@salency.ai" className="text-accent-warm hover:underline">hello@salency.ai</a>.</p>
         </div>
       </main>
       <SiteFooter />

--- a/components/sections/InvestorsSection.tsx
+++ b/components/sections/InvestorsSection.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { FOUNDERS } from '@/lib/founders';
+import { FOUNDERS_EMAIL } from '@/lib/links';
 
 export function InvestorsSection() {
   return (
@@ -23,7 +24,9 @@ export function InvestorsSection() {
               <span className="sep">·</span>
               <span>Early access opening Q2 2026</span>
               <span className="sep">·</span>
-              <span>Private deck available on request</span>
+              <a href={`mailto:${FOUNDERS_EMAIL}`}>
+                Private deck available on request
+              </a>
             </div>
           </div>
         </div>

--- a/lib/links.ts
+++ b/lib/links.ts
@@ -1,3 +1,3 @@
-export const FOUNDERS_EMAIL = 'founders@salency.ai';
+export const FOUNDERS_EMAIL = 'hello@salency.ai';
 
 export const PILOT_FORM_ANCHOR = '/#pilot';


### PR DESCRIPTION
## Promotion to main
Verified on `test` via PR #133, plus one additional commit (`/investors` "Private deck available on request" hyperlinked to mailto) added after staging review.

## Summary
- Switches public contact email from \`founders@salency.ai\` to \`hello@salency.ai\` across the site:
  - \`lib/links.ts\` — \`FOUNDERS_EMAIL\` constant value
  - \`app/privacy/page.tsx\` — 2 mailto + visible text
  - \`app/terms/page.tsx\` — 1 mailto + visible text
  - \`app/layout.tsx\` — JSON-LD \`Organization.email\`
  - \`app/api/send/route.ts\` — pilot inbound admin recipient
- Adds: hyperlink "Private deck available on request" on \`/investors\` to a mailto using the same canonical address.

## Pre-merge check
- DNS / mailbox routing for \`hello@salency.ai\` must accept inbound. Resend sender domain config must allow that recipient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)