### PR TITLE
seo: body links to /why-salency (promote to prod)

### DIFF
--- a/components/sections/HowItWorksSection.tsx
+++ b/components/sections/HowItWorksSection.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 export function HowItWorksSection() {
   return (
     <section className="how" id="how-it-works">
@@ -78,7 +80,8 @@ export function HowItWorksSection() {
       <div className="how-foot">
         <span>
           Works with any transcript.<span className="sep">·</span>
-          Citations and confidence scores on every extraction.
+          Citations and confidence scores on every extraction.<span className="sep">·</span>
+          <Link href="/why-salency">See our take on Gong &rarr;</Link>
         </span>
       </div>
     </section>

--- a/components/sections/MemorySection.tsx
+++ b/components/sections/MemorySection.tsx
@@ -195,6 +195,10 @@ export function MemorySection() {
               <Link href="/investors#platform" className="bridge-link">
                 Why not Salesforce &rarr;
               </Link>
+              {' · '}
+              <Link href="/why-salency" className="bridge-link">
+                See our take on Gong &rarr;
+              </Link>
             </span>
           </div>
         </section>


### PR DESCRIPTION
## Summary
Promotes `feat/gh-146/why-salency-body-links` from `test` (merged in #147) to `main`.

Closes the audit gap repeatedly flagged on PR #144's /seo-check: `/why-salency` had zero body anchor signal beyond header/footer nav. Two contextually-fitting links added:

1. `HowItWorksSection.tsx` (home how-foot) — "See our take on Gong →"
2. `MemorySection.tsx` (/memory bridge, parallel to "Why not Salesforce →") — "See our take on Gong →"

Anchor text follows the established voice: "our" + topical noun, 4 words.

Closes #146.

## Test plan
- [x] `npm run build` succeeds.
- [x] Verified on staging.
- [ ] After production deploy, view-source on `/` and `/memory` shows `<a href="/why-salency">` in body content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)