### PR TITLE
design(legal): bump typography on /privacy and /terms

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -15,29 +15,29 @@ export default function Privacy() {
     <div className="page">
       <MarketingHeader />
       <main className="pt-32 pb-24 px-6 max-w-3xl mx-auto">
-        <h1 className="text-4xl font-bold text-white mb-8">Privacy Policy</h1>
-        <div className="prose prose-invert prose-gray max-w-none space-y-6 text-gray-300 text-sm leading-relaxed">
+        <h1 className="text-5xl font-bold text-white mb-8">Privacy Policy</h1>
+        <div className="prose prose-invert prose-gray max-w-none space-y-6 text-gray-300 text-base leading-relaxed">
           <p><strong>Effective date:</strong> March 25, 2026</p>
 
           <p>Salency (&ldquo;we,&rdquo; &ldquo;us,&rdquo; or &ldquo;our&rdquo;) is committed to protecting your privacy. This policy explains how we collect, use, and safeguard information when you visit salency.ai or use our services.</p>
 
-          <h2 className="text-lg font-bold text-white mt-8 mb-3">Information We Collect</h2>
+          <h2 className="text-2xl font-bold text-white mt-8 mb-3">Information We Collect</h2>
           <p>When you submit the pilot request form, we collect: your name, work email, company name, role, and team size. We also collect standard web analytics data (page views, referrer, device type) via Vercel Analytics. No cookies, no personal identifiers.</p>
 
-          <h2 className="text-lg font-bold text-white mt-8 mb-3">How We Use Your Information</h2>
+          <h2 className="text-2xl font-bold text-white mt-8 mb-3">How We Use Your Information</h2>
           <p>We use the information you provide solely to evaluate pilot fit and contact you about Salency. We do not sell, rent, or share your personal information with third parties for marketing purposes.</p>
 
-          <h2 className="text-lg font-bold text-white mt-8 mb-3">Data Storage</h2>
+          <h2 className="text-2xl font-bold text-white mt-8 mb-3">Data Storage</h2>
           <p>Form submissions are sent via Resend (our email provider) and stored in our internal systems. We do not store credit card information or sensitive financial data.</p>
 
-          <h2 className="text-lg font-bold text-white mt-8 mb-3">Your Rights</h2>
-          <p>You may request access to, correction of, or deletion of your personal data at any time by emailing <a href="mailto:hello@salency.ai" className="text-accent-warm hover:underline">hello@salency.ai</a>.</p>
+          <h2 className="text-2xl font-bold text-white mt-8 mb-3">Your Rights</h2>
+          <p>You may request access to, correction of, or deletion of your personal data at any time by emailing <a href="mailto:hello@salency.ai" className="text-copper hover:underline">hello@salency.ai</a>.</p>
 
-          <h2 className="text-lg font-bold text-white mt-8 mb-3">Changes</h2>
+          <h2 className="text-2xl font-bold text-white mt-8 mb-3">Changes</h2>
           <p>We may update this policy from time to time. Changes will be posted on this page with an updated effective date.</p>
 
-          <h2 className="text-lg font-bold text-white mt-8 mb-3">Contact</h2>
-          <p>Questions? Email us at <a href="mailto:hello@salency.ai" className="text-accent-warm hover:underline">hello@salency.ai</a>.</p>
+          <h2 className="text-2xl font-bold text-white mt-8 mb-3">Contact</h2>
+          <p>Questions? Email us at <a href="mailto:hello@salency.ai" className="text-copper hover:underline">hello@salency.ai</a>.</p>
         </div>
       </main>
       <SiteFooter />

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -15,29 +15,29 @@ export default function Terms() {
     <div className="page">
       <MarketingHeader />
       <main className="pt-32 pb-24 px-6 max-w-3xl mx-auto">
-        <h1 className="text-4xl font-bold text-white mb-8">Terms of Service</h1>
-        <div className="prose prose-invert prose-gray max-w-none space-y-6 text-gray-300 text-sm leading-relaxed">
+        <h1 className="text-5xl font-bold text-white mb-8">Terms of Service</h1>
+        <div className="prose prose-invert prose-gray max-w-none space-y-6 text-gray-300 text-base leading-relaxed">
           <p><strong>Effective date:</strong> March 25, 2026</p>
 
           <p>These terms govern your use of salency.ai and any pilot services provided by Salency (&ldquo;we,&rdquo; &ldquo;us,&rdquo; or &ldquo;our&rdquo;).</p>
 
-          <h2 className="text-lg font-bold text-white mt-8 mb-3">Use of the Site</h2>
+          <h2 className="text-2xl font-bold text-white mt-8 mb-3">Use of the Site</h2>
           <p>You may use this site to learn about Salency and submit a pilot request. You agree not to misuse the site, submit false information, or attempt to interfere with its operation.</p>
 
-          <h2 className="text-lg font-bold text-white mt-8 mb-3">Pilot Program</h2>
+          <h2 className="text-2xl font-bold text-white mt-8 mb-3">Pilot Program</h2>
           <p>Pilot access is offered at our discretion. During the pilot period, Salency is provided free of charge. We reserve the right to modify or discontinue the pilot at any time. Continued use after the pilot requires a paid subscription.</p>
 
-          <h2 className="text-lg font-bold text-white mt-8 mb-3">Intellectual Property</h2>
+          <h2 className="text-2xl font-bold text-white mt-8 mb-3">Intellectual Property</h2>
           <p>All content on this site (text, design, logos, and code) is owned by Salency. You may not reproduce or distribute it without our written permission. Your data remains yours; we do not claim ownership of any transcripts or business information you provide.</p>
 
-          <h2 className="text-lg font-bold text-white mt-8 mb-3">Limitation of Liability</h2>
+          <h2 className="text-2xl font-bold text-white mt-8 mb-3">Limitation of Liability</h2>
           <p>Salency is provided &ldquo;as is&rdquo; during the pilot period. We are not liable for any indirect, incidental, or consequential damages arising from your use of the service.</p>
 
-          <h2 className="text-lg font-bold text-white mt-8 mb-3">Changes</h2>
+          <h2 className="text-2xl font-bold text-white mt-8 mb-3">Changes</h2>
           <p>We may update these terms from time to time. Continued use of the site constitutes acceptance of the revised terms.</p>
 
-          <h2 className="text-lg font-bold text-white mt-8 mb-3">Contact</h2>
-          <p>Questions? Email us at <a href="mailto:hello@salency.ai" className="text-accent-warm hover:underline">hello@salency.ai</a>.</p>
+          <h2 className="text-2xl font-bold text-white mt-8 mb-3">Contact</h2>
+          <p>Questions? Email us at <a href="mailto:hello@salency.ai" className="text-copper hover:underline">hello@salency.ai</a>.</p>
         </div>
       </main>
       <SiteFooter />


### PR DESCRIPTION
## Summary
Closes most of #185 + #186. Both legal pages share a template with sub-floor typography (body 14px, H2 18px). One small set of edits fixes both.

## Changes
- Body: \`text-sm\` → \`text-base\` (14 → 16px). Universal hard rule: body ≥16px.
- H2: \`text-lg\` → \`text-2xl\` (18 → 24px). Read as section heads, not bold paragraphs.
- H1: \`text-4xl\` → \`text-5xl\` (36 → 48px). Gives doc title proper visual weight.
- Mailto links: \`text-accent-warm\` → \`text-copper\` (matches PR #193).

## Out of scope (separate issues)
- #194 — sticky right-rail TOC (real component work, IntersectionObserver-driven)
- #195 — mailto color override caused by `.prose a` specificity beating `.text-copper` (pre-existing bug, not introduced by this PR or #193)
- Jurisdiction / arbitration / termination clauses (legal content, not design)
- Pricing copy lift from /terms § Pilot Program to /pricing (content move, separate concern)

## Test plan
- [x] /privacy renders H1=48, H2=24×6, body p=16
- [x] /terms renders H1=48, H2=24×6, body p=16
- [x] Page layout no horizontal overflow
- [x] No visible regression vs `.gstack/design-reports/audit-20260427/screenshots/privacy-d.png`
- [ ] Verify in production after merge

## Dependency
Independent of #193 — but if #193 merges first, no conflict (this PR uses \`text-copper\` which #193 introduces). If this PR merges first, #193's migration of /privacy + /terms becomes a no-op (both files already use \`text-copper\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)