### PR TITLE
revert: notetaker table subhead mono treatment (PR #167)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1178,13 +1178,14 @@ html {
     letter-spacing:.18em;text-transform:uppercase;color:var(--ink-3);
   }
   .notetaker-table thead th.col-s{color:var(--copper);background:var(--copper-a04)}
-  .notetaker-table thead th.col-s .brand,
-  .notetaker-table thead th.col-n .brand{
-    display:block;font-family:'Geist Mono',monospace;font-size:12.5px;font-weight:500;
-    letter-spacing:.12em;text-transform:uppercase;margin-top:8px;
+  .notetaker-table thead th.col-s .brand{
+    display:block;font-family:var(--font-body), 'Instrument Sans', system-ui, sans-serif;font-size:22px;font-weight:400;
+    letter-spacing:-.01em;color:var(--ink);text-transform:none;margin-top:4px;
   }
-  .notetaker-table thead th.col-s .brand{color:var(--ink)}
-  .notetaker-table thead th.col-n .brand{color:var(--ink-3)}
+  .notetaker-table thead th.col-n .brand{
+    display:block;font-family:var(--font-body), 'Instrument Sans', system-ui, sans-serif;font-weight:500;font-size:18px;
+    color:var(--ink-2);text-transform:none;letter-spacing:-.005em;margin-top:4px;
+  }
   .notetaker-table tbody td{
     padding:20px 24px;border-bottom:1px solid var(--hair);vertical-align:top;
     font-family:var(--font-body), 'Geist', sans-serif;font-size:14.5px;line-height:1.5;color:var(--ink-2);


### PR DESCRIPTION
## Summary

Revert PR #167. Restores Instrument Sans subheads (the post-#165 state).

After seeing the Geist Mono uppercase treatment shipped, Howard preferred the prior Instrument Sans look. The four-voice reality is acceptable; the FOUC fix from #165 is the real win and stays in place.

## Test plan

- [ ] Visit \`/why-salency\`
- [ ] Column subheads (\"Conversation intelligence\" / \"Institutional memory\") render in Instrument Sans 18-22px (not Geist Mono uppercase)
- [ ] No font flicker on hard refresh (FOUC fix from #165 still in place)

🤖 Generated with [Claude Code](https://claude.com/claude-code)