### PR TITLE
fix(lint): clean up 8 pre-existing issues

### DIFF
--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -28,7 +28,7 @@ export default async function Image() {
         }}
       >
         <div style={{ display: 'flex', alignItems: 'center', gap: '24px' }}>
-          {/* eslint-disable-next-line @next/next/no-img-element */}
+          { }
           <img src={logoSrc} alt="" width={88} height={95} />
           <div
             style={{

--- a/app/pilot/opengraph-image.tsx
+++ b/app/pilot/opengraph-image.tsx
@@ -28,7 +28,7 @@ export default async function Image() {
         }}
       >
         <div style={{ display: 'flex', alignItems: 'center', gap: '24px' }}>
-          {/* eslint-disable-next-line @next/next/no-img-element */}
+          { }
           <img src={logoSrc} alt="" width={88} height={95} />
           <div
             style={{

--- a/app/why-salency/opengraph-image.tsx
+++ b/app/why-salency/opengraph-image.tsx
@@ -28,7 +28,7 @@ export default async function Image() {
         }}
       >
         <div style={{ display: 'flex', alignItems: 'center', gap: '24px' }}>
-          {/* eslint-disable-next-line @next/next/no-img-element */}
+          { }
           <img src={logoSrc} alt="" width={88} height={95} />
           <div
             style={{

--- a/components/MarketingHeader.tsx
+++ b/components/MarketingHeader.tsx
@@ -61,6 +61,7 @@ export function MarketingHeader() {
     <header>
       <div className="nav">
         <Link className="brand" href="/">
+          {/* eslint-disable-next-line @next/next/no-img-element -- SVG mark, no next/image optimization needed */}
           <img src="/salency-mark.svg" alt="" />
           <span className="name">Salency</span>
         </Link>

--- a/components/sections/HubSection.tsx
+++ b/components/sections/HubSection.tsx
@@ -180,6 +180,7 @@ export function HubSection() {
 
         <div className="hub-core">
           <div className="hub-core-brand">
+            {/* eslint-disable-next-line @next/next/no-img-element -- SVG mark, no next/image optimization needed */}
             <img className="hub-core-mark" src="/salency-mark.svg" alt="" />
             <span className="hub-core-name">Salency</span>
           </div>

--- a/packages/brand-reveal/src/BrandReveal.tsx
+++ b/packages/brand-reveal/src/BrandReveal.tsx
@@ -57,6 +57,7 @@ export function BrandReveal({
     }
 
     if (forcePlay) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot mount; browser-API gated, can't lazy-init
       setShouldAnimate(true);
       return;
     }

--- a/packages/brand-reveal/src/BrandRevealSplash.tsx
+++ b/packages/brand-reveal/src/BrandRevealSplash.tsx
@@ -89,6 +89,7 @@ export function BrandRevealSplash({
     if (alreadyShown && !isReload) return;
 
     sessionStorage.setItem(storageKey, '1');
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot mount; sessionStorage/performance gated, can't lazy-init
     setMounted(true);
 
     const hideTimer = window.setTimeout(() => {
@@ -110,6 +111,7 @@ export function BrandRevealSplash({
       <div className="loading-inner">
         <div className="brand-lockup">
           {markSrc && (
+            // eslint-disable-next-line @next/next/no-img-element -- portable package, can't depend on next/image
             <img
               className="brand-lockup-mark"
               src={markSrc}


### PR DESCRIPTION
## Summary

- Auto-removed 3 unused `@next/next/no-img-element` directives from OG image generators (Satori-rendered, rule doesn't fire there).
- Inline-disabled the rule on 3 SVG mark `<img>` tags (`MarketingHeader`, `HubSection`, `BrandRevealSplash`). `next/image` adds zero value for static SVG marks, and `brand-reveal` is a portable package that can't depend on `next/image`.
- Inline-disabled `react-hooks/set-state-in-effect` on 2 one-shot mount setters in `brand-reveal` that are guarded by browser APIs.

`npm run lint` exits clean.

Promotes #159 from test → main. Already validated on staging.

## Test plan

- [ ] CI lint step passes on prod build
- [ ] Salency mark renders in header + hub on prod
- [ ] Brand reveal animation still plays once per session