### PR TITLE
seo: descriptive anchor text on body internal links

### DIFF
--- a/components/sections/CtaSection.tsx
+++ b/components/sections/CtaSection.tsx
@@ -25,7 +25,7 @@ export function CtaSection() {
             Request pilot access →
           </button>
           <Link href="/investors#thesis" className="btn btn-ghost">
-            Read the institutional memory thesis
+            Read our thesis
           </Link>
         </div>
         <div className="fine">

--- a/components/sections/CtaSection.tsx
+++ b/components/sections/CtaSection.tsx
@@ -25,7 +25,7 @@ export function CtaSection() {
             Request pilot access →
           </button>
           <Link href="/investors#thesis" className="btn btn-ghost">
-            Read our thesis
+            Read our memory thesis
           </Link>
         </div>
         <div className="fine">

--- a/components/sections/CtaSection.tsx
+++ b/components/sections/CtaSection.tsx
@@ -25,7 +25,7 @@ export function CtaSection() {
             Request pilot access →
           </button>
           <Link href="/investors#thesis" className="btn btn-ghost">
-            Read our thesis
+            Read the institutional memory thesis
           </Link>
         </div>
         <div className="fine">

--- a/components/sections/InvestorsSection.tsx
+++ b/components/sections/InvestorsSection.tsx
@@ -248,7 +248,7 @@ export function InvestorsSection() {
             </div>
 
             <Link href="/our-story" className="team-compact-link">
-              Read full founder bios and the founding story →
+              Read our founding story →
             </Link>
           </section>
 

--- a/components/sections/InvestorsSection.tsx
+++ b/components/sections/InvestorsSection.tsx
@@ -248,7 +248,7 @@ export function InvestorsSection() {
             </div>
 
             <Link href="/our-story" className="team-compact-link">
-              Full bios + founding story on /our-story →
+              Read full founder bios and the founding story →
             </Link>
           </section>
 

--- a/components/sections/MemorySection.tsx
+++ b/components/sections/MemorySection.tsx
@@ -192,7 +192,7 @@ export function MemorySection() {
             <span className="bridge-also">
               Also in the brief: commitments &middot; contradictions &middot;
               pain &rarr; product &middot; cliffhanger.{' '}
-              <Link href="/investors#moat" className="bridge-link">
+              <Link href="/investors#platform" className="bridge-link">
                 Why not Salesforce &rarr;
               </Link>
             </span>
@@ -333,7 +333,7 @@ export function MemorySection() {
           </table>
           <p className="mem-compare-foot">
             Flatten the graph and you kill the thing.{' '}
-            <Link href="/investors#thesis">Read our full thesis &rarr;</Link>
+            <Link href="/investors#thesis">Read our memory thesis &rarr;</Link>
           </p>
         </section>
       </ScrollReveal>

--- a/components/sections/MemorySection.tsx
+++ b/components/sections/MemorySection.tsx
@@ -333,7 +333,7 @@ export function MemorySection() {
           </table>
           <p className="mem-compare-foot">
             Flatten the graph and you kill the thing.{' '}
-            <Link href="/investors#thesis">Read the full thesis &rarr;</Link>
+            <Link href="/investors#thesis">Read the full institutional memory thesis &rarr;</Link>
           </p>
         </section>
       </ScrollReveal>

--- a/components/sections/MemorySection.tsx
+++ b/components/sections/MemorySection.tsx
@@ -333,7 +333,7 @@ export function MemorySection() {
           </table>
           <p className="mem-compare-foot">
             Flatten the graph and you kill the thing.{' '}
-            <Link href="/investors#thesis">Read the full institutional memory thesis &rarr;</Link>
+            <Link href="/investors#thesis">Read our full thesis &rarr;</Link>
           </p>
         </section>
       </ScrollReveal>

--- a/components/sections/ProblemSection.tsx
+++ b/components/sections/ProblemSection.tsx
@@ -86,7 +86,7 @@ export function ProblemSection() {
           surfacing it the moment someone new picks up the relationship.
         </p>
         <Link href="/memory" className="link">
-          See how it works →
+          See how the memory layer works →
         </Link>
       </div>
     </section>

--- a/components/sections/ProblemSection.tsx
+++ b/components/sections/ProblemSection.tsx
@@ -86,7 +86,7 @@ export function ProblemSection() {
           surfacing it the moment someone new picks up the relationship.
         </p>
         <Link href="/memory" className="link">
-          See how the memory layer works →
+          See our memory layer →
         </Link>
       </div>
     </section>


### PR DESCRIPTION
## Summary

Rewrites four generic body-content anchors using the site's "our"-framed brand voice while adding destination-keyword signal where it carries weight, and fixes one broken anchor fragment surfaced during review.

### Anchor rewrites

| File | Before | After |
|---|---|---|
| \`components/sections/ProblemSection.tsx\` | "See how it works →" | "See our memory layer →" |
| \`components/sections/CtaSection.tsx\` (home CTA button) | "Read our thesis" | "Read our memory thesis" |
| \`components/sections/MemorySection.tsx\` (footer link) | "Read the full thesis →" | "Read our memory thesis →" |
| \`components/sections/InvestorsSection.tsx\` | "Full bios + founding story on /our-story →" | "Read our founding story →" |

All four use "our" + a topical noun in 3–5 words. The InvestorsSection edit also strips the awkward visible \`/our-story\` path suffix.

### Broken anchor fragment fix

\`MemorySection.tsx:195\` — the "Why not Salesforce →" link previously pointed to \`/investors#moat\`, but no element with \`id="moat"\` exists. The destination section in \`InvestorsSection.tsx:34\` has \`id="platform"\` and carries the "Platform & moat" content. Updated the link so the anchor jump lands at the correct section.

\`#thesis\` verified to exist at \`InvestorsSection.tsx:312\`.

### Out of scope (deliberately not changed)
- Header / footer nav labels — short labels are appropriate for navigation usability.
- \`OurStorySection.tsx:112\` "Request early access →" — already descriptive.
- The \`MarketingHeader\` "Request a pilot →" CTA is a button (no \`href\`), so doesn't affect anchor signal.

### Audit gap noted (separate issue worth filing)
Zero body links currently point to \`/why-salency\` — the page built around the highest-leverage Gong-comparison keyword gets no internal anchor signal beyond header/footer nav. Adding 1–2 contextual links from \`/\`, \`/memory\`, or \`/our-story\` would be a separate, scoped change. Out of this PR.

Closes #136.

## Test plan
- [x] \`npm run build\` succeeds.
- [ ] After merge, view-source on \`/\`, \`/memory\`, \`/investors\`, \`/our-story\` shows the new anchor text.
- [ ] Click "Why not Salesforce →" on \`/memory\` and confirm the page scrolls to the Platform & moat section, not the top of \`/investors\`.
- [ ] Visual check: button widths in \`CtaSection\` and footer copy didn't break the layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)