### PR TITLE
design: retroactive cleanup from grill (#196 #197 #198 #199)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -687,6 +687,25 @@ html {
     &:disabled:hover{filter:none}
   }
 
+  /* Custom select chevron rendered as a mask-image so the color is
+     tokenized via background-color, not baked into a data URL. The
+     <select> can't host a pseudo-element (replaced element), so wrap
+     it in <div class="select-wrap"> and paint the chevron on ::after. */
+  .select-wrap{position:relative;display:block}
+  .select-wrap::after{
+    content:"";
+    position:absolute;
+    right:16px;top:50%;
+    width:12px;height:8px;
+    transform:translateY(-50%);
+    background-color:var(--copper);
+    -webkit-mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 8'%3E%3Cpath d='M1 1.5L6 6.5L11 1.5' stroke='black' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+            mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 8'%3E%3Cpath d='M1 1.5L6 6.5L11 1.5' stroke='black' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    -webkit-mask-repeat:no-repeat;mask-repeat:no-repeat;
+    -webkit-mask-size:contain;mask-size:contain;
+    pointer-events:none;
+  }
+
   /* Application/intake page — shared by /pilot and /pricing.
      Generic "apply-*" naming so the classes aren't misleading when
      viewed through the pricing-page lens. All layout/typography lives

--- a/app/globals.css
+++ b/app/globals.css
@@ -790,20 +790,6 @@ html {
     position:relative;
   }
 
-  /* Founder avatar with photo — applies to .photo wherever it
-     appears (story-founder-meta, team-strip strip-cell). The
-     parent .photo rule still owns size + border-radius + border.
-     This modifier just clips the image and removes the initials
-     gradient background. */
-  .photo.photo--has-image{
-    background:none;
-    overflow:hidden;
-    padding:0;
-  }
-  .photo.photo--has-image img{
-    width:100%;height:100%;object-fit:cover;display:block;
-  }
-
   /* Pricing-status meta line on /pricing + /pilot — small mono caps
      under the lede. Same visual register as the home hero-meta. */
   .apply-page .apply-price{
@@ -1631,14 +1617,10 @@ html {
     }
     .photo{
       width:56px;height:56px;border-radius:8px;
-      background:linear-gradient(135deg,var(--copper-a22),rgba(209,60,19,.35));
-      color:#FFEDE8;font-family:var(--font-display), 'Instrument Serif', serif;font-weight:400;font-size:22px;
-      display:flex;align-items:center;justify-content:center;letter-spacing:-.01em;
       border:1px solid var(--copper-a30);
+      overflow:hidden;
 
-      &.photo--violet{background:linear-gradient(135deg,rgba(107,78,255,.22),rgba(42,30,128,.5));border-color:rgba(107,78,255,.3);color:#D8CEFF}
-      &.photo--teal{background:linear-gradient(135deg,rgba(0,181,160,.22),rgba(0,107,94,.45));border-color:rgba(0,181,160,.3);color:#B5F0E5}
-      &.photo--amber{background:linear-gradient(135deg,rgba(251,191,36,.22),rgba(146,64,14,.5));border-color:rgba(251,191,36,.32);color:#FFE8A8}
+      img{width:100%;height:100%;object-fit:cover;display:block}
     }
     .name{
       font-family:var(--font-display), 'Instrument Serif', serif;font-weight:500;font-size:18px;color:var(--ink);
@@ -1860,14 +1842,10 @@ html {
 
     .photo{
       width:88px;height:88px;border-radius:0;
-      background:linear-gradient(135deg,var(--copper-a22),rgba(209,60,19,.35));
-      color:#FFEDE8;font-family:'Geist Mono',monospace;font-weight:500;font-size:13px;
-      display:flex;align-items:center;justify-content:center;letter-spacing:.1em;
       border:1px solid var(--hair-2);
+      overflow:hidden;
 
-      &.photo--violet{background:linear-gradient(135deg,rgba(107,78,255,.22),rgba(42,30,128,.5));color:#D8CEFF}
-      &.photo--teal{background:linear-gradient(135deg,rgba(0,181,160,.22),rgba(0,107,94,.45));color:#B5F0E5}
-      &.photo--amber{background:linear-gradient(135deg,rgba(251,191,36,.22),rgba(146,64,14,.5));color:#FFE8A8}
+      img{width:100%;height:100%;object-fit:cover;display:block}
     }
   }
 
@@ -1952,7 +1930,7 @@ html {
     .story-collision-close{margin-top:40px}
 
     .story-founders-list{grid-template-columns:1fr;gap:48px}
-    .story-founder-meta .photo{width:72px;height:72px;font-size:12px}
+    .story-founder-meta .photo{width:72px;height:72px}
 
     .story-close{margin-top:64px;padding-top:40px}
     .story-close-ctas{gap:16px}

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -16,7 +16,7 @@ export default function Privacy() {
       <MarketingHeader />
       <main className="pt-32 pb-24 px-6 max-w-3xl mx-auto">
         <h1 className="text-5xl font-bold text-white mb-8">Privacy Policy</h1>
-        <div className="prose prose-invert prose-gray max-w-none space-y-6 text-gray-300 text-base leading-relaxed">
+        <div className="max-w-none space-y-6 text-gray-300 text-base leading-relaxed">
           <p><strong>Effective date:</strong> March 25, 2026</p>
 
           <p>Salency (&ldquo;we,&rdquo; &ldquo;us,&rdquo; or &ldquo;our&rdquo;) is committed to protecting your privacy. This policy explains how we collect, use, and safeguard information when you visit salency.ai or use our services.</p>

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -16,7 +16,7 @@ export default function Terms() {
       <MarketingHeader />
       <main className="pt-32 pb-24 px-6 max-w-3xl mx-auto">
         <h1 className="text-5xl font-bold text-white mb-8">Terms of Service</h1>
-        <div className="prose prose-invert prose-gray max-w-none space-y-6 text-gray-300 text-base leading-relaxed">
+        <div className="max-w-none space-y-6 text-gray-300 text-base leading-relaxed">
           <p><strong>Effective date:</strong> March 25, 2026</p>
 
           <p>These terms govern your use of salency.ai and any pilot services provided by Salency (&ldquo;we,&rdquo; &ldquo;us,&rdquo; or &ldquo;our&rdquo;).</p>

--- a/components/EmailForm.tsx
+++ b/components/EmailForm.tsx
@@ -110,8 +110,7 @@ export function EmailForm({ prefillEmail }: { prefillEmail?: string }) {
     }
 
     const inputClass = 'w-full bg-black/20 border border-white/10 rounded-lg px-4 py-3 text-white focus:outline-none focus:border-copper transition-colors';
-    const selectChevron = `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8' fill='none'%3E%3Cpath d='M1 1.5L6 6.5L11 1.5' stroke='%23FE8531' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E")`;
-    const selectClass = `${inputClass} appearance-none pr-10 bg-no-repeat bg-[right_1rem_center]`;
+    const selectClass = `${inputClass} appearance-none pr-10`;
 
     return (
         <form
@@ -189,41 +188,43 @@ export function EmailForm({ prefillEmail }: { prefillEmail?: string }) {
 
             <div className="mb-4">
                 <label htmlFor="pilot-industry" className="block text-sm font-medium text-gray-300 mb-1">Industry *</label>
-                <select
-                    id="pilot-industry"
-                    {...register('industry', { required: true })}
-                    className={selectClass}
-                    style={{ backgroundImage: selectChevron }}
-                    defaultValue=""
-                    aria-invalid={errors.industry ? 'true' : undefined}
-                    aria-describedby={errors.industry ? 'pilot-industry-error' : undefined}
-                    suppressHydrationWarning
-                >
-                    <option value="" disabled>Select an industry</option>
-                    {INDUSTRIES.map((i) => (
-                        <option key={i} value={i}>{i}</option>
-                    ))}
-                </select>
+                <div className="select-wrap">
+                    <select
+                        id="pilot-industry"
+                        {...register('industry', { required: true })}
+                        className={selectClass}
+                        defaultValue=""
+                        aria-invalid={errors.industry ? 'true' : undefined}
+                        aria-describedby={errors.industry ? 'pilot-industry-error' : undefined}
+                        suppressHydrationWarning
+                    >
+                        <option value="" disabled>Select an industry</option>
+                        {INDUSTRIES.map((i) => (
+                            <option key={i} value={i}>{i}</option>
+                        ))}
+                    </select>
+                </div>
                 {errors.industry && <span id="pilot-industry-error" className="text-red-400 text-xs mt-1 block">Please select an industry</span>}
             </div>
 
             <div className="mb-4">
                 <label htmlFor="pilot-role" className="block text-sm font-medium text-gray-300 mb-1">Your Role *</label>
-                <select
-                    id="pilot-role"
-                    {...register('role', { required: true })}
-                    className={selectClass}
-                    style={{ backgroundImage: selectChevron }}
-                    defaultValue=""
-                    aria-invalid={errors.role ? 'true' : undefined}
-                    aria-describedby={errors.role ? 'pilot-role-error' : undefined}
-                    suppressHydrationWarning
-                >
-                    <option value="" disabled>Select your role</option>
-                    {ROLES.map((r) => (
-                        <option key={r} value={r}>{r}</option>
-                    ))}
-                </select>
+                <div className="select-wrap">
+                    <select
+                        id="pilot-role"
+                        {...register('role', { required: true })}
+                        className={selectClass}
+                        defaultValue=""
+                        aria-invalid={errors.role ? 'true' : undefined}
+                        aria-describedby={errors.role ? 'pilot-role-error' : undefined}
+                        suppressHydrationWarning
+                    >
+                        <option value="" disabled>Select your role</option>
+                        {ROLES.map((r) => (
+                            <option key={r} value={r}>{r}</option>
+                        ))}
+                    </select>
+                </div>
                 {errors.role && <span id="pilot-role-error" className="text-red-400 text-xs mt-1 block">Please select your role</span>}
             </div>
 

--- a/components/FounderAvatar.tsx
+++ b/components/FounderAvatar.tsx
@@ -7,22 +7,16 @@ interface FounderAvatarProps {
 }
 
 export function FounderAvatar({ founder, size }: FounderAvatarProps) {
-  const className = `photo ${founder.photoVariant}`.trim();
-
-  if (founder.photoSrc) {
-    return (
-      <div className={`${className} photo--has-image`}>
-        <Image
-          src={founder.photoSrc}
-          alt={`${founder.name}, ${founder.role}`}
-          width={size * 2}
-          height={size * 2}
-          sizes={`${size}px`}
-          loading="lazy"
-        />
-      </div>
-    );
-  }
-
-  return <div className={className}>{founder.initials}</div>;
+  return (
+    <div className="photo">
+      <Image
+        src={founder.photoSrc}
+        alt={`${founder.name}, ${founder.role}`}
+        width={size * 2}
+        height={size * 2}
+        sizes={`${size}px`}
+        loading="lazy"
+      />
+    </div>
+  );
 }

--- a/components/sections/PilotApplication.tsx
+++ b/components/sections/PilotApplication.tsx
@@ -7,7 +7,6 @@ const APPLY_CARDS: Array<{ title: string; marker: MarkerKind; items: string[] }>
     title: 'Pilot includes',
     marker: 'check',
     items: [
-      '60 days of free access',
       'Weekly extraction reports on your calls',
       '30-minute weekly debrief with our team',
       '1–2 week setup, no obligation to continue',

--- a/lib/founders.tsx
+++ b/lib/founders.tsx
@@ -1,14 +1,10 @@
 import { ReactNode } from 'react';
 
-export type PhotoVariant = '' | 'photo--violet' | 'photo--teal' | 'photo--amber';
-
 export interface Founder {
   id: string;
   name: string;
   role: string;
-  initials: string;
-  photoVariant: PhotoVariant;
-  photoSrc?: string;
+  photoSrc: string;
   shortBio: ReactNode;
   longBio: ReactNode;
   linkedin?: string;
@@ -19,8 +15,6 @@ export const FOUNDERS: Founder[] = [
     id: 'howard',
     name: 'Howard Tam',
     role: 'Co-founder & CEO',
-    initials: 'HT',
-    photoVariant: '',
     photoSrc: '/founders/howard.png',
     linkedin: 'https://www.linkedin.com/in/howardhwt/',
     shortBio: (
@@ -44,8 +38,6 @@ export const FOUNDERS: Founder[] = [
     id: 'nikki',
     name: 'Nikki Ip',
     role: 'Co-founder & Product',
-    initials: 'NI',
-    photoVariant: 'photo--violet',
     photoSrc: '/founders/nikki.png',
     linkedin: 'https://www.linkedin.com/in/nikkilkip/',
     shortBio: (
@@ -66,8 +58,6 @@ export const FOUNDERS: Founder[] = [
     id: 'babajide',
     name: 'Babajide Okusanya',
     role: 'Founding Engineer',
-    initials: 'BO',
-    photoVariant: 'photo--teal',
     photoSrc: '/founders/babajide.png',
     linkedin: 'https://www.linkedin.com/in/jideokusanya/',
     shortBio: (
@@ -88,8 +78,6 @@ export const FOUNDERS: Founder[] = [
     id: 'shristi',
     name: 'Shristi Gartaula',
     role: 'Founding Designer',
-    initials: 'SG',
-    photoVariant: 'photo--amber',
     photoSrc: '/founders/shristi.png',
     linkedin: 'https://www.linkedin.com/in/shristi1/',
     shortBio: (


### PR DESCRIPTION
## Summary

Bundle of 4 cleanups confirmed during the retroactive grill of recently-shipped PRs. Each commit is a separate, reviewable change.

- **`design(form): rewrite chevron as mask-image + currentColor`** — the select chevron was a data-URL background with a hardcoded `#FE8531` fill, invisible to the token system and impossible to tint. Wrap each `<select>` in `.select-wrap` so a sibling `::after` paints the chevron via `mask-image` with `background-color: var(--copper)`. Closes #199.
- **`design(founders): drop initials-fallback path`** — all four founders now ship with photo files in `/public/founders`, so the initials + `photoVariant` gradient fallback in `FounderAvatar` is dead code. Drop the fallback branch, the `.photo--violet/teal/amber` rules, and the `.photo--has-image` modifier — the parent `.photo` rule now owns image clipping directly. Closes #198.
- **`design(legal): drop @tailwindcss/typography wrappers`** — the `.prose prose-invert prose-gray` wrapper on `/privacy` + `/terms` was overriding our utility classes via plugin specificity (`text-copper` on mailto links wasn't winning against `.prose a`). Drop the wrapper — every element inside already has explicit utility classes for color, size, weight, and spacing. Closes #195, #196.
- **`design(pilot): drop duplicate "60 days free" bullet`** — the `.apply-price` meta line above the cards already says "Free during the Spring 2026 pilot." Repeating "60 days of free access" as the first bullet of "Pilot includes" was redundant. Closes #197.

## Test plan
- [ ] Pilot form (`/pilot`): chevron renders copper on Industry + Role selects in light + dark, hover + focus states correct
- [ ] `/team` and `/our-story`: founder photos still render at correct size + border, no layout shift
- [ ] `/privacy` and `/terms`: mailto links render copper, h2 + p spacing intact
- [ ] `/pilot`: "Pilot includes" card has 3 bullets (no duplicate pricing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)