### PR TITLE
fix(css): notetaker table subheads in Geist Mono uppercase

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1178,14 +1178,13 @@ html {
     letter-spacing:.18em;text-transform:uppercase;color:var(--ink-3);
   }
   .notetaker-table thead th.col-s{color:var(--copper);background:var(--copper-a04)}
-  .notetaker-table thead th.col-s .brand{
-    display:block;font-family:var(--font-body), 'Instrument Sans', system-ui, sans-serif;font-size:22px;font-weight:400;
-    letter-spacing:-.01em;color:var(--ink);text-transform:none;margin-top:4px;
-  }
+  .notetaker-table thead th.col-s .brand,
   .notetaker-table thead th.col-n .brand{
-    display:block;font-family:var(--font-body), 'Instrument Sans', system-ui, sans-serif;font-weight:500;font-size:18px;
-    color:var(--ink-2);text-transform:none;letter-spacing:-.005em;margin-top:4px;
+    display:block;font-family:'Geist Mono',monospace;font-size:12.5px;font-weight:500;
+    letter-spacing:.12em;text-transform:uppercase;margin-top:8px;
   }
+  .notetaker-table thead th.col-s .brand{color:var(--ink)}
+  .notetaker-table thead th.col-n .brand{color:var(--ink-3)}
   .notetaker-table tbody td{
     padding:20px 24px;border-bottom:1px solid var(--hair);vertical-align:top;
     font-family:var(--font-body), 'Geist', sans-serif;font-size:14.5px;line-height:1.5;color:var(--ink-2);


### PR DESCRIPTION
## Summary

Cut the notetaker comparison table from four type voices to two.

\"Conversation intelligence\" / \"Institutional memory\" subheads now render in Geist Mono 12.5px uppercase with .12em tracking, matching the parent \`<th>\` eyebrow (\"NOTETAKER\" / \"SALENCY\") and the leftmost column (\"OUTPUT\", \"UNIT OF MEMORY\") that already use the same voice.

**Type voices in the table:**
- Geist Mono — all labels (eyebrows + dimension column + subheads)
- Instrument Sans — cell prose

Hierarchy preserved via color (\`--ink\` for Salency, \`--ink-3\` for Notetaker), not size.

## Why

Previous fix aligned the fallback chains (#165) but kept the four-voice reality. Howard pushed for a real type-voice cleanup. Mocked up [option B](file:///tmp/notetaker-table-mockup.html) side-by-side, approved.

## Test plan

- [ ] Visit \`/why-salency\` on production
- [ ] Both column subheads render in Geist Mono uppercase, not Instrument Sans
- [ ] Salency column subhead is brighter (\`--ink\`), Notetaker dimmer (\`--ink-3\`)
- [ ] Mobile card view still readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)