### PR TITLE
seo: founder LinkedIn URLs + .gitignore .claude/ (promote to prod)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 .gstack/
+
+# Claude Code local state
+.claude/

--- a/lib/founders.tsx
+++ b/lib/founders.tsx
@@ -89,6 +89,7 @@ export const FOUNDERS: Founder[] = [
     role: 'Founding Designer',
     initials: 'SG',
     photoVariant: 'photo--amber',
+    linkedin: 'https://www.linkedin.com/in/shristi1/',
     shortBio: (
       <>
         Shipped Salency&rsquo;s V1. Five years enterprise B2B design — Index

--- a/lib/founders.tsx
+++ b/lib/founders.tsx
@@ -21,6 +21,7 @@ export const FOUNDERS: Founder[] = [
     role: 'Co-founder & CEO',
     initials: 'HT',
     photoVariant: '',
+    linkedin: 'https://www.linkedin.com/in/howardhwt/',
     shortBio: (
       <>
         Founding AE at Viggle. 2+ years at Sequence as BD &amp; Partnerships
@@ -46,6 +47,7 @@ export const FOUNDERS: Founder[] = [
     role: 'Co-founder & Product',
     initials: 'NI',
     photoVariant: 'photo--violet',
+    linkedin: 'https://www.linkedin.com/in/nikkilkip/',
     shortBio: (
       <>
         Three years as a data analyst in B2B SaaS. Operations roles across
@@ -66,6 +68,7 @@ export const FOUNDERS: Founder[] = [
     role: 'Founding Engineer',
     initials: 'BO',
     photoVariant: 'photo--teal',
+    linkedin: 'https://www.linkedin.com/in/jideokusanya/',
     shortBio: (
       <>
         Scaled MakersValley from 0 to $2M ARR (6.5y, NYC). Ships


### PR DESCRIPTION
## Summary
Promotes `feat/gh-135/founder-linkedin-urls` from `test` (merged in #142) to `main`.

- All 4 founders now have `linkedin` populated in `lib/founders.tsx` — the Person JSON-LD on `/our-story` will emit `sameAs` arrays for each, unlocking AI knowledge-graph attribution.
- `.claude/` added to `.gitignore`.

Closes #135.

## Test plan
- [x] `npm run build` succeeds.
- [x] Verified on staging.
- [ ] After production deploy, `curl -sL https://www.salency.ai/our-story | grep -c '"sameAs"'` returns 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)