### PR TITLE
fix(css): align notetaker table subhead fonts, kill FOUC mismatch

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1179,11 +1179,11 @@ html {
   }
   .notetaker-table thead th.col-s{color:var(--copper);background:var(--copper-a04)}
   .notetaker-table thead th.col-s .brand{
-    display:block;font-family:var(--font-display), 'Instrument Serif', serif;font-size:22px;font-weight:400;
+    display:block;font-family:var(--font-body), 'Instrument Sans', system-ui, sans-serif;font-size:22px;font-weight:400;
     letter-spacing:-.01em;color:var(--ink);text-transform:none;margin-top:4px;
   }
   .notetaker-table thead th.col-n .brand{
-    display:block;font-family:var(--font-body), 'Geist', sans-serif;font-weight:500;font-size:18px;
+    display:block;font-family:var(--font-body), 'Instrument Sans', system-ui, sans-serif;font-weight:500;font-size:18px;
     color:var(--ink-2);text-transform:none;letter-spacing:-.005em;margin-top:4px;
   }
   .notetaker-table tbody td{


### PR DESCRIPTION
## Summary

Both column subheaders on the \`/why-salency\` notetaker comparison table now use the same \`font-family\` declaration: \`var(--font-body), 'Instrument Sans', system-ui, sans-serif\`.

**Root cause:** \`col-s .brand\` fell back to \`'Instrument Serif', serif\` while \`col-n .brand\` fell back to \`'Geist', sans-serif\`. During the ~100ms before next/font swaps in Instrument Sans, the two columns rendered in different typeface families — that's the \"weird font\" Howard caught.

Also dropped the misleading \`var(--font-display)\` reference in \`col-s\`. That token is currently bound to Instrument Sans (\`globals.css:1923\`), so the \`'Instrument Serif'\` fallback never matched intent.

Size/weight/color hierarchy preserved:
- Salency column: 22px / 400 / \`--ink\`
- Notetaker column: 18px / 500 / \`--ink-2\`

## Followup (not in this PR)

\`--font-display\` token is bound to Instrument Sans but ~30 places sitewide still declare \`var(--font-display), 'Instrument Serif', serif\` fallback chains. Either the binding is wrong (should be Instrument Serif) or the fallbacks are wrong. Worth a separate design-token audit.

## Test plan

- [ ] Visit \`/why-salency\` on production
- [ ] Hard refresh — both column subheads render in same typeface immediately, no flicker
- [ ] Salency column still bigger / lighter weight / copper, Notetaker column smaller / heavier / dimmer (hierarchy intact)
- [ ] Mobile card view still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)