### PR TITLE
content(why-salency): align register, generic notetaker in body, Gong stays in SEO surfaces

### DIFF
--- a/components/sections/GongSection.tsx
+++ b/components/sections/GongSection.tsx
@@ -102,7 +102,7 @@ export function GongSection() {
         </tbody>
       </table>
       <p className="notetaker-takeaway">
-        Gong tells you <em>what happened.</em> Salency tells you{' '}
+        Notetakers tell you <em>what happened.</em> Salency tells you{' '}
         <em>what to do next.</em>
       </p>
     </section>


### PR DESCRIPTION
## Summary
- /why-salency body said "AI notetakers" 3x then closed with "Gong tells you what happened" — register mismatch between section body and closing line.
- Generalize closing to "Notetakers tell you what happened. Salency tells you what to do next." so the section reads consistently.
- Title, meta, OG, FAQ schema, and FAQ Q1 still name Gong — those are the SEO surfaces capturing "salency vs gong" intent. Untouched.

## Test plan
- [ ] Visit /why-salency on staging
- [ ] Confirm Gong section closing line reads "Notetakers tell you what happened. Salency tells you what to do next."
- [ ] Confirm page <title>, meta description, and FAQ Q1 still mention Gong
- [ ] Confirm no other copy regressed