### PR TITLE
fix(our-story): anchor "Read our founding story" CTA to team bios

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1734,6 +1734,7 @@ html {
   /* Layer 3 — 2x2 founder grid with square photos + side-by-side bio */
   .story-founders{
     margin-bottom:64px;
+    scroll-margin-top:96px;
 
     .eb{margin-bottom:40px;display:flex}
   }

--- a/components/sections/InvestorsSection.tsx
+++ b/components/sections/InvestorsSection.tsx
@@ -246,7 +246,7 @@ export function InvestorsSection() {
               ))}
             </div>
 
-            <Link href="/our-story" className="team-compact-link">
+            <Link href="/our-story#team" className="team-compact-link">
               Read our founding story →
             </Link>
           </section>

--- a/components/sections/OurStorySection.tsx
+++ b/components/sections/OurStorySection.tsx
@@ -80,7 +80,7 @@ export function OurStorySection() {
       </div>
 
       {/* Layer 3 — 4 founders, 2x2 grid, square photos */}
-      <div className="story-founders">
+      <div id="team" className="story-founders">
         <span className="eb">Who&rsquo;s building it</span>
         <div className="story-founders-list">
           {FOUNDERS.map((founder) => (


### PR DESCRIPTION
## Summary
- Investors-page CTA \"Read our founding story →\" scrolled to top of `/our-story` instead of the founder bios section
- Added `id=\"team\"` to `.story-founders`, pointed Link at `/our-story#team`
- Added `scroll-margin-top:96px` on `.story-founders` so the sticky header doesn't occlude the anchor target

## Test plan
- [ ] On staging, visit `/investors`, click \"Read our founding story →\"
- [ ] Verify URL becomes `/our-story#team`
- [ ] Verify viewport scrolls past hero/collision sections to land on \"Who's building it\" with header not covering it
- [ ] Verify smooth scroll behavior (already enabled via `html { scroll-behavior: smooth }`)
- [ ] Sanity-check direct nav to `/our-story#team` (cold load) also lands at the team block

🤖 Generated with [Claude Code](https://claude.com/claude-code)