### PR TITLE
design: mobile hero wrap + legal TOC (#189 #194)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1440,6 +1440,59 @@ html {
     text-wrap:balance;
   }
 
+  /* Legal pages — /privacy + /terms.
+     Two-column layout at >=1024 with sticky right-rail TOC.
+     Below 1024, falls back to single column and the TOC is hidden
+     (the page is short enough at mobile that a top-of-page anchor
+     list adds noise rather than helping). */
+  .legal-layout{
+    display:block;
+  }
+  .legal-toc{display:none}
+
+  @media (min-width: 1024px){
+    .legal-layout{
+      display:grid;
+      grid-template-columns:minmax(0,1fr) 220px;
+      gap:64px;
+      align-items:start;
+    }
+    .legal-toc{
+      display:block;
+      position:sticky;top:96px;
+      font-family:'Geist Mono', SFMono-Regular, Consolas, monospace;
+      font-size:12px;
+      line-height:1.5;
+    }
+    .legal-toc-eb{
+      display:block;
+      font-size:10.5px;font-weight:500;letter-spacing:.18em;
+      text-transform:uppercase;color:var(--copper);
+      margin-bottom:14px;
+    }
+    .legal-toc ol{
+      list-style:none;margin:0;padding:0;
+      border-left:1px solid var(--hair-2);
+    }
+    .legal-toc li{
+      margin:0;padding:0;
+    }
+    .legal-toc a{
+      display:block;
+      padding:6px 14px;
+      color:var(--ink-3);
+      text-decoration:none;
+      border-left:1px solid transparent;
+      margin-left:-1px;
+      transition:color .18s ease, border-color .18s ease;
+    }
+    .legal-toc a:hover{color:var(--ink-2)}
+    .legal-toc li.is-active a{
+      color:var(--copper);
+      border-left-color:var(--copper);
+    }
+  }
+
   /* Tabular figures on financial stats — keeps numeric strings
      aligned and prevents jitter when values change. Applies to all
      .figure stat displays under /investors sections. */

--- a/app/globals.css
+++ b/app/globals.css
@@ -822,6 +822,10 @@ html {
   }
   @media (max-width: 768px) {
     .hero { padding: 56px 22px 48px; }
+    /* Force the muted second sentence onto its own visual block so
+       text-wrap: balance can split "Institutional memory for revenue
+       teams." cleanly without orphaning the orange <em>. */
+    .h1 .soft { display: block; margin-top: .25em; }
   }
   .hero-hairline{
     max-width:var(--page-max);margin:0 auto;

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { MarketingHeader } from '@/components/MarketingHeader';
 import { SiteFooter } from '@/components/sections/SiteFooter';
+import { LegalToc, type LegalTocSection } from '@/components/LegalToc';
 
 export const metadata: Metadata = {
   title: 'Privacy Policy · Salency',
@@ -10,34 +11,48 @@ export const metadata: Metadata = {
   robots: { index: true, follow: true },
 };
 
+const SECTIONS: LegalTocSection[] = [
+  { id: 'information-we-collect', title: 'Information We Collect' },
+  { id: 'how-we-use-your-information', title: 'How We Use Your Information' },
+  { id: 'data-storage', title: 'Data Storage' },
+  { id: 'your-rights', title: 'Your Rights' },
+  { id: 'changes', title: 'Changes' },
+  { id: 'contact', title: 'Contact' },
+];
+
 export default function Privacy() {
   return (
     <div className="page">
       <MarketingHeader />
-      <main className="pt-32 pb-24 px-6 max-w-3xl mx-auto">
+      <main className="pt-32 pb-24 px-6 max-w-5xl mx-auto">
         <h1 className="text-5xl font-bold text-white mb-8">Privacy Policy</h1>
-        <div className="max-w-none space-y-6 text-gray-300 text-base leading-relaxed">
-          <p><strong>Effective date:</strong> March 25, 2026</p>
+        <div className="legal-layout">
+          <div className="max-w-none space-y-6 text-gray-300 text-base leading-relaxed">
+            <p><strong>Effective date:</strong> March 25, 2026</p>
 
-          <p>Salency (&ldquo;we,&rdquo; &ldquo;us,&rdquo; or &ldquo;our&rdquo;) is committed to protecting your privacy. This policy explains how we collect, use, and safeguard information when you visit salency.ai or use our services.</p>
+            <p>Salency (&ldquo;we,&rdquo; &ldquo;us,&rdquo; or &ldquo;our&rdquo;) is committed to protecting your privacy. This policy explains how we collect, use, and safeguard information when you visit salency.ai or use our services.</p>
 
-          <h2 className="text-2xl font-bold text-white mt-8 mb-3">Information We Collect</h2>
-          <p>When you submit the pilot request form, we collect: your name, work email, company name, role, and team size. We also collect standard web analytics data (page views, referrer, device type) via Vercel Analytics. No cookies, no personal identifiers.</p>
+            <h2 id="information-we-collect" className="text-2xl font-bold text-white mt-8 mb-3 scroll-mt-32">Information We Collect</h2>
+            <p>When you submit the pilot request form, we collect: your name, work email, company name, role, and team size. We also collect standard web analytics data (page views, referrer, device type) via Vercel Analytics. No cookies, no personal identifiers.</p>
 
-          <h2 className="text-2xl font-bold text-white mt-8 mb-3">How We Use Your Information</h2>
-          <p>We use the information you provide solely to evaluate pilot fit and contact you about Salency. We do not sell, rent, or share your personal information with third parties for marketing purposes.</p>
+            <h2 id="how-we-use-your-information" className="text-2xl font-bold text-white mt-8 mb-3 scroll-mt-32">How We Use Your Information</h2>
+            <p>We use the information you provide solely to evaluate pilot fit and contact you about Salency. We do not sell, rent, or share your personal information with third parties for marketing purposes.</p>
 
-          <h2 className="text-2xl font-bold text-white mt-8 mb-3">Data Storage</h2>
-          <p>Form submissions are sent via Resend (our email provider) and stored in our internal systems. We do not store credit card information or sensitive financial data.</p>
+            <h2 id="data-storage" className="text-2xl font-bold text-white mt-8 mb-3 scroll-mt-32">Data Storage</h2>
+            <p>Form submissions are sent via Resend (our email provider) and stored in our internal systems. We do not store credit card information or sensitive financial data.</p>
 
-          <h2 className="text-2xl font-bold text-white mt-8 mb-3">Your Rights</h2>
-          <p>You may request access to, correction of, or deletion of your personal data at any time by emailing <a href="mailto:hello@salency.ai" className="text-copper hover:underline">hello@salency.ai</a>.</p>
+            <h2 id="your-rights" className="text-2xl font-bold text-white mt-8 mb-3 scroll-mt-32">Your Rights</h2>
+            <p>You may request access to, correction of, or deletion of your personal data at any time by emailing <a href="mailto:hello@salency.ai" className="text-copper hover:underline">hello@salency.ai</a>.</p>
 
-          <h2 className="text-2xl font-bold text-white mt-8 mb-3">Changes</h2>
-          <p>We may update this policy from time to time. Changes will be posted on this page with an updated effective date.</p>
+            <h2 id="changes" className="text-2xl font-bold text-white mt-8 mb-3 scroll-mt-32">Changes</h2>
+            <p>We may update this policy from time to time. Changes will be posted on this page with an updated effective date.</p>
 
-          <h2 className="text-2xl font-bold text-white mt-8 mb-3">Contact</h2>
-          <p>Questions? Email us at <a href="mailto:hello@salency.ai" className="text-copper hover:underline">hello@salency.ai</a>.</p>
+            <h2 id="contact" className="text-2xl font-bold text-white mt-8 mb-3 scroll-mt-32">Contact</h2>
+            <p>Questions? Email us at <a href="mailto:hello@salency.ai" className="text-copper hover:underline">hello@salency.ai</a>.</p>
+          </div>
+          <aside>
+            <LegalToc sections={SECTIONS} />
+          </aside>
         </div>
       </main>
       <SiteFooter />

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { MarketingHeader } from '@/components/MarketingHeader';
 import { SiteFooter } from '@/components/sections/SiteFooter';
+import { LegalToc, type LegalTocSection } from '@/components/LegalToc';
 
 export const metadata: Metadata = {
   title: 'Terms of Service · Salency',
@@ -10,34 +11,48 @@ export const metadata: Metadata = {
   robots: { index: true, follow: true },
 };
 
+const SECTIONS: LegalTocSection[] = [
+  { id: 'use-of-the-site', title: 'Use of the Site' },
+  { id: 'pilot-program', title: 'Pilot Program' },
+  { id: 'intellectual-property', title: 'Intellectual Property' },
+  { id: 'limitation-of-liability', title: 'Limitation of Liability' },
+  { id: 'changes', title: 'Changes' },
+  { id: 'contact', title: 'Contact' },
+];
+
 export default function Terms() {
   return (
     <div className="page">
       <MarketingHeader />
-      <main className="pt-32 pb-24 px-6 max-w-3xl mx-auto">
+      <main className="pt-32 pb-24 px-6 max-w-5xl mx-auto">
         <h1 className="text-5xl font-bold text-white mb-8">Terms of Service</h1>
-        <div className="max-w-none space-y-6 text-gray-300 text-base leading-relaxed">
-          <p><strong>Effective date:</strong> March 25, 2026</p>
+        <div className="legal-layout">
+          <div className="max-w-none space-y-6 text-gray-300 text-base leading-relaxed">
+            <p><strong>Effective date:</strong> March 25, 2026</p>
 
-          <p>These terms govern your use of salency.ai and any pilot services provided by Salency (&ldquo;we,&rdquo; &ldquo;us,&rdquo; or &ldquo;our&rdquo;).</p>
+            <p>These terms govern your use of salency.ai and any pilot services provided by Salency (&ldquo;we,&rdquo; &ldquo;us,&rdquo; or &ldquo;our&rdquo;).</p>
 
-          <h2 className="text-2xl font-bold text-white mt-8 mb-3">Use of the Site</h2>
-          <p>You may use this site to learn about Salency and submit a pilot request. You agree not to misuse the site, submit false information, or attempt to interfere with its operation.</p>
+            <h2 id="use-of-the-site" className="text-2xl font-bold text-white mt-8 mb-3 scroll-mt-32">Use of the Site</h2>
+            <p>You may use this site to learn about Salency and submit a pilot request. You agree not to misuse the site, submit false information, or attempt to interfere with its operation.</p>
 
-          <h2 className="text-2xl font-bold text-white mt-8 mb-3">Pilot Program</h2>
-          <p>Pilot access is offered at our discretion. During the pilot period, Salency is provided free of charge. We reserve the right to modify or discontinue the pilot at any time. Continued use after the pilot requires a paid subscription.</p>
+            <h2 id="pilot-program" className="text-2xl font-bold text-white mt-8 mb-3 scroll-mt-32">Pilot Program</h2>
+            <p>Pilot access is offered at our discretion. During the pilot period, Salency is provided free of charge. We reserve the right to modify or discontinue the pilot at any time. Continued use after the pilot requires a paid subscription.</p>
 
-          <h2 className="text-2xl font-bold text-white mt-8 mb-3">Intellectual Property</h2>
-          <p>All content on this site (text, design, logos, and code) is owned by Salency. You may not reproduce or distribute it without our written permission. Your data remains yours; we do not claim ownership of any transcripts or business information you provide.</p>
+            <h2 id="intellectual-property" className="text-2xl font-bold text-white mt-8 mb-3 scroll-mt-32">Intellectual Property</h2>
+            <p>All content on this site (text, design, logos, and code) is owned by Salency. You may not reproduce or distribute it without our written permission. Your data remains yours; we do not claim ownership of any transcripts or business information you provide.</p>
 
-          <h2 className="text-2xl font-bold text-white mt-8 mb-3">Limitation of Liability</h2>
-          <p>Salency is provided &ldquo;as is&rdquo; during the pilot period. We are not liable for any indirect, incidental, or consequential damages arising from your use of the service.</p>
+            <h2 id="limitation-of-liability" className="text-2xl font-bold text-white mt-8 mb-3 scroll-mt-32">Limitation of Liability</h2>
+            <p>Salency is provided &ldquo;as is&rdquo; during the pilot period. We are not liable for any indirect, incidental, or consequential damages arising from your use of the service.</p>
 
-          <h2 className="text-2xl font-bold text-white mt-8 mb-3">Changes</h2>
-          <p>We may update these terms from time to time. Continued use of the site constitutes acceptance of the revised terms.</p>
+            <h2 id="changes" className="text-2xl font-bold text-white mt-8 mb-3 scroll-mt-32">Changes</h2>
+            <p>We may update these terms from time to time. Continued use of the site constitutes acceptance of the revised terms.</p>
 
-          <h2 className="text-2xl font-bold text-white mt-8 mb-3">Contact</h2>
-          <p>Questions? Email us at <a href="mailto:hello@salency.ai" className="text-copper hover:underline">hello@salency.ai</a>.</p>
+            <h2 id="contact" className="text-2xl font-bold text-white mt-8 mb-3 scroll-mt-32">Contact</h2>
+            <p>Questions? Email us at <a href="mailto:hello@salency.ai" className="text-copper hover:underline">hello@salency.ai</a>.</p>
+          </div>
+          <aside>
+            <LegalToc sections={SECTIONS} />
+          </aside>
         </div>
       </main>
       <SiteFooter />

--- a/components/LegalToc.tsx
+++ b/components/LegalToc.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export interface LegalTocSection {
+  id: string;
+  title: string;
+}
+
+interface Props {
+  sections: LegalTocSection[];
+}
+
+export function LegalToc({ sections }: Props) {
+  const [activeId, setActiveId] = useState<string | null>(sections[0]?.id ?? null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || sections.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible[0]) setActiveId(visible[0].target.id);
+      },
+      { rootMargin: '-20% 0px -65% 0px', threshold: 0 },
+    );
+
+    sections.forEach(({ id }) => {
+      const el = document.getElementById(id);
+      if (el) observer.observe(el);
+    });
+
+    return () => observer.disconnect();
+  }, [sections]);
+
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>, id: string) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    e.preventDefault();
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    el.scrollIntoView({ behavior: reduced ? 'auto' : 'smooth', block: 'start' });
+    history.replaceState(null, '', `#${id}`);
+  };
+
+  return (
+    <nav className="legal-toc" aria-label="Section navigation">
+      <span className="legal-toc-eb">On this page</span>
+      <ol>
+        {sections.map(({ id, title }) => (
+          <li key={id} className={activeId === id ? 'is-active' : undefined}>
+            <a href={`#${id}`} onClick={(e) => handleClick(e, id)}>
+              {title}
+            </a>
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary

- **`design(home): force muted second sentence to its own line on mobile`** — at 375 viewport, the hero H1 wrapped awkwardly because `text-wrap: balance` treats the inline `<em>` and `<span class="soft">` as atomic units and orphaned the orange "revenue" at end-of-line. At `<=768` force `.h1 .soft` to `display:block` so balance can split the first sentence cleanly on its own and the muted second sentence falls onto its own block. Closes #189.
- **`design(legal): add sticky right-rail TOC at desktop`** — `/privacy` and `/terms` were flat documents with no wayfinding. Add a sticky right-rail TOC at `>=1024` that lists all H2 section titles, highlights the current section as the user scrolls (IntersectionObserver-driven), and respects `prefers-reduced-motion` when clicking anchor links. Below 1024, the TOC is hidden and the page collapses to a single column. Closes #194.

## Verification of #178
While in the area, also verifying the audit findings on `/our-story`:
- HIGH 1 (H1 hierarchy): `<h1 className="sr-only">Our story</h1>` is now in `OurStorySection.tsx:8` — visible blockquote stays editorial, document outline gets a real H1.
- HIGH 2 (founder photos): all four founders ship with photos in `/public/founders/*.png` and `FounderAvatar` always renders the `<Image>` (no more initials fallback after PR #204).
- Remaining items (founder name H2 sizing, dense paragraph block, touch targets) are out of scope for this PR — they're editorial decisions that should land in their own pass.

## Test plan
- [ ] `/` at 375/414 widths: H1 reads "Institutional memory for revenue teams." on its own balanced unit, "Not another call recorder." on its own block, orange "revenue" never orphaned end-of-line
- [ ] `/privacy` at >=1024: TOC sticks at top: 96px, current section highlighted on scroll, click-to-anchor smooth-scrolls
- [ ] `/terms` at >=1024: same TOC behavior
- [ ] `/privacy` and `/terms` at <1024: TOC hidden, content fills width
- [ ] `prefers-reduced-motion`: TOC anchor clicks jump (no smooth scroll)

🤖 Generated with [Claude Code](https://claude.com/claude-code)