### PR TITLE
seo: per-page OG images for /why-salency and /pilot

### DIFF
--- a/app/pilot/opengraph-image.tsx
+++ b/app/pilot/opengraph-image.tsx
@@ -1,0 +1,112 @@
+import { ImageResponse } from 'next/og';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+export const runtime = 'nodejs';
+export const alt = 'Join the Spring 2026 Salency pilot cohort';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default async function Image() {
+  const logoBuffer = readFileSync(join(process.cwd(), 'public/logo.png'));
+  const logoSrc = `data:image/png;base64,${logoBuffer.toString('base64')}`;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          padding: '72px',
+          background:
+            'radial-gradient(ellipse at top left, #1A171E 0%, #121015 60%)',
+          color: '#E8E6E3',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: '24px' }}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={logoSrc} alt="" width={88} height={95} />
+          <div
+            style={{
+              fontSize: 56,
+              fontWeight: 600,
+              letterSpacing: '-0.02em',
+              color: '#E8E6E3',
+            }}
+          >
+            Salency
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '24px',
+          }}
+        >
+          <div
+            style={{
+              fontSize: 22,
+              fontWeight: 500,
+              letterSpacing: '0.16em',
+              textTransform: 'uppercase',
+              color: '#E8925A',
+            }}
+          >
+            Pilot cohort · Spring 2026
+          </div>
+          <div
+            style={{
+              fontSize: 64,
+              lineHeight: 1.1,
+              fontWeight: 500,
+              letterSpacing: '-0.02em',
+              color: '#E8E6E3',
+              maxWidth: '950px',
+            }}
+          >
+            A memory layer that outlasts any rep.
+          </div>
+          <div
+            style={{
+              fontSize: 28,
+              lineHeight: 1.4,
+              fontWeight: 400,
+              color: '#9B9A97',
+              maxWidth: '880px',
+              marginTop: '8px',
+            }}
+          >
+            The next hire inherits a Day-1 brief instead of starting from zero.
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '16px',
+              fontSize: 24,
+              color: '#9B9A97',
+              letterSpacing: '0.02em',
+              marginTop: '16px',
+            }}
+          >
+            <div
+              style={{
+                width: 48,
+                height: 2,
+                background: '#E8925A',
+              }}
+            />
+            www.salency.ai/pilot
+          </div>
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/app/why-salency/opengraph-image.tsx
+++ b/app/why-salency/opengraph-image.tsx
@@ -1,0 +1,106 @@
+import { ImageResponse } from 'next/og';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+export const runtime = 'nodejs';
+export const alt = 'Salency vs Gong — what to do with call recordings';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default async function Image() {
+  const logoBuffer = readFileSync(join(process.cwd(), 'public/logo.png'));
+  const logoSrc = `data:image/png;base64,${logoBuffer.toString('base64')}`;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          padding: '72px',
+          background:
+            'radial-gradient(ellipse at top left, #1A171E 0%, #121015 60%)',
+          color: '#E8E6E3',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: '24px' }}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={logoSrc} alt="" width={88} height={95} />
+          <div
+            style={{
+              fontSize: 56,
+              fontWeight: 600,
+              letterSpacing: '-0.02em',
+              color: '#E8E6E3',
+            }}
+          >
+            Salency
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '24px',
+          }}
+        >
+          <div
+            style={{
+              fontSize: 22,
+              fontWeight: 500,
+              letterSpacing: '0.16em',
+              textTransform: 'uppercase',
+              color: '#E8925A',
+            }}
+          >
+            Salency vs Gong
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '12px',
+              fontSize: 60,
+              lineHeight: 1.1,
+              fontWeight: 500,
+              letterSpacing: '-0.02em',
+              color: '#E8E6E3',
+              maxWidth: '1000px',
+            }}
+          >
+            <div style={{ color: '#9B9A97' }}>
+              Gong records your calls.
+            </div>
+            <div>Salency solves what happens after.</div>
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '16px',
+              fontSize: 24,
+              color: '#9B9A97',
+              letterSpacing: '0.02em',
+              marginTop: '16px',
+            }}
+          >
+            <div
+              style={{
+                width: 48,
+                height: 2,
+                background: '#E8925A',
+              }}
+            />
+            www.salency.ai/why-salency
+          </div>
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}


### PR DESCRIPTION
## Summary

Two new `opengraph-image.tsx` routes using Next.js's file-based convention (same pattern as the site-wide #128). Each composes a 1200×630 PNG via `ImageResponse` and reuses `public/logo.png` + brand palette.

### `app/why-salency/opengraph-image.tsx`
Copper eyebrow "Salency vs Gong"; the page's actual thesis as the hero — "Gong records your calls. Salency solves what happens after." — with the contrast emphasized via two-line muted/foreground typography. URL footer: `www.salency.ai/why-salency`.

### `app/pilot/opengraph-image.tsx`
Copper eyebrow "Pilot cohort · Spring 2026"; "A memory layer that outlasts any rep" hero; supporting line "The next hire inherits a Day-1 brief instead of starting from zero." URL footer: `www.salency.ai/pilot`.

Each route shipped as static at build time — no runtime cost. The site-wide default from #128 still covers every other route (homepage, /memory, /investors, /our-story, /pricing, /privacy, /terms).

Closes #139.

## Test plan
- [x] `npm run build` succeeds; both new OG routes listed as static.
- [x] Local render verified (1200×630, brand-correct typography and color).
- [ ] After merge to test, paste `https://www.salency.ai/why-salency` and `https://www.salency.ai/pilot` into LinkedIn Post Inspector — confirm each gets its bespoke card.
- [ ] Same on Twitter Card Validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)