### PR TITLE
design(investors): lock heading scale + tabular-nums on stats

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1332,7 +1332,7 @@ html {
 
     .eb{margin-bottom:28px;display:flex}
     h2{
-      font-size:clamp(38px,4.2vw,54px);line-height:1.1;color:var(--ink);
+      font-size:clamp(32px,4vw,48px);line-height:1.05;color:var(--ink);
       margin:0 0 28px;max-width:32ch;text-wrap:balance;
     }
     p{
@@ -1387,13 +1387,23 @@ html {
     margin-top:44px;
   }
 
+  /* Tabular figures on financial stats — keeps numeric strings
+     aligned and prevents jitter when values change. Applies to all
+     .figure stat displays under /investors sections. */
+  .inv-tam .figure,
+  .platform-evidence .stat,
+  .inv-intro-meta{
+    font-variant-numeric: tabular-nums;
+    font-feature-settings: 'tnum';
+  }
+
   /* TAM — market size strip */
   .inv-tam{
     max-width:var(--page-max);margin:80px auto 0;padding:0 40px;
 
     .eb{margin-bottom:28px;display:flex}
     h2{
-      font-size:clamp(38px,4.2vw,54px);line-height:1.1;color:var(--ink);
+      font-size:clamp(32px,4vw,48px);line-height:1.05;color:var(--ink);
       margin:0 0 36px;max-width:32ch;text-wrap:balance;
     }
     .tam-grid{
@@ -1443,7 +1453,7 @@ html {
 
     .eb{margin-bottom:28px;display:flex}
     h2{
-      font-size:clamp(38px,4.2vw,54px);line-height:1.1;color:var(--ink);
+      font-size:clamp(32px,4vw,48px);line-height:1.05;color:var(--ink);
       margin:0 0 20px;max-width:32ch;text-wrap:balance;
     }
     .compete-lede{
@@ -1487,7 +1497,7 @@ html {
 
     .eb{margin-bottom:28px;display:flex}
     h2{
-      font-size:clamp(38px,4.2vw,54px);line-height:1.1;color:var(--ink);
+      font-size:clamp(32px,4vw,48px);line-height:1.05;color:var(--ink);
       margin:0 0 36px;max-width:22ch;text-wrap:balance;
     }
     .horizon-list{display:grid;grid-template-columns:1fr;gap:20px}
@@ -1539,7 +1549,7 @@ html {
         font-family:var(--font-display), 'Instrument Serif', serif;font-style:italic;font-size:22px;color:var(--copper);
       }
       h2{
-        font-size:clamp(36px,3.8vw,48px);color:var(--ink);margin:0;max-width:18ch;
+        font-size:clamp(32px,4vw,48px);line-height:1.05;color:var(--ink);margin:0;max-width:18ch;
       }
     }
   }
@@ -1596,7 +1606,7 @@ html {
     }
     .eb{margin-bottom:24px}
     h2{
-      font-size:clamp(34px,3.6vw,46px);line-height:1.1;color:var(--ink);
+      font-size:clamp(32px,4vw,48px);line-height:1.05;color:var(--ink);
       margin:0 0 28px;max-width:22ch;
     }
     p{


### PR DESCRIPTION
## Summary
Closes #181 typography findings. Caps all 6 H2s on /investors to \`clamp(32, 4vw, 48)\`. Adds \`font-variant-numeric: tabular-nums\` to financial stat displays.

Heading scale now consistent across /, /why-salency, /memory, /investors.

## Changes
- 6 H2 selectors capped to clamp(32, 4vw, 48). Was 53.76 / 48 / 46 px (3 sizes, no system).
  - \`.platform h2\` / \`.inv-tam h2\` / \`.inv-compete h2\` / \`.roadmap h2\` (shared rule shape)
  - \`.team .sect-head h2\`
  - \`.thesis-card h2\`
- Tabular-nums on \`.inv-tam .figure\`, \`.platform-evidence .stat\`, \`.inv-intro-meta\` — keeps ~50K / 0.5-1% / $1M → $100M / 40-50% / Pre-seed strings aligned.

## Out of scope
- $100M ARR opportunity needs a chart (UX work)
- Comparison table contrast (separate concern)
- "What ships next" timeline visualization (UX work)
- Italic accent overuse → #191
- No deck-download CTA (content)

## Test plan
- [x] All 6 H2s on /investors render 48px
- [x] Financial figures resolve `font-variant-numeric: tabular-nums` in computed style

🤖 Generated with [Claude Code](https://claude.com/claude-code)