### PR TITLE
design(memory): lock heading scale on /memory

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2721,9 +2721,9 @@ header button:focus:not(:focus-visible){
   .mem-compare-head h2 {
     font-family: var(--font-display), 'Instrument Sans', system-ui, sans-serif;
     font-weight: 400;
-    font-size: clamp(34px, 4vw, 52px);
+    font-size: clamp(32px, 4vw, 48px);
     line-height: 1.05;
-    letter-spacing: -.025em;
+    letter-spacing: -.02em;
     color: var(--ink);
     margin: 0;
     max-width: 22ch;
@@ -2801,9 +2801,9 @@ header button:focus:not(:focus-visible){
     h2 {
       font-family: var(--font-display), 'Instrument Sans', system-ui, sans-serif;
       font-weight: 400;
-      font-size: clamp(36px, 4.5vw, 56px);
+      font-size: clamp(32px, 4vw, 48px);
       line-height: 1.05;
-      letter-spacing: -.025em;
+      letter-spacing: -.02em;
       color: var(--ink);
       margin: 0 auto 18px;
       max-width: 22ch;
@@ -3041,8 +3041,8 @@ header button:focus:not(:focus-visible){
 .mem-stack-head { margin-bottom: 48px; }
 .mem-stack-head h2 {
   font-family: var(--font-display);
-  font-size: clamp(34px, 3.8vw, 48px);
-  line-height: 1.08;
+  font-size: clamp(32px, 4vw, 48px);
+  line-height: 1.05;
   letter-spacing: -.02em;
   font-weight: 400;
   color: var(--ink);


### PR DESCRIPTION
## Summary
Closes the #177 typography finding (3 different H2 sizes — 56 / 51.2 / 48 px). Caps all three to \`clamp(32, 4vw, 48)\` matching the canonical scale set in #193 (home) and #200 (why-salency).

## Changes
- \`.mem-cta h2\`: clamp(36, 4.5vw, 56) → clamp(32, 4vw, 48)
- \`.mem-compare-head h2\`: clamp(34, 4vw, 52) → clamp(32, 4vw, 48)
- \`.mem-stack-head h2\`: clamp(34, 3.8vw, 48) → clamp(32, 4vw, 48)

## Result
Same H2 ceiling on /, /why-salency, and /memory: H1 67 → H2 48. The 3 marketing pages now share one heading rhythm.

## Audit corrections
Finding 1 ("three mid-page sections render invisible") was a misread of the screenshot — the sections are styled correctly. Verified via `getComputedStyle` on production.

## Out of scope
- Hero artifact promotion (UX work)
- Hero subtitle run-on (content)
- Italic accent overuse → #191
- Comparison section visual diff (UX work)
- Day 1 vs Day 0 (content)

## Test plan
- [x] All H2s on /memory render 48px
- [x] H3s on .mem-support-card stay at 22px (in-card sub-titles, intentionally smaller)
- [x] No visible regression
- [ ] Verify in production after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)