### PR TITLE
content(investors): trim duplicate intro punchline + drop stale Q2 2026

### DIFF
--- a/components/sections/InvestorsSection.tsx
+++ b/components/sections/InvestorsSection.tsx
@@ -14,15 +14,14 @@ export function InvestorsSection() {
               We own the layer.
             </h1>
             <p>
-              Salency is a system of record for what your accounts actually
-              told you — a structured, cited, queryable memory layer that every
-              future revenue tool will inherit from. Below: what we&apos;re
-              building, who&apos;s building it, and why this moat compounds.
+              Salency is the structured, cited, queryable memory layer for
+              what your accounts actually told you — the input every future
+              revenue tool will inherit from. Every call compounds the graph.
             </p>
             <div className="inv-intro-meta">
-              <span>Pre-seed · Q2 2026</span>
+              <span>Pre-seed</span>
               <span className="sep">·</span>
-              <span>Early access opening Q2 2026</span>
+              <span>Pilot cohort · Spring 2026</span>
               <span className="sep">·</span>
               <a href={`mailto:${FOUNDERS_EMAIL}`}>
                 Private deck available on request


### PR DESCRIPTION
## Summary

Two small copy edits to `/investors` intro area:

- **Intro paragraph trim** — drop the "system of record" framing + "Below: what we're building, who's building it, and why this moat compounds" TOC sentence + duplicate "remembered to type" punchline (the platform section paragraph immediately below already lands that line as the close of a fuller setup → setup → punch structure). Lands cleaner on category claim + "Every call compounds the graph."
- **inv-intro-meta** — align stale "Q2 2026" + "Early access opening Q2 2026" to the site-wide "Pilot cohort · Spring 2026" language already used in `CtaSection`, `/why-salency` CTA, `/memory` CTA.

## Test plan

- [ ] Vercel preview: `/investors` hero renders with two-sentence intro and updated meta strip
- [ ] No layout regression in `inv-intro-inner` or `inv-intro-meta` flex
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)