### PR TITLE
seo: add body internal links to /why-salency

### DIFF
--- a/components/sections/HowItWorksSection.tsx
+++ b/components/sections/HowItWorksSection.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 export function HowItWorksSection() {
   return (
     <section className="how" id="how-it-works">
@@ -78,7 +80,8 @@ export function HowItWorksSection() {
       <div className="how-foot">
         <span>
           Works with any transcript.<span className="sep">·</span>
-          Citations and confidence scores on every extraction.
+          Citations and confidence scores on every extraction.<span className="sep">·</span>
+          <Link href="/why-salency">See our take on Gong &rarr;</Link>
         </span>
       </div>
     </section>

--- a/components/sections/MemorySection.tsx
+++ b/components/sections/MemorySection.tsx
@@ -195,6 +195,10 @@ export function MemorySection() {
               <Link href="/investors#platform" className="bridge-link">
                 Why not Salesforce &rarr;
               </Link>
+              {' · '}
+              <Link href="/why-salency" className="bridge-link">
+                See our take on Gong &rarr;
+              </Link>
             </span>
           </div>
         </section>


### PR DESCRIPTION
## Summary

Closes the audit gap repeatedly flagged on PR #144's /seo-check: `/why-salency` is the highest-leverage organic page (built around the "Salency vs Gong" keyword) but had **zero** body anchor signal beyond header/footer nav. PageRank flow + topical relevance need at least one descriptive body link.

Two contextually-fitting links added.

### 1. `HowItWorksSection.tsx` — home page how-foot
Natural fit next to the existing "Works with any transcript" line:

```diff
  Works with any transcript. · Citations and confidence scores on every extraction.
+ · See our take on Gong →
```

### 2. `MemorySection.tsx` — /memory bridge
Parallel to the existing "Why not Salesforce →" bridge link, which already enumerates Salency-vs-other-categories. Both now sit side-by-side:

```diff
  Why not Salesforce →
+ · See our take on Gong →
```

Anchor text follows the [established voice](https://github.com/Project-Cerebro/Salency-Landing-Page/pull/144) (per #136): "our" + topical noun, 4 words.

Closes #146.

## Test plan
- [x] `npm run build` succeeds.
- [ ] Visual check: home-page how-foot doesn't wrap awkwardly on mobile.
- [ ] Visual check: /memory bridge with two links side-by-side reads cleanly.
- [ ] After merge, view-source confirms both `<a href="/why-salency">` appear in body content (not just nav).

🤖 Generated with [Claude Code](https://claude.com/claude-code)