### PR TITLE
content: refresh Howard bio + drop retracted flat-fields framing (→ main)

### DIFF
--- a/components/sections/CompoundsSection.tsx
+++ b/components/sections/CompoundsSection.tsx
@@ -47,7 +47,7 @@ export function CompoundsSection() {
       </div>
 
       <p className="compounds-foot">
-        Flatten the graph into flat fields and you kill the thing. The memory
+        Flatten the graph into a CRM row and you kill the thing. The memory
         layer has to live on Salency, or it isn&rsquo;t memory.
       </p>
     </section>

--- a/lib/founders.tsx
+++ b/lib/founders.tsx
@@ -23,17 +23,20 @@ export const FOUNDERS: Founder[] = [
     photoVariant: '',
     shortBio: (
       <>
-        Four founding-AE / BD seats in five years. Ran the HubSpot→Monday CRM
-        migration at Sequence.
+        Founding AE at Viggle. 2+ years at Sequence as BD &amp; Partnerships
+        Manager &mdash; ran the HubSpot&rarr;Monday CRM migration there.
       </>
     ),
     longBio: (
       <>
-        Four founding-AE/BD seats in five years —{' '}
-        <em>Sequence, Treasure, Nijta, Viggle</em> (a16z). Same handoff
-        failure on every team. Ran the HubSpot→Monday CRM migration at
-        Sequence. MBET, Waterloo. Earlier: MUFG HK, led their first Panda
-        Bond issuance.
+        Founding AE at <em>Viggle</em> (a16z-backed) &mdash; pilot-to-paid
+        motions with the exact B2B buyers Salency sells to today. Four
+        early-stage GTM seats in five years across{' '}
+        <em>Sequence, Treasure, Nijta, Viggle</em>, including 2+ years at
+        Sequence as BD &amp; Partnerships Manager. Ran the HubSpot&rarr;Monday
+        CRM migration there &mdash; came out knowing the rep&rsquo;s actual
+        context lives in the call, not the CRM row. Earlier: MUFG HK, led
+        their first Panda Bond issuance. MBET, Waterloo.
       </>
     ),
   },


### PR DESCRIPTION
## Promotion to main
Verified on test via PR #131. Promoting same branch to main per branching flow.

## Summary
- lib/founders.tsx: Howard shortBio + longBio refreshed (founding AE at Viggle, 2+ years Sequence as BD & Partnerships Manager, "rep's actual context lives in the call, not the CRM row" framing).
- components/sections/CompoundsSection.tsx: /why-salency foot copy — "flat fields" → "CRM row."
- Drops retracted "structured-data-vs-flat-fields" moat framing per competitor.md (2026-04-25 base-rate research wave).

🤖 Generated with [Claude Code](https://claude.com/claude-code)