### PR TITLE
fix(font+table): variable Instrument Sans + fixed-layout cols

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1169,9 +1169,13 @@ html {
   }
   .notetaker-head p{font-family:var(--font-body), 'Geist', sans-serif;font-weight:300;font-size:16px;line-height:1.65;color:var(--ink-2);margin:0}
   .notetaker-table{
-    width:100%;border-collapse:collapse;
+    width:100%;border-collapse:collapse;table-layout:fixed;
     background:#121015;border:1px solid var(--hair-2);border-radius:14px;overflow:hidden;
   }
+  .notetaker-table thead th.col-n,
+  .notetaker-table thead th.col-s,
+  .notetaker-table tbody td.col-n,
+  .notetaker-table tbody td.col-s{width:38%}
   .notetaker-table thead th{
     padding:22px 24px;text-align:left;border-bottom:1px solid var(--hair-2);
     font-family:'Geist Mono',monospace;font-size:10.5px;font-weight:500;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -55,7 +55,6 @@ const instrumentSerif = Instrument_Serif({
 
 const instrumentSans = Instrument_Sans({
   variable: "--font-instrument-sans",
-  weight: ["400", "500", "600", "700"],
   style: ["normal", "italic"],
   subsets: ["latin"],
 });


### PR DESCRIPTION
## Summary

Closes the gap between the editorial-display mockup approved earlier and how /why-salency renders in production.

### Change 1 — Variable-axis Instrument Sans

\`app/layout.tsx\` previously loaded Instrument Sans as **static weight files** (one woff2 per weight: 400, 500, 600, 700). The mockup pulled Instrument Sans from Google Fonts CDN as a **variable-axis** woff2.

Same typeface name, but variable-axis weight 400 and static weight 400 don't render byte-identical. Stroke widths, bowl shapes, and antialiasing differ subtly.

Removing the \`weight\` array from the next/font config tells next/font to request the variable woff2 from Google. Same render path as the mockup. Bonus: one woff2 instead of 8 per-weight files.

### Change 2 — Fixed table layout

The notetaker comparison table was using auto layout. When col-s rows have longer content (\"Live account graph — the brief regenerates from it...\"), the auto layout gives col-s extra horizontal space and shrinks col-n. Result: \"Conversation intelligence\" wraps to two lines while \"Institutional memory\" stays single-line, which reads visually inconsistent.

Added \`table-layout: fixed\` and explicit \`width: 38%\` on both col-n and col-s. The \`.dim\` column already had \`width: 24%\`, so the math sums to 100. Both content columns now share width equally regardless of row content length.

Mobile card-per-row override (\`@media (max-width: 768px)\`) is unaffected — that layer overrides \`display\` on the table elements anyway.

## Test plan

- [ ] Visit \`/why-salency\` on production after deploy
- [ ] At ~900-1100px viewport: \"Conversation intelligence\" stays on one line
- [ ] At ~900-1100px viewport: col-n and col-s look the same width
- [ ] Subhead font weight rendering matches the editorial-display mockup approved earlier
- [ ] Mobile (<768px): table still collapses to card-per-row, dim column reads as eyebrow
- [ ] Network tab: only one Instrument Sans woff2 loads instead of 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)