### PR TITLE
fix(css): --font-body/--font-display empty sitewide due to invalid var()

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1921,10 +1921,19 @@ html {
   }
 
 /* ═══════════ Marketing font mapping ═══════════ */
-/* Bind --font-body / --font-display to next/font variables. */
+/* Bind --font-body / --font-display directly to the loaded next/font
+   font-family name. Previously we used var(--font-instrument-sans) here,
+   but that next/font CSS variable is set on <body> via the className,
+   not on :root. Per CSS spec, an unresolved var() without an explicit
+   fallback makes the entire custom property "guaranteed-invalid" — so
+   --font-body and --font-display silently computed to empty sitewide,
+   breaking every font-family declaration that referenced them and
+   causing inherited fonts (e.g. Geist Mono on table headers) to leak
+   into descendants. Using literal font-family strings removes the
+   var() indirection entirely. */
 :root{
-  --font-body: var(--font-instrument-sans), 'Instrument Sans', system-ui, sans-serif;
-  --font-display: var(--font-instrument-sans), 'Instrument Sans', system-ui, sans-serif;
+  --font-body: 'Instrument Sans', 'Instrument Sans Fallback', system-ui, sans-serif;
+  --font-display: 'Instrument Sans', 'Instrument Sans Fallback', system-ui, sans-serif;
 }
 
 /* ═══════════ Mobile nav — hamburger + slide-down panel ═══════════ */


### PR DESCRIPTION
## Root cause (the actual bug)

The \`:root\` rule defining font tokens at \`globals.css:1925\` used \`var(--font-instrument-sans)\`. But that next/font CSS variable is only set on \`<body>\` via the next/font className — **never on \`:root\`**.

Per CSS spec ([custom properties resolution](https://www.w3.org/TR/css-variables-1/#invalid-variables)): an unresolved \`var()\` without an explicit fallback makes the entire custom property \"guaranteed-invalid\". Trailing tokens after \`var(...)\` (like \`'Instrument Sans', system-ui, sans-serif\`) are NOT a fallback — they're additional value tokens that join the now-invalid value.

**Net effect:** \`--font-body\` and \`--font-display\` computed to empty string sitewide.

Verified via browse tool:
\`\`\`js
getComputedStyle(document.documentElement).getPropertyValue('--font-body')
// → \"\"  (empty)
\`\`\`

## Symptoms

Every \`font-family: var(--font-body), ...\` declaration sitewide was invalid → browser fell back to inherited font.

On \`/why-salency\` the table comparison subheads (\`.brand\` inside \`<th>\`) inherited Geist Mono from their parent \`<th>\`'s eyebrow rule. That's why production rendered \"Conversation intelligence\" / \"Institutional memory\" in monospace despite our CSS clearly specifying \`var(--font-body)\`.

This bug was latent since the day \`--font-body\` was introduced. Sitewide, body text rendered through accidental inheritance and browser defaults rather than from the design tokens.

## Fix

Drop the var() indirection. Reference \`'Instrument Sans'\` (the literal name from the next/font @font-face declaration) and \`'Instrument Sans Fallback'\` directly:

\`\`\`css
:root{
  --font-body: 'Instrument Sans', 'Instrument Sans Fallback', system-ui, sans-serif;
  --font-display: 'Instrument Sans', 'Instrument Sans Fallback', system-ui, sans-serif;
}
\`\`\`

Custom properties now have valid values regardless of where the next/font className lives.

## Test plan

- [ ] After deploy: \`getComputedStyle(document.documentElement).getPropertyValue('--font-body')\` returns \`'Instrument Sans', 'Instrument Sans Fallback', system-ui, sans-serif\` (not empty)
- [ ] \`/why-salency\` notetaker subheads render in Instrument Sans (not Geist Mono)
- [ ] Hard refresh required to bust old CSS chunk

🤖 Generated with [Claude Code](https://claude.com/claude-code)