### PR TITLE
content: ship first blog post + tone guide

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,0 +1,116 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { MarketingHeader } from '@/components/MarketingHeader';
+import { SiteFooter } from '@/components/sections/SiteFooter';
+import { JsonLd } from '@/components/JsonLd';
+import { FOUNDERS } from '@/lib/founders';
+import { getAllPostSlugs, getPostBySlug } from '@/content/posts';
+
+type Params = { slug: string };
+
+export function generateStaticParams() {
+  return getAllPostSlugs().map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<Params>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const post = getPostBySlug(slug);
+  if (!post) return {};
+
+  const url = `/blog/${post.slug}`;
+  return {
+    title: `${post.title} · Salency`,
+    description: post.description,
+    alternates: { canonical: url },
+    openGraph: {
+      title: post.title,
+      description: post.description,
+      url: `https://www.salency.ai${url}`,
+      type: 'article',
+      publishedTime: post.publishedAt,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: post.title,
+      description: post.description,
+    },
+  };
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+export default async function BlogPostPage({
+  params,
+}: {
+  params: Promise<Params>;
+}) {
+  const { slug } = await params;
+  const post = getPostBySlug(slug);
+  if (!post) notFound();
+
+  const author = FOUNDERS.find((f) => f.id === post.authorId);
+  const authorName = author?.name ?? 'Salency';
+
+  const articleSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: post.title,
+    description: post.description,
+    datePublished: post.publishedAt,
+    author: {
+      '@type': 'Person',
+      name: authorName,
+      ...(author?.linkedin ? { url: author.linkedin } : {}),
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'Salency',
+      logo: {
+        '@type': 'ImageObject',
+        url: 'https://www.salency.ai/salency-mark.svg',
+      },
+    },
+    mainEntityOfPage: `https://www.salency.ai/blog/${post.slug}`,
+  };
+
+  return (
+    <div className="page">
+      <JsonLd data={articleSchema} />
+      <MarketingHeader />
+      <main className="post-page">
+        <article className="post-article">
+          <div className="post-meta-top">
+            <Link href="/blog" className="post-back">
+              ← Build log
+            </Link>
+            <span className="post-date">
+              {formatDate(post.publishedAt)} · By {authorName}
+            </span>
+          </div>
+          <h1>{post.title}</h1>
+          <p className="post-dek">{post.dek}</p>
+          <div className="post-body">{post.body}</div>
+          <div className="post-footer">
+            <p>
+              Salency is institutional memory for B2B sales teams.{' '}
+              <Link href="/why-salency">See our take on Gong</Link>, or{' '}
+              <Link href="/pilot">join the Spring 2026 pilot cohort</Link>.
+            </p>
+          </div>
+        </article>
+      </main>
+      <SiteFooter />
+    </div>
+  );
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,36 +1,61 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 import { MarketingHeader } from '@/components/MarketingHeader';
 import { SiteFooter } from '@/components/sections/SiteFooter';
+import { POSTS } from '@/content/posts';
+import { FOUNDERS } from '@/lib/founders';
 
 export const metadata: Metadata = {
-  title: 'Blog · Salency',
+  title: 'Build log · Salency',
   description:
-    'Long-form thinking on institutional memory, sales call intelligence, and the layer between Gong and the rep who inherits the account. Coming soon.',
+    'Long-form thinking on institutional memory, sales call intelligence, and the layer between Gong and the rep who inherits the account.',
   alternates: { canonical: '/blog' },
-  robots: { index: false, follow: true },
+  robots: { index: true, follow: true },
 };
 
-export default function BlogPage() {
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+export default function BlogIndexPage() {
+  const posts = [...POSTS].sort((a, b) =>
+    b.publishedAt.localeCompare(a.publishedAt),
+  );
+
   return (
     <div className="page">
       <MarketingHeader />
-      <section className="coming-soon">
-        <div className="coming-soon-inner">
-          <span className="eb">Salency Blog</span>
-          <h1>
-            Posts on the way. <em>The memory layer, written down.</em>
-          </h1>
-          <p>
-            We&rsquo;re shipping V1 first. When the writing starts, expect
-            long-form thinking on institutional memory, sales call intelligence,
-            and what comes after Gong.
+      <main className="blog-index">
+        <header className="blog-index-head">
+          <span className="eb">Salency build log</span>
+          <h1>Long-form thinking from the team building it.</h1>
+          <p className="blog-index-lede">
+            Institutional memory, sales call intelligence, and the layer between
+            Gong and the rep who inherits the account.
           </p>
-          <div className="coming-soon-meta hero-meta">
-            <span className="hero-meta-item">First posts · 2026</span>
-            <span className="hero-meta-item">No newsletter, no spam</span>
-          </div>
-        </div>
-      </section>
+        </header>
+        <ul className="blog-index-list">
+          {posts.map((post) => {
+            const author = FOUNDERS.find((f) => f.id === post.authorId);
+            return (
+              <li key={post.slug} className="blog-index-item">
+                <Link href={`/blog/${post.slug}`} className="blog-index-link">
+                  <span className="blog-index-date">
+                    {formatDate(post.publishedAt)} · By {author?.name ?? 'Salency'}
+                  </span>
+                  <h2 className="blog-index-title">{post.title}</h2>
+                  <p className="blog-index-dek">{post.dek}</p>
+                  <span className="blog-index-cta">Read post →</span>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </main>
       <SiteFooter />
     </div>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -2031,6 +2031,109 @@ header button:focus:not(:focus-visible){
 }
 .coming-soon-meta{margin-top:32px}
 
+/* ═══════════ Blog index ═══════════ */
+.blog-index{
+  max-width:var(--page-max);margin:80px auto 0;padding:20px 40px 96px;
+}
+.blog-index-head{max-width:780px;margin-bottom:64px}
+.blog-index-head .eb{margin-bottom:24px}
+.blog-index-head h1{
+  font-family:var(--font-display), 'Instrument Sans', system-ui, sans-serif;
+  font-weight:500;font-size:clamp(36px,4.8vw,60px);
+  line-height:1.1;letter-spacing:-.025em;
+  margin:0;color:var(--ink);text-wrap:balance;
+}
+.blog-index-lede{
+  margin:24px 0 0;max-width:58ch;
+  font-size:18px;line-height:1.55;color:var(--ink-2);
+}
+.blog-index-list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:1px;background:var(--hair);border-top:1px solid var(--hair);border-bottom:1px solid var(--hair)}
+.blog-index-item{background:var(--background)}
+.blog-index-link{
+  display:block;padding:32px 0;text-decoration:none;color:inherit;
+  transition:padding 0.2s ease;
+}
+.blog-index-link:hover{padding-left:8px}
+.blog-index-date{
+  font-family:'Geist Mono','SFMono-Regular',Consolas,monospace;
+  font-size:11px;font-weight:500;letter-spacing:.18em;text-transform:uppercase;
+  color:var(--copper);display:block;margin-bottom:12px;
+}
+.blog-index-title{
+  font-family:var(--font-display), 'Instrument Sans', system-ui, sans-serif;
+  font-weight:500;font-size:clamp(22px,2.4vw,30px);line-height:1.2;
+  letter-spacing:-.02em;color:var(--ink);margin:0 0 12px;text-wrap:balance;
+}
+.blog-index-dek{
+  font-size:17px;line-height:1.55;color:var(--ink-2);margin:0 0 14px;max-width:62ch;
+}
+.blog-index-cta{
+  font-size:14px;font-weight:500;color:var(--copper);
+  display:inline-block;
+}
+
+/* ═══════════ Blog post (article body) ═══════════ */
+.post-page{max-width:780px;margin:0 auto;padding:80px 32px 96px}
+.post-meta-top{
+  display:flex;justify-content:space-between;align-items:center;
+  margin-bottom:48px;gap:24px;flex-wrap:wrap;
+  font-family:'Geist Mono','SFMono-Regular',Consolas,monospace;
+  font-size:11px;font-weight:500;letter-spacing:.12em;text-transform:uppercase;
+}
+.post-back{color:var(--copper);text-decoration:none}
+.post-back:hover{text-decoration:underline}
+.post-date{color:var(--ink-3)}
+
+.post-article h1{
+  font-family:var(--font-display), 'Instrument Sans', system-ui, sans-serif;
+  font-weight:500;font-size:clamp(34px,4.4vw,52px);line-height:1.08;
+  letter-spacing:-.025em;color:var(--ink);margin:0 0 20px;text-wrap:balance;
+}
+.post-dek{
+  font-size:20px;line-height:1.5;color:var(--ink-3);
+  margin:0 0 56px;font-weight:400;text-wrap:pretty;
+}
+.post-body{font-size:18px;line-height:1.65;color:var(--ink-2)}
+.post-body h2{
+  font-family:var(--font-display), 'Instrument Sans', system-ui, sans-serif;
+  font-weight:500;font-size:clamp(24px,2.6vw,32px);line-height:1.2;
+  letter-spacing:-.015em;color:var(--ink);margin:56px 0 20px;
+}
+.post-body p{margin:0 0 22px}
+.post-body p strong{color:var(--ink);font-weight:600}
+.post-body p em{color:var(--copper);font-style:italic}
+.post-body a{color:var(--copper);text-decoration:none;border-bottom:1px solid rgba(232,146,90,0.4)}
+.post-body a:hover{border-bottom-color:var(--copper)}
+.post-body ul{margin:0 0 22px;padding-left:20px}
+.post-body ul li{margin-bottom:8px}
+.post-body blockquote{
+  margin:28px 0;padding:6px 0 6px 22px;
+  border-left:2px solid var(--copper);
+  font-size:21px;color:var(--ink);font-style:italic;line-height:1.45;
+}
+.post-body table{
+  width:100%;border-collapse:collapse;margin:28px 0;font-size:16px;
+}
+.post-body table th,.post-body table td{
+  text-align:left;padding:14px 16px;border-bottom:1px solid var(--hair);
+}
+.post-body table th{
+  color:var(--copper);
+  font-family:'Geist Mono','SFMono-Regular',Consolas,monospace;
+  font-size:11px;letter-spacing:.12em;text-transform:uppercase;font-weight:500;
+}
+.post-body table td{color:var(--ink-2)}
+.post-pullquote{
+  margin:32px 0;padding:24px 0;
+  border-top:1px solid var(--hair);border-bottom:1px solid var(--hair);
+  font-size:22px;line-height:1.4;color:var(--ink);font-weight:500;
+}
+.post-footer{
+  margin-top:64px;padding-top:32px;border-top:1px solid var(--hair);
+  font-size:16px;color:var(--ink-3);
+}
+.post-footer a{color:var(--copper);text-decoration:none;border-bottom:1px solid rgba(232,146,90,0.4)}
+
 /* ═══════════ A11y utilities ═══════════ */
 .sr-only{
   position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from 'next';
+import { POSTS } from '@/content/posts';
 
 const BASE_URL = 'https://www.salency.ai';
 
@@ -15,6 +16,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: '/memory', changeFrequency: 'weekly', priority: 0.9 },
     { path: '/pricing', changeFrequency: 'weekly', priority: 0.8 },
     { path: '/pilot', changeFrequency: 'weekly', priority: 0.8 },
+    { path: '/blog', changeFrequency: 'weekly', priority: 0.7 },
     { path: '/our-story', changeFrequency: 'monthly', priority: 0.6 },
     { path: '/changelog', changeFrequency: 'monthly', priority: 0.4 },
     { path: '/investors', changeFrequency: 'monthly', priority: 0.5 },
@@ -22,10 +24,21 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: '/terms', changeFrequency: 'yearly', priority: 0.2 },
   ];
 
-  return routes.map(({ path, changeFrequency, priority }) => ({
-    url: `${BASE_URL}${path}`,
-    lastModified,
-    changeFrequency,
-    priority,
+  const staticEntries: MetadataRoute.Sitemap = routes.map(
+    ({ path, changeFrequency, priority }) => ({
+      url: `${BASE_URL}${path}`,
+      lastModified,
+      changeFrequency,
+      priority,
+    }),
+  );
+
+  const postEntries: MetadataRoute.Sitemap = POSTS.map((post) => ({
+    url: `${BASE_URL}/blog/${post.slug}`,
+    lastModified: new Date(post.publishedAt),
+    changeFrequency: 'monthly' as const,
+    priority: 0.6,
   }));
+
+  return [...staticEntries, ...postEntries];
 }

--- a/components/MarketingHeader.tsx
+++ b/components/MarketingHeader.tsx
@@ -16,6 +16,7 @@ const links: NavLink[] = [
   { label: 'Why Salency', href: '/why-salency' },
   { label: 'Memory', href: '/memory' },
   { label: 'Our story', href: '/our-story' },
+  { label: 'Blog', href: '/blog' },
   { label: 'Investors', href: '/investors' },
   { label: 'Pricing', href: '/pricing' },
 ];

--- a/components/sections/SiteFooter.tsx
+++ b/components/sections/SiteFooter.tsx
@@ -8,6 +8,7 @@ export function SiteFooter() {
         <Link href="/why-salency" className="footer-link">Why Salency</Link>
         <Link href="/memory" className="footer-link">Memory</Link>
         <Link href="/our-story" className="footer-link">Our story</Link>
+        <Link href="/blog" className="footer-link">Blog</Link>
         <Link href="/pricing" className="footer-link">Pricing</Link>
         <Link href="/investors" className="footer-link">Investors</Link>
         <Link href="/privacy" className="footer-link">Privacy</Link>

--- a/content/posts/index.ts
+++ b/content/posts/index.ts
@@ -1,0 +1,12 @@
+import { post as institutionalMemoryAiBottleneck } from './institutional-memory-ai-bottleneck';
+import type { Post } from './types';
+
+export const POSTS: Post[] = [institutionalMemoryAiBottleneck];
+
+export function getPostBySlug(slug: string): Post | undefined {
+  return POSTS.find((p) => p.slug === slug);
+}
+
+export function getAllPostSlugs(): string[] {
+  return POSTS.map((p) => p.slug);
+}

--- a/content/posts/institutional-memory-ai-bottleneck.tsx
+++ b/content/posts/institutional-memory-ai-bottleneck.tsx
@@ -1,0 +1,238 @@
+import type { Post } from './types';
+
+export const post: Post = {
+  slug: 'institutional-memory-ai-bottleneck',
+  title:
+    'Stop arguing about AI replacing salespeople. Start asking which layer it should own.',
+  dek: 'Or: why your call recordings are a graveyard.',
+  description:
+    'The augment-vs-replace debate is brain-rot. The right question for revenue leaders is which knowledge layer AI is uniquely suited to own — and the answer is institutional memory.',
+  authorId: 'howard',
+  publishedAt: '2026-04-26',
+  body: (
+    <>
+      <p>Your top AE quit Friday.</p>
+
+      <p>By Monday, three deals are gone.</p>
+
+      <p>
+        Not because the prospects ghosted. Because everything that mattered,
+        the pain the buyer named in call one, the objection from call three,
+        the contradiction between week two and week six, the next step nobody
+        wrote down, all of it lived in one place. Their head.
+      </p>
+
+      <p>That head is now at a competitor.</p>
+
+      <p>
+        Eight hours of recorded calls are sitting in your Gong account. Nobody
+        is going to replay them. You know it. Your VP of Sales knows it. The
+        new rep who&rsquo;ll inherit those accounts in six weeks doesn&rsquo;t
+        even know what to look for.
+      </p>
+
+      <p>This is the bottleneck.</p>
+
+      <p>This is also what every &ldquo;AI in sales&rdquo; think piece is missing.</p>
+
+      <h2>The wrong question</h2>
+
+      <p>The augment-vs-replace debate is brain-rot.</p>
+
+      <p>
+        It&rsquo;s the easiest take in tech. Every consultant has a slide on it.
+        Every vendor has a webinar. Every CEO has a LinkedIn post.
+      </p>
+
+      <p>
+        It&rsquo;s also useless. It produces opinions, not products. It
+        doesn&rsquo;t tell you what to build, what to buy, or where to point
+        your engineering team.
+      </p>
+
+      <p>The right question is sharper:</p>
+
+      <blockquote>Which knowledge layer is AI uniquely suited to own?</blockquote>
+
+      <p>
+        Frame it that way and the answer falls out. And it isn&rsquo;t what most
+        &ldquo;AI sales tools&rdquo; are doing.
+      </p>
+
+      <h2>What humans do that AI can&rsquo;t</h2>
+
+      <ul>
+        <li>Read the room.</li>
+        <li>Know when to push and when to back off.</li>
+        <li>
+          Catch the half-second pause where the buyer&rsquo;s voice doesn&rsquo;t
+          match their words.
+        </li>
+        <li>Build trust over months.</li>
+        <li>Walk into a renewal call and read the org chart in five minutes.</li>
+      </ul>
+
+      <p>
+        This is what your best AE does. Some of it can&rsquo;t even be
+        articulated. AI isn&rsquo;t going to replicate it.
+      </p>
+
+      <p>Stop trying to replace this layer.</p>
+
+      <h2>What AI does that humans can&rsquo;t</h2>
+
+      <p>Remember.</p>
+
+      <p>
+        Not &ldquo;summarize a call.&rdquo; Anyone can do that. Notion can do
+        that. Your phone can do that.
+      </p>
+
+      <p>Real memory:</p>
+
+      <ul>
+        <li>
+          Every pain extracted from every call across years, with the verbatim
+          quote and timestamp.
+        </li>
+        <li>Every contradiction across calls flagged.</li>
+        <li>Every commitment tracked, deadline included.</li>
+        <li>Every pain mapped to your product catalog.</li>
+        <li>
+          Every signal still queryable two years later when the third rep on the
+          account starts asking questions.
+        </li>
+      </ul>
+
+      <p>
+        Most AI sales tools mistake transcription for memory. They record. They
+        transcribe. They generate a 200-word summary. They dump it back into the
+        CRM as a notes field nobody reads.
+      </p>
+
+      <p>That&rsquo;s not memory. That&rsquo;s a graveyard with full-text search.</p>
+
+      <h2>The right model</h2>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Human layer</th>
+            <th>AI layer</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Reading the room</td>
+            <td>Remembering what was said</td>
+          </tr>
+          <tr>
+            <td>Knowing when to push</td>
+            <td>Tracking what was promised</td>
+          </tr>
+          <tr>
+            <td>Building trust</td>
+            <td>Surfacing what changed</td>
+          </tr>
+          <tr>
+            <td>Closing</td>
+            <td>Inheriting context</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>
+        The handoff between those columns is where institutional memory actually
+        lives.
+      </p>
+
+      <p>
+        Right now in most teams, that handoff is a CRM note someone wrote at
+        4:55pm on a Friday.
+      </p>
+
+      <h2>What changes when AI owns the memory layer</h2>
+
+      <p>
+        The new AE doesn&rsquo;t read recordings. They inherit a Day-1 brief:
+        who the stakeholders are, what pains have been raised across the last 14
+        calls, which products got mapped, what was committed and to whom,
+        what&rsquo;s still open, what contradicts what.
+      </p>
+
+      <p>
+        The CSM doesn&rsquo;t ask &ldquo;tell me about the relationship&rdquo;
+        on the kickoff call. They walk in already in the story.
+      </p>
+
+      <p>
+        Pipeline review stops being theater. The VP can ask{' '}
+        <em>
+          &ldquo;show me every account where data residency came up in the last
+          quarter&rdquo;
+        </em>{' '}
+        and get an answer in seconds. From the actual conversations. With
+        citations.
+      </p>
+
+      <p>
+        Pain raised in call one actually gets answered in call five. Because the
+        rep on call five can see it.
+      </p>
+
+      <p>
+        The &ldquo;AE-to-CSM handoff&rdquo; stops being a euphemism for
+        &ldquo;the new person reads notes and hopes.&rdquo;
+      </p>
+
+      <h2>This is what we&rsquo;re building</h2>
+
+      <p>
+        Salency is institutional memory for B2B sales. We turn every call into
+        structured, cited, queryable context. Pains, products, stakeholders,
+        contradictions, commitments. We don&rsquo;t replace your CRM. We sit on
+        top of it. The piece between the call recording and the rep who
+        inherits the account.
+      </p>
+
+      <p>
+        If you&rsquo;ve ever lost a deal to a rep who left, or watched a CSM
+        start from zero on a relationship the AE built for a year,{' '}
+        <a href="/pilot">we&rsquo;d love to talk</a>.
+      </p>
+
+      <h2>The actual reframe</h2>
+
+      <p>AI doesn&rsquo;t replace humans in sales.</p>
+
+      <p>AI replaces:</p>
+
+      <ul>
+        <li>The VP&rsquo;s hope that someone will rewatch the call</li>
+        <li>The notes field nobody updated</li>
+        <li>
+          The Slack message that explained the deal, now buried in #sales-team
+        </li>
+        <li>The spreadsheet someone built in 2023 that&rsquo;s three reps out of date</li>
+        <li>
+          The assumption that institutional memory transfers when accounts
+          change hands
+        </li>
+      </ul>
+
+      <p>
+        When AI does this layer well, the human layer becomes more valuable. Not
+        less. Because the relational work, the actual reason buyers buy, gets to
+        do what it&rsquo;s good at.
+      </p>
+
+      <p>This isn&rsquo;t AI versus humans.</p>
+
+      <p className="post-pullquote">
+        This is the human layer finally getting the memory it always needed.
+      </p>
+
+      <p>That&rsquo;s the bet.</p>
+    </>
+  ),
+};

--- a/content/posts/types.ts
+++ b/content/posts/types.ts
@@ -1,0 +1,11 @@
+import type { ReactNode } from 'react';
+
+export interface Post {
+  slug: string;
+  title: string;
+  dek: string;
+  description: string;
+  authorId: string;
+  publishedAt: string;
+  body: ReactNode;
+}

--- a/tone.md
+++ b/tone.md
@@ -1,0 +1,80 @@
+# Tone
+
+Writing guide for Salency long-form content (blog posts, build-log entries, founder essays).
+Established when the first blog post (`/blog/institutional-memory-ai-bottleneck`) shipped — Voice B from the dual-mockup review on 2026-04-26.
+
+## North star
+
+Founder essay, not corporate blog. Direct, specific, sharp. Sound like someone who shipped code today and cares whether the thing actually works for users. Don't sound like a consultant presenting to a client.
+
+The reader is a VP of Sales, RevOps lead, or sales-curious operator scrolling on LinkedIn or X. They're skeptical of "AI in sales" content because most of it is theater. We earn the read by being concrete and refusing to handwave.
+
+## Cadence
+
+- **One-line paragraphs are encouraged.** Use them to land hard. Especially after a stack of evidence — let the conclusion sit alone.
+- **Stack sentences for rhythm.** Three-sentence runs, then a one-line drop. Mix lengths.
+- **Direct address.** "You." "Your VP of Sales knows it." Not "users may experience" — speak to the actual reader.
+- **Lists where prose would pad.** A 5-bullet list of what AI replaces is sharper than a 5-sentence paragraph saying the same thing.
+- **Tables for two-column thinking.** Human layer vs AI layer. Before vs after. CRM vs Salency. Visual contrast > prose contrast.
+- **Blockquote the question.** When you pose the right question after dismissing the wrong one, blockquote it. Makes it the visual focus of the section.
+- **Pull-quote the closer.** One sentence per post that's allowed to be the loudest line on the page. Set it apart with `<p className="post-pullquote">`.
+
+## Words to avoid
+
+These hollow out a sentence. Edit them out:
+
+- *delve, crucial, robust, comprehensive, nuanced, multifaceted, furthermore, moreover, additionally, pivotal, landscape, tapestry, underscore, foster, showcase, intricate, vibrant, fundamental, significant, interplay*
+- *Here's the kicker, here's the thing, plot twist, let me break this down, the bottom line, make no mistake*
+- *In today's fast-paced world, in the rapidly evolving landscape, more than ever before*
+- *Leverage* (use *use*), *utilize* (use *use*), *seamless* (use a real word)
+
+## Punctuation
+
+- **No em-dashes.** Use commas, periods, or "..." instead. This is a hard rule across the site.
+- **Use "our," not "the."** "Our take on Gong" beats "the Gong comparison." First-person plural is the house voice.
+- **Quotation marks for things people actually say.** Strawman quotes earn a place: `"tell me about the relationship"` if it's the literal phrase a CSM uses on a kickoff call.
+- **Italics for emphasis sparingly.** A single italicized phrase per section, max. Use the copper accent (`<em>`) — the CSS will color it. Reserve for the line you want the eye to land on.
+
+## Structure
+
+The first blog post is the template. Every long-form post should have:
+
+1. **A real moment, not a stat.** "An AE quits Friday." Not "73% of sales teams report churn challenges."
+2. **The wrong frame, dismissed in 3-4 sentences.** Don't dwell on what we're arguing against. Name it, dismiss it, move on.
+3. **The right frame, posed as a single question.** Blockquote it.
+4. **Concrete answer in two parts.** Often "what humans do" / "what AI does" or "the broken way" / "the right way." Use lists or a table here.
+5. **What changes if we do this right.** Specific, not abstract. "The new AE doesn't read recordings. They inherit a Day-1 brief." Visual, present-tense.
+6. **One paragraph on what we're building.** Soft pitch, with one link to `/why-salency`, `/memory`, or `/pilot` as natural.
+7. **Reframe + closer.** Pull-quote the line you want people to remember.
+
+Length target: **800–1,500 words.** Long enough for Google to take seriously, short enough that prospects finish.
+
+## Specific patterns to repeat
+
+- **"Most X tools mistake A for B."** ("Most AI sales tools mistake transcription for memory.") — Names the category error precisely. Use when reframing.
+- **"That's not memory. That's a graveyard with full-text search."** — Negation followed by the real thing in concrete terms. Hits hard.
+- **"The X stops being a euphemism for Y."** ("The AE-to-CSM handoff stops being a euphemism for 'the new person reads notes and hopes.'") — Calls out industry doublespeak. Reader nods.
+- **Stacked one-liners with verbs.** "AI replaces: the VP's hope... / the notes field... / the spreadsheet..." — A list that reads like an indictment.
+
+## What this voice is *not*
+
+- Not consultant-speak. No "key takeaways" sections. No "in this post, we'll explore..." preambles. Get to the punch immediately.
+- Not academic. No abstract framing without a concrete example following it within two sentences.
+- Not founder-bro. No "let's get real" or "here's the truth nobody wants to hear." We trust the reader to recognize a sharp argument without being told it's sharp.
+- Not corporate "we." The "we" is the founding team, not a marketing department. If a sentence sounds like it came from a brand guidelines doc, rewrite it.
+- Not hype. No exclamation points outside dialogue. No "game-changer," "revolutionary," "next-gen."
+
+## Voice fidelity test
+
+Before publishing, read the draft aloud. Check:
+
+1. Could a real founder say this in a conversation?
+2. Would a skeptical VP of Sales finish it?
+3. Is there a single concrete moment, named tool, or specific scenario in every section?
+4. Does the closer earn its weight, or is it a soft "thanks for reading" landing?
+
+If any answer is no, edit before shipping.
+
+## Reference
+
+The canonical example is the first published post: `content/posts/institutional-memory-ai-bottleneck.tsx` (live at `/blog/institutional-memory-ai-bottleneck`). When in doubt about voice, re-read it.


### PR DESCRIPTION
## Summary

Stands up `/blog` with the first long-form post (Voice B from the dual-mockup review). `/blog` flips from `noindex` placeholder to indexable post index. Adds `tone.md` so the voice survives across future posts.

### Post

**Title:** *"Stop arguing about AI replacing salespeople. Start asking which layer it should own."*
**Slug:** `/blog/institutional-memory-ai-bottleneck`
**Author:** Howard Tam
**Date:** 2026-04-26
**Length:** ~800 words

The augment-vs-replace reframe, with Salency's institutional-memory thesis embedded naturally. Soft pitch links to `/pilot` and `/why-salency`.

### Infrastructure

- `content/posts/{types,index}.ts` + per-post `.tsx` files. TSX over MDX deliberately — type-safe, no extra deps, fits the single-post starting state.
- `app/blog/[slug]/page.tsx` — dynamic route, `generateStaticParams` enumerates slugs at build time, `BlogPosting` JSON-LD per post (author Person ref, publisher Organization ref, datePublished, mainEntityOfPage).
- `app/blog/page.tsx` — index page listing all posts. `noindex` removed.
- `app/sitemap.ts` enumerates `/blog` + every post slug dynamically.
- "Blog" link added to `MarketingHeader` and `SiteFooter`.
- Scoped CSS in `globals.css` for `.blog-index` and `.post-*` — brand-consistent (Instrument Sans display, Geist Mono eyebrows, copper accent).

### Tone guide (`tone.md`)

Captures the Voice B writing rules so future posts hit the same register:
- Cadence (one-line paragraphs, stacked sentences, direct address, lists/tables for punch)
- Words to avoid (consultant-ese, AI buzzwords, "leverage")
- Punctuation rules (no em-dashes, "our" not "the", italics sparingly)
- Structure template (real moment → wrong frame → right frame as blockquote → two-part answer → what changes → soft pitch → reframe + pull-quote)
- Specific patterns to repeat ("most X tools mistake A for B", "stops being a euphemism for")
- Voice fidelity test (read aloud, would a skeptical VP finish it, etc.)

Closes #129.

## Test plan
- [x] `npm run build` — `/blog/institutional-memory-ai-bottleneck` rendered as static, `/blog` index renders with the post listed.
- [x] Local: post page returns 200, BlogPosting JSON-LD present, canonical correct, author Howard's LinkedIn embedded in `sameAs`-style author URL.
- [x] Local: `/blog` returns 200, `index, follow`, post link present.
- [x] Local: sitemap includes both `/blog` and `/blog/institutional-memory-ai-bottleneck`.
- [ ] Visual check on staging: post page typography matches the mockup, table renders, blockquote + pullquote land correctly.
- [ ] After deploy, validate BlogPosting JSON-LD at https://validator.schema.org/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)