### PR TITLE
fix(css): dimension column cells to --font-body (Instrument Sans)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1193,7 +1193,7 @@ html {
   .notetaker-table tbody tr:last-child td{border-bottom:0}
   .notetaker-table tbody td.dim{
     color:var(--ink);font-weight:500;font-size:14px;
-    font-family:'Geist Mono',monospace;letter-spacing:.02em;width:24%;
+    font-family:var(--font-body), 'Instrument Sans', system-ui, sans-serif;width:24%;
   }
   .notetaker-table tbody td.col-s{background:var(--copper-a03);color:var(--ink)}
   .notetaker-table tbody td.col-s strong{color:var(--copper);font-weight:500}


### PR DESCRIPTION
## Summary

\"Output\", \"Unit of memory\", \"Citations\", etc — the leftmost row labels in the notetaker comparison table — switched from Geist Mono to Instrument Sans via \`var(--font-body)\`. Drops the \`.02em\` letter-spacing (a Geist Mono affordance that looks awkward on a proportional font).

Subheads (\"Conversation intelligence\" / \"Institutional memory\") are already on \`var(--font-body)\` from PR #168.

## Kept unchanged

Mobile \`td.dim\` treatment stays on Geist Mono uppercase. On mobile the table collapses to card-per-row and \`.dim\` becomes a tiny eyebrow above each card — the Geist Mono uppercase fits the eyebrow role.

## Test plan

- [ ] Visit \`/why-salency\` on desktop — leftmost column reads in Instrument Sans
- [ ] Resize to mobile — \`.dim\` cells render as small uppercase eyebrows above each card (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)