### PR TITLE
seo: add /blog coming-soon page

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from 'next';
+import { MarketingHeader } from '@/components/MarketingHeader';
+import { SiteFooter } from '@/components/sections/SiteFooter';
+
+export const metadata: Metadata = {
+  title: 'Blog · Salency',
+  description:
+    'Long-form thinking on institutional memory, sales call intelligence, and the layer between Gong and the rep who inherits the account. Coming soon.',
+  alternates: { canonical: '/blog' },
+  robots: { index: false, follow: true },
+};
+
+export default function BlogPage() {
+  return (
+    <div className="page">
+      <MarketingHeader />
+      <section className="coming-soon">
+        <div className="coming-soon-inner">
+          <span className="eb">Salency Blog</span>
+          <h1>
+            Posts on the way. <em>The memory layer, written down.</em>
+          </h1>
+          <p>
+            We&rsquo;re shipping V1 first. When the writing starts, expect
+            long-form thinking on institutional memory, sales call intelligence,
+            and what comes after Gong.
+          </p>
+          <div className="coming-soon-meta hero-meta">
+            <span className="hero-meta-item">First posts · 2026</span>
+            <span className="hero-meta-item">No newsletter, no spam</span>
+          </div>
+        </div>
+      </section>
+      <SiteFooter />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Per #129 scoped down to "no content yet, just stand up the page." Reuses the existing `.coming-soon` styling pattern (eyebrow + h1 + body + meta items) so no new CSS is needed.

### What ships
- `app/blog/page.tsx` — server component, returns 200, brand-consistent typography
  - Eyebrow: "Salency Blog"
  - h1: "Posts on the way. *The memory layer, written down.*"
  - Body: "We're shipping V1 first. When the writing starts, expect long-form thinking on institutional memory, sales call intelligence, and what comes after Gong."
  - Meta items: "First posts · 2026" · "No newsletter, no spam"
- `metadata` export with title, description, canonical (`/blog`), and **`robots: { index: false, follow: true }`** — don't compete to rank on a thin page; crawlers can still follow internal links out.

### What's intentionally NOT in this PR
- `app/blog/[slug]/page.tsx` — no posts to render yet.
- MDX setup, `Article` JSON-LD — defer to first-post PR.
- Sitemap entry — sitemap is for indexable URLs. When the first post ships, that PR will flip the noindex AND add `/blog` + `/blog/[slug]` slugs to the sitemap together.
- Header/footer "Blog" nav link — keep page reachable only by direct URL until there's content. Avoids leading users to an empty room.

When content lands, the follow-up PR adds the dynamic route, MDX, Article schema, sitemap enumeration, nav links, and removes the noindex from this page.

Closes #129.

## Test plan
- [x] `npm run build` succeeds; `/blog` listed as static.
- [x] Local: `curl -sI http://localhost:3000/blog` returns 200.
- [x] Local: `<meta name="robots" content="noindex, follow">` present.
- [x] Local: `<link rel="canonical" href="https://www.salency.ai/blog">` present.
- [ ] After merge to test, visual check on staging: page reads as on-brand, not empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)