### PR TITLE
seo: /changelog build log with current company context

### DIFF
--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -1,0 +1,108 @@
+import type { Metadata } from 'next';
+import { MarketingHeader } from '@/components/MarketingHeader';
+import { SiteFooter } from '@/components/sections/SiteFooter';
+
+export const metadata: Metadata = {
+  title: 'Build log · Salency',
+  description:
+    'A running log of what’s moving on Salency — V1 build, user interviews with B2B sales leaders, accelerator applications, and the SEO foundation.',
+  alternates: { canonical: '/changelog' },
+  robots: { index: true, follow: true },
+};
+
+type Entry = {
+  id: string;
+  date: string;
+  title: string;
+  body: React.ReactNode;
+};
+
+const ENTRIES: Entry[] = [
+  {
+    id: '2026-04-seo-foundation',
+    date: 'April 2026',
+    title: 'SEO foundation shipped',
+    body: (
+      <>
+        Sitemap, robots, per-page metadata, canonicals, JSON-LD (Organization,
+        WebSite, SoftwareApplication, Person, FAQPage), 1200&times;630 OG
+        cards, anchor diversity, and broken-fragment fixes. The site is now
+        properly discoverable to search engines and AI assistants.
+      </>
+    ),
+  },
+  {
+    id: '2026-04-v1-build',
+    date: 'April 2026',
+    title: 'V1 build underway',
+    body: (
+      <>
+        Shipping the V1 sales surface: notetaker bot, transcript ingest, pain
+        extraction with citations, account brief, and pain-to-product mapping.
+        Aiming to land the Spring 2026 pilot cohort with the first real account
+        memories.
+      </>
+    ),
+  },
+  {
+    id: '2026-spring-user-interviews',
+    date: 'Spring 2026',
+    title: 'User interview cycle running',
+    body: (
+      <>
+        Talking with VPs of Sales, CSMs, and AEs across B2B SaaS to validate
+        the institutional-memory thesis. The &ldquo;AE&rarr;CSM handoff&rdquo;
+        and &ldquo;new rep on inherited book&rdquo; pain patterns keep showing
+        up. If you live one of those, we want to hear about it.
+      </>
+    ),
+  },
+  {
+    id: '2026-spring-accelerators',
+    date: 'Spring 2026',
+    title: 'Accelerator applications submitted',
+    body: (
+      <>
+        Applying to early-stage accelerator programs with the structured-context
+        platform pitch. Thesis: institutional memory is the next bottleneck for
+        B2B revenue teams.
+      </>
+    ),
+  },
+];
+
+export default function ChangelogPage() {
+  return (
+    <div className="page">
+      <MarketingHeader />
+      <main className="pt-32 pb-24 px-6 max-w-3xl mx-auto">
+        <span className="eb mb-6 inline-flex">Build log</span>
+        <h1 className="text-4xl md:text-5xl font-semibold text-white mb-6 tracking-tight">
+          What we&rsquo;re shipping.
+        </h1>
+        <p className="text-lg text-gray-400 mb-16 leading-relaxed">
+          A running log of what&rsquo;s moving on Salency. Updated as we ship,
+          interview, and apply.
+        </p>
+
+        <div className="space-y-14">
+          {ENTRIES.map((entry) => (
+            <article key={entry.id}>
+              <div className="text-xs font-mono uppercase tracking-[0.16em] text-accent-warm mb-2">
+                {entry.date}
+              </div>
+              <h2
+                id={entry.id}
+                className="text-2xl font-semibold text-white mb-3 tracking-tight"
+              >
+                {entry.title}
+              </h2>
+              <p className="text-gray-300 leading-relaxed">{entry.body}</p>
+            </article>
+          ))}
+        </div>
+      </main>
+      <SiteFooter />
+    </div>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -16,6 +16,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: '/pricing', changeFrequency: 'weekly', priority: 0.8 },
     { path: '/pilot', changeFrequency: 'weekly', priority: 0.8 },
     { path: '/our-story', changeFrequency: 'monthly', priority: 0.6 },
+    { path: '/changelog', changeFrequency: 'monthly', priority: 0.4 },
     { path: '/investors', changeFrequency: 'monthly', priority: 0.5 },
     { path: '/privacy', changeFrequency: 'yearly', priority: 0.2 },
     { path: '/terms', changeFrequency: 'yearly', priority: 0.2 },


### PR DESCRIPTION
## Summary

Stands up `/changelog` as a real **build log** (not an empty stub) using the current company context: V1 in flight, user interviews underway, accelerator applications submitted, plus the SEO foundation work just shipped.

### Four dated entries (newest first)

| ID | Date | Title |
|---|---|---|
| `2026-04-seo-foundation` | April 2026 | SEO foundation shipped |
| `2026-04-v1-build` | April 2026 | V1 build underway |
| `2026-spring-user-interviews` | Spring 2026 | User interview cycle running |
| `2026-spring-accelerators` | Spring 2026 | Accelerator applications submitted |

Each `<h2>` carries a stable `id` so external links can deep-link to a specific entry (e.g. `/changelog#2026-spring-user-interviews`).

### Tone / framing notes
- "Build log" framing rather than "Changelog" — accurate for a pre-launch product where the work is the journey, not yet release notes.
- Accelerator entry deliberately doesn't name specific programs (avoids public signaling before announcements).
- User interview entry frames it as an active call for participation — anyone living the AE→CSM handoff pain who lands on the page knows the door is open.
- Tagline: "Updated as we ship, interview, and apply." Three-verb cadence captures the company's current shape.

### SEO posture
- **Indexable** (`index, follow`) — content is real and dated, unlike the `/blog` placeholder shipped in #129 which is `noindex`.
- Canonical: `https://www.salency.ai/changelog`
- Added to sitemap with priority 0.4 (above legal pages, below product surfaces)
- Inherits the site-wide OG card from #128
- 1 h1, 4 h2 — clean heading hierarchy

### What's NOT in this PR
- Header/footer "Changelog" nav link — keeping page reachable by direct URL only for now. Add later when there's a steady cadence of new entries (or via a separate small PR).
- `Article` JSON-LD per entry — overkill for a 4-entry running log; revisit if entry count grows past ~10.
- RSS feed — defer until there's actual rhythm to subscribe to.

Closes #138.

## Test plan
- [x] `npm run build` succeeds; `/changelog` listed as static.
- [x] Local `curl` confirms 200, indexable, canonical correct, all 4 entry anchor IDs render.
- [x] Sitemap includes `/changelog`.
- [ ] After merge to test, visual check on staging: typography reads on-brand, copper accent dates render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)