### PR TITLE
design(ia): pricing-status copy + Changelog footer link

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -769,6 +769,16 @@ html {
   .apply-page{
     position:relative;
   }
+
+  /* Pricing-status meta line on /pricing + /pilot — small mono caps
+     under the lede. Same visual register as the home hero-meta. */
+  .apply-page .apply-price{
+    margin:20px 0 0;
+    font-family:'Geist Mono', SFMono-Regular, Consolas, monospace;
+    font-size:11px;font-weight:500;letter-spacing:.12em;
+    text-transform:uppercase;color:var(--ink-3);
+    max-width:none;
+  }
   .hero::before,
   .mem-intro::before,
   .thesis-hero::before,

--- a/components/sections/PilotApplication.tsx
+++ b/components/sections/PilotApplication.tsx
@@ -48,6 +48,9 @@ export function PilotApplication() {
           small group of revenue teams this cohort. Tell us about your team and
           we&apos;ll scope the fit together.
         </p>
+        <p className="apply-price">
+          Free during the Spring 2026 pilot. Pricing per engagement after.
+        </p>
       </section>
 
       <section className="apply-layout">

--- a/components/sections/SiteFooter.tsx
+++ b/components/sections/SiteFooter.tsx
@@ -9,6 +9,7 @@ export function SiteFooter() {
         <Link href="/memory" className="footer-link">Memory</Link>
         <Link href="/our-story" className="footer-link">Our story</Link>
         <Link href="/blog" className="footer-link">Blog</Link>
+        <Link href="/changelog" className="footer-link">Changelog</Link>
         <Link href="/pricing" className="footer-link">Pricing</Link>
         <Link href="/investors" className="footer-link">Investors</Link>
         <Link href="/privacy" className="footer-link">Privacy</Link>


### PR DESCRIPTION
## Summary
Closes #10 (Changelog orphan) + #12 (pricing signal hidden) from the meta IA cleanup. Per user direction, /pilot and /pricing intentionally render identical content (placeholder for real pricing later), so #9 deduplication is parked.

## Changes
- **PilotApplication**: small mono-caps meta line under the lede — "Free during the Spring 2026 pilot. Pricing per engagement after." Renders on both `/pricing` and `/pilot` (shared component). Sets price expectation without committing to tiers.
- **SiteFooter**: `Changelog` link inserted between Blog and Pricing. Only nav surface for `/changelog`; header stays uncluttered (8 items would crowd at 1024px).
- **globals.css**: `.apply-page .apply-price` rule (Geist Mono 11px, --ink-3, .12em letter-spacing).

## Test plan
- [x] /pricing renders the price-status line below the lede
- [x] /pilot renders the price-status line (same component)
- [x] Footer shows Changelog between Blog and Pricing on every page
- [x] /changelog reachable via footer link
- [ ] Verify in production after merge

Closes #10, closes #12. Refs #9 (parked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)