### PR TITLE
content: name top notetakers + kill integration objection

### DIFF
--- a/components/sections/HeroSection.tsx
+++ b/components/sections/HeroSection.tsx
@@ -33,7 +33,7 @@ export function HeroSection() {
         </div>
 
         <div className="hero-meta">
-          <span className="hero-meta-item">Works alongside your notetaker</span>
+          <span className="hero-meta-item">Gong, Fireflies, Otter, Granola, Fathom &mdash; or any raw transcript</span>
           <span className="hero-meta-item">Early access · Q2 2026</span>
         </div>
       </section>

--- a/components/sections/HowItWorksSection.tsx
+++ b/components/sections/HowItWorksSection.tsx
@@ -11,9 +11,10 @@ export function HowItWorksSection() {
           </h2>
         </div>
         <p className="lede">
-          Any transcript &mdash; <em>AI notetaker</em> or raw &mdash; runs
-          through the same pipeline, and the output is{' '}
-          <em>structured, cited, queryable</em> before your next stand-up.
+          Drop in a Gong, Fireflies, Otter, Granola, or Fathom transcript. Or
+          paste raw text from Zoom, Meet, or Teams. Same pipeline, same
+          output: <em>structured, cited, queryable</em> before your next
+          stand-up.
         </p>
       </div>
       <div className="how-steps">

--- a/components/sections/PilotCtaSection.tsx
+++ b/components/sections/PilotCtaSection.tsx
@@ -10,8 +10,10 @@ export function PilotCtaSection() {
         Start the memory. <em>Inherit it forever.</em>
       </h2>
       <p className="sub">
-        First account memory stands up in a week. By month two, the rep
-        inheriting it reads the story, not a notes field.
+        Week one, your existing calls become searchable memory. Every handoff
+        after that &mdash; internal or customer-side &mdash; reads the story
+        instead of restarting the relationship. No notetaker integration
+        required to start.
       </p>
       <button
         type="button"


### PR DESCRIPTION
## Summary

- Hero meta + How-It-Works lede now name the 5 most-recognized B2B revenue notetakers: Gong, Fireflies, Otter, Granola, Fathom.
- How-It-Works adds Zoom, Meet, Teams as the concrete "raw transcript" use case so "raw" stops being abstract.
- Pilot CTA replaces vague "stands up in a week / month-two inheritance" with honest week-one indexing + handoff-agnostic framing. Adds "No notetaker integration required to start".

Promotes #158 from test → main. Already validated on staging.

## Test plan

- [ ] Visit `/` on prod after deploy
- [ ] Hero meta + How-It-Works + Pilot CTA copy match staging