### PR TITLE
fix(css): notetaker subheads borrow H2's editorial-display voice

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1178,14 +1178,14 @@ html {
     letter-spacing:.18em;text-transform:uppercase;color:var(--ink-3);
   }
   .notetaker-table thead th.col-s{color:var(--copper);background:var(--copper-a04)}
-  .notetaker-table thead th.col-s .brand{
-    display:block;font-family:var(--font-body), 'Instrument Sans', system-ui, sans-serif;font-size:22px;font-weight:400;
-    letter-spacing:-.01em;color:var(--ink);text-transform:none;margin-top:4px;
-  }
+  .notetaker-table thead th.col-s .brand,
   .notetaker-table thead th.col-n .brand{
-    display:block;font-family:var(--font-body), 'Instrument Sans', system-ui, sans-serif;font-weight:500;font-size:18px;
-    color:var(--ink-2);text-transform:none;letter-spacing:-.005em;margin-top:4px;
+    display:block;font-family:var(--font-body), 'Instrument Sans', system-ui, sans-serif;
+    font-weight:400;letter-spacing:-.02em;line-height:1.1;
+    text-transform:none;margin-top:6px;
   }
+  .notetaker-table thead th.col-s .brand{font-size:26px;color:var(--ink)}
+  .notetaker-table thead th.col-n .brand{font-size:22px;color:var(--ink-2)}
   .notetaker-table tbody td{
     padding:20px 24px;border-bottom:1px solid var(--hair);vertical-align:top;
     font-family:var(--font-body), 'Geist', sans-serif;font-size:14.5px;line-height:1.5;color:var(--ink-2);


### PR DESCRIPTION
## Summary

\"Conversation intelligence\" / \"Institutional memory\" subheads now echo the section H2 (\"The last mile AI notetakers leave unaddressed\") through tight tracking and bigger size.

**Before:** 18-22px, weight 400/500, letter-spacing -.005/-.01em. Body-text feel; didn't relate to the H2.

**After:** 22-26px, weight 400 unified, letter-spacing -.02em (close to H2's -.025em), line-height 1.1. Same family (Instrument Sans), borrowed treatment.

Salency-vs-Notetaker hierarchy carried by color: \`--ink\` (bright) for Salency, \`--ink-2\` (dim) for Notetaker. No weight differentiation.

Approved via side-by-side mockup comparison with the H2 above each table.

## Test plan

- [ ] Visit \`/why-salency\`
- [ ] Subheads visually relate to the section H2 (tight tracking, larger)
- [ ] Salency column reads brighter than Notetaker column
- [ ] Mobile view still readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)