### PR TITLE
design(blog): magazine layout + Resend Audiences subscribe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,12 +18,13 @@ No test suite is configured.
 `.env.local` vars:
 
 ```
-RESEND_API_KEY=...                 # required — pilot form emails
+RESEND_API_KEY=...                 # required — pilot form emails + blog subscribe
+RESEND_AUDIENCE_ID=...             # required for /api/subscribe — Resend Audiences ID
 UPSTASH_REDIS_REST_URL=...         # optional — enables per-IP rate limit (5/hour)
 UPSTASH_REDIS_REST_TOKEN=...       # required if UPSTASH_REDIS_REST_URL is set
 ```
 
-Rate limiting in `app/api/send/route.ts` is gated on `UPSTASH_REDIS_REST_URL` — if unset, the limiter is skipped entirely (fine for local dev).
+Rate limiting in `app/api/send/route.ts` and `app/api/subscribe/route.ts` is gated on `UPSTASH_REDIS_REST_URL` — if unset, the limiter is skipped entirely (fine for local dev). `/api/subscribe` returns 503 if `RESEND_AUDIENCE_ID` is unset.
 
 ## Architecture
 

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from 'next/server';
+import { Resend } from 'resend';
+import { z } from 'zod';
+import { Ratelimit } from '@upstash/ratelimit';
+import { Redis } from '@upstash/redis';
+
+const resend = new Resend(process.env.RESEND_API_KEY || 'placeholder');
+
+const ratelimit = process.env.UPSTASH_REDIS_REST_URL
+  ? new Ratelimit({
+      redis: Redis.fromEnv(),
+      limiter: Ratelimit.slidingWindow(5, '1 h'),
+      analytics: true,
+    })
+  : null;
+
+const SubscribeSchema = z.object({
+  email: z.string().email('Invalid email address').max(120),
+  address: z.string().optional(),
+});
+
+export async function POST(request: Request) {
+  try {
+    if (ratelimit) {
+      const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'anonymous';
+      const { success } = await ratelimit.limit(`subscribe:${ip}`);
+      if (!success) {
+        return NextResponse.json(
+          { error: 'Too many requests. Please try again later.' },
+          { status: 429 },
+        );
+      }
+    }
+
+    let body;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+    }
+
+    if (body.address) {
+      return NextResponse.json({ success: true, status: 'filtered' });
+    }
+
+    const result = SubscribeSchema.safeParse(body);
+    if (!result.success) {
+      return NextResponse.json(
+        { error: 'Invalid input', details: result.error.flatten() },
+        { status: 400 },
+      );
+    }
+
+    const audienceId = process.env.RESEND_AUDIENCE_ID;
+    if (!audienceId) {
+      return NextResponse.json(
+        { error: 'Subscribe is not configured. Try again soon.' },
+        { status: 503 },
+      );
+    }
+
+    const { email } = result.data;
+    const { error } = await resend.contacts.create({
+      email,
+      audienceId,
+      unsubscribed: false,
+    });
+
+    if (error) {
+      console.error('Resend contacts.create error:', error);
+      return NextResponse.json(
+        { error: 'Could not subscribe. Please try again.' },
+        { status: 502 },
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Subscribe error:', error);
+    return NextResponse.json(
+      { error: 'Could not subscribe. Please try again.' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { MarketingHeader } from '@/components/MarketingHeader';
 import { SiteFooter } from '@/components/sections/SiteFooter';
+import { SubscribeForm } from '@/components/SubscribeForm';
 import { POSTS } from '@/content/posts';
 import { FOUNDERS } from '@/lib/founders';
 
@@ -22,39 +23,60 @@ function formatDate(iso: string): string {
 }
 
 export default function BlogIndexPage() {
-  const posts = [...POSTS].sort((a, b) =>
+  const sorted = [...POSTS].sort((a, b) =>
     b.publishedAt.localeCompare(a.publishedAt),
   );
+  const featured = sorted[0];
+  const featuredAuthor = featured
+    ? FOUNDERS.find((f) => f.id === featured.authorId)
+    : undefined;
 
   return (
     <div className="page">
       <MarketingHeader />
-      <main className="blog-index">
-        <header className="blog-index-head">
-          <span className="eb">Salency build log</span>
-          <h1>Long-form thinking from the team building it.</h1>
-          <p className="blog-index-lede">
-            Institutional memory, sales call intelligence, and the layer between
-            the call recording and the rep who inherits the account.
-          </p>
-        </header>
-        <ul className="blog-index-list">
-          {posts.map((post) => {
-            const author = FOUNDERS.find((f) => f.id === post.authorId);
-            return (
-              <li key={post.slug} className="blog-index-item">
-                <Link href={`/blog/${post.slug}`} className="blog-index-link">
-                  <span className="blog-index-date">
-                    {formatDate(post.publishedAt)} · By {author?.name ?? 'Salency'}
-                  </span>
-                  <h2 className="blog-index-title">{post.title}</h2>
-                  <p className="blog-index-dek">{post.dek}</p>
-                  <span className="blog-index-cta">Read post →</span>
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
+      <main className="blog-page">
+        <span className="eb">Salency build log</span>
+        <h1 className="blog-h1">Long-form thinking from the team building it.</h1>
+        <p className="blog-sub">
+          Institutional memory, sales call intelligence, and the layer between the
+          call recording and the rep who inherits the account.
+        </p>
+
+        {featured && (
+          <Link href={`/blog/${featured.slug}`} className="blog-featured">
+            <div className="blog-featured-cover" aria-hidden="true" />
+            <div className="blog-featured-body">
+              <div className="blog-featured-meta">
+                <span className="cat">Strategy</span>
+                <span>{formatDate(featured.publishedAt)}</span>
+                <span>{featured.readMinutes ?? 5} min read</span>
+              </div>
+              <h2 className="blog-featured-title">{featured.title}</h2>
+              <p className="blog-featured-dek">{featured.dek}</p>
+              <div className="blog-featured-author">
+                <span className="avatar" aria-hidden="true" />
+                <span className="author-name">
+                  {featuredAuthor?.name ?? 'Salency'}
+                </span>
+              </div>
+            </div>
+          </Link>
+        )}
+
+        <aside className="blog-subscribe">
+          <div className="blog-subscribe-copy">
+            <span className="sub-eb">Notes from building Salency</span>
+            <h3>
+              Customer interviews, product calls, <em>pilot results.</em>
+            </h3>
+            <p>
+              Notes from building Salency. Customer interviews, product calls,
+              pilot results. One essay a month, sometimes two. No newsletter
+              cruft.
+            </p>
+          </div>
+          <SubscribeForm />
+        </aside>
       </main>
       <SiteFooter />
     </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -2188,45 +2188,144 @@ header button:focus:not(:focus-visible){
 }
 .coming-soon-meta{margin-top:32px}
 
-/* ═══════════ Blog index ═══════════ */
-.blog-index{
-  max-width:var(--page-max);margin:80px auto 0;padding:20px 40px 96px;
+/* ═══════════ Blog index — magazine layout ═══════════
+   Single featured-post split with a subscribe block beneath.
+   Designed to read editorially on a single post (current state) and
+   gracefully welcome a grid of more posts when we have them. */
+.blog-page{
+  max-width:var(--page-max);margin:0 auto;
+  padding:80px 40px 120px;
 }
-.blog-index-head{max-width:780px;margin-bottom:64px}
-.blog-index-head .eb{margin-bottom:24px}
-.blog-index-head h1{
-  font-family:var(--font-display), 'Instrument Sans', system-ui, sans-serif;
-  font-weight:500;font-size:clamp(36px,4.8vw,60px);
-  line-height:1.1;letter-spacing:-.025em;
-  margin:0;color:var(--ink);text-wrap:balance;
+.blog-page > .eb{margin-bottom:16px}
+.blog-h1{
+  font-family:var(--font-display), 'Instrument Serif', serif;
+  font-weight:500;font-size:clamp(40px,5vw,60px);
+  line-height:1.05;letter-spacing:-.02em;
+  margin:0 0 16px;color:var(--ink);
+  max-width:22ch;text-wrap:balance;
 }
-.blog-index-lede{
-  margin:24px 0 0;max-width:58ch;
-  font-size:18px;line-height:1.55;color:var(--ink-2);
+.blog-sub{
+  font-size:17px;line-height:1.55;color:var(--ink-2);
+  margin:0 0 64px;font-weight:300;max-width:56ch;
 }
-.blog-index-list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:1px;background:var(--hair);border-top:1px solid var(--hair);border-bottom:1px solid var(--hair)}
-.blog-index-item{background:var(--background)}
-.blog-index-link{
-  display:block;padding:32px 0;text-decoration:none;color:inherit;
-  transition:padding 0.2s ease;
+
+.blog-featured{
+  display:grid;
+  grid-template-columns:1.1fr 1fr;
+  gap:56px;
+  align-items:center;
+  border-top:1px solid var(--hair-2);
+  padding-top:56px;
+  text-decoration:none;color:inherit;
+  transition:opacity .2s;
 }
-.blog-index-link:hover{padding-left:8px}
-.blog-index-date{
-  font-family:'Geist Mono','SFMono-Regular',Consolas,monospace;
-  font-size:11px;font-weight:500;letter-spacing:.18em;text-transform:uppercase;
-  color:var(--copper);display:block;margin-bottom:12px;
+.blog-featured:hover{opacity:.85}
+.blog-featured-cover{
+  aspect-ratio:4 / 3;
+  background:
+    radial-gradient(ellipse at 30% 30%, var(--copper-a22) 0%, transparent 60%),
+    radial-gradient(ellipse at 70% 70%, rgba(107,78,255,.10) 0%, transparent 50%),
+    linear-gradient(135deg, var(--copper-a18), var(--copper-a08));
+  border:1px solid var(--hair-2);
+  border-radius:12px;
 }
-.blog-index-title{
-  font-family:var(--font-display), 'Instrument Sans', system-ui, sans-serif;
-  font-weight:500;font-size:clamp(22px,2.4vw,30px);line-height:1.2;
-  letter-spacing:-.02em;color:var(--ink);margin:0 0 12px;text-wrap:balance;
+.blog-featured-meta{
+  display:flex;gap:16px;align-items:baseline;
+  font-family:'Geist Mono', SFMono-Regular, Consolas, monospace;
+  font-size:11px;color:var(--ink-3);
+  letter-spacing:.12em;text-transform:uppercase;
+  margin-bottom:14px;
 }
-.blog-index-dek{
-  font-size:17px;line-height:1.55;color:var(--ink-2);margin:0 0 14px;max-width:62ch;
+.blog-featured-meta .cat{color:var(--copper)}
+.blog-featured-title{
+  font-family:var(--font-display), 'Instrument Serif', serif;
+  font-size:clamp(28px,3vw,38px);
+  font-weight:500;line-height:1.1;
+  letter-spacing:-.015em;color:var(--ink);
+  margin:0 0 14px;text-wrap:balance;
 }
-.blog-index-cta{
-  font-size:14px;font-weight:500;color:var(--copper);
-  display:inline-block;
+.blog-featured-dek{
+  font-size:17px;line-height:1.55;color:var(--ink-2);
+  margin:0 0 24px;font-weight:300;
+}
+.blog-featured-author{
+  display:flex;align-items:center;gap:12px;
+}
+.blog-featured-author .avatar{
+  width:32px;height:32px;border-radius:999px;
+  background:linear-gradient(135deg, var(--copper-a30), rgba(209,60,19,.6));
+  border:1px solid var(--hair-2);
+}
+.blog-featured-author .author-name{
+  font-size:14px;color:var(--ink-2);font-weight:500;
+}
+
+.blog-subscribe{
+  margin-top:96px;
+  padding:40px 48px;
+  background:var(--bg-2);
+  border:1px solid var(--hair);
+  border-radius:14px;
+  display:grid;
+  grid-template-columns:1fr auto;
+  gap:32px;align-items:center;
+}
+.blog-subscribe-copy .sub-eb{
+  font-family:'Geist Mono', SFMono-Regular, Consolas, monospace;
+  font-size:11px;letter-spacing:.18em;text-transform:uppercase;
+  color:var(--copper);margin-bottom:8px;display:block;
+}
+.blog-subscribe-copy h3{
+  font-family:var(--font-display), 'Instrument Serif', serif;
+  font-size:24px;font-weight:500;line-height:1.25;
+  color:var(--ink);margin:0 0 6px;
+}
+.blog-subscribe-copy h3 em{font-style:italic;color:var(--copper)}
+.blog-subscribe-copy p{
+  font-size:14px;color:var(--ink-2);margin:0;
+  max-width:50ch;line-height:1.55;
+}
+
+.subscribe-form{
+  display:flex;gap:8px;align-items:center;
+  background:rgba(0,0,0,.2);
+  border:1px solid var(--hair-2);
+  border-radius:8px;
+  padding:4px 4px 4px 16px;
+  min-width:360px;
+  position:relative;
+}
+.subscribe-form input{
+  background:transparent;border:none;color:var(--ink);
+  font-size:14px;font-family:inherit;outline:none;
+  flex:1;padding:10px 0;
+}
+.subscribe-form input::placeholder{color:var(--ink-3)}
+.subscribe-form button{
+  background:var(--copper);color:#1A0A02;
+  border:none;border-radius:6px;
+  padding:10px 18px;font-weight:500;font-size:13px;
+  font-family:inherit;cursor:pointer;
+  display:inline-flex;align-items:center;gap:6px;
+  transition:filter .18s ease;
+}
+.subscribe-form button:hover{filter:brightness(1.1)}
+.subscribe-form button:disabled{opacity:.6;cursor:not-allowed}
+.subscribe-error{
+  position:absolute;top:calc(100% + 8px);left:0;
+  font-size:12px;color:#F87171;
+}
+.subscribe-success{
+  font-size:14px;color:var(--copper);margin:0;
+  font-family:'Geist Mono', SFMono-Regular, Consolas, monospace;
+  letter-spacing:.04em;
+}
+
+@media (max-width: 800px){
+  .blog-featured{grid-template-columns:1fr;gap:32px}
+  .blog-featured-title{font-size:clamp(24px,5vw,32px)}
+  .blog-subscribe{grid-template-columns:1fr;padding:28px 24px}
+  .subscribe-form{min-width:0;width:100%}
 }
 
 /* ═══════════ Blog post (article body) ═══════════ */

--- a/components/SubscribeForm.tsx
+++ b/components/SubscribeForm.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { track } from '@vercel/analytics';
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function SubscribeForm() {
+  const [email, setEmail] = useState('');
+  const [address, setAddress] = useState('');
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (status === 'loading') return;
+
+    if (!EMAIL_REGEX.test(email)) {
+      setStatus('error');
+      setErrorMsg('Enter a valid email address.');
+      return;
+    }
+
+    if (address) {
+      setStatus('success');
+      return;
+    }
+
+    setStatus('loading');
+    setErrorMsg(null);
+    try {
+      const res = await fetch('/api/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, address }),
+      });
+
+      if (res.status === 429) {
+        setStatus('error');
+        setErrorMsg('Too many requests. Try again in a few minutes.');
+        return;
+      }
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        setStatus('error');
+        setErrorMsg(data?.error ?? 'Could not subscribe. Please try again.');
+        return;
+      }
+
+      setStatus('success');
+      track('blog_subscribe_complete');
+    } catch {
+      setStatus('error');
+      setErrorMsg('Network error. Check your connection and try again.');
+    }
+  }
+
+  if (status === 'success') {
+    return (
+      <p className="subscribe-success">
+        You&rsquo;re on the list. Watch your inbox.
+      </p>
+    );
+  }
+
+  return (
+    <form className="subscribe-form" onSubmit={handleSubmit} noValidate>
+      <div className="hidden" aria-hidden="true" style={{ position: 'absolute', left: '-9999px' }}>
+        <label>
+          Address
+          <input
+            type="text"
+            tabIndex={-1}
+            autoComplete="off"
+            value={address}
+            onChange={(e) => setAddress(e.target.value)}
+          />
+        </label>
+      </div>
+      <label htmlFor="subscribe-email" className="sr-only">
+        Email address
+      </label>
+      <input
+        id="subscribe-email"
+        type="email"
+        autoComplete="email"
+        required
+        value={email}
+        onChange={(e) => {
+          setEmail(e.target.value);
+          if (status === 'error') {
+            setStatus('idle');
+            setErrorMsg(null);
+          }
+        }}
+        placeholder="you@company.com"
+        aria-invalid={status === 'error' ? 'true' : undefined}
+        aria-describedby={errorMsg ? 'subscribe-error' : undefined}
+      />
+      <button type="submit" disabled={status === 'loading'}>
+        {status === 'loading' ? (
+          <Loader2 className="animate-spin w-4 h-4" />
+        ) : (
+          <>Notify me &rarr;</>
+        )}
+      </button>
+      {errorMsg && (
+        <span id="subscribe-error" className="subscribe-error" role="alert">
+          {errorMsg}
+        </span>
+      )}
+    </form>
+  );
+}

--- a/content/posts/types.ts
+++ b/content/posts/types.ts
@@ -7,5 +7,6 @@ export interface Post {
   description: string;
   authorId: string;
   publishedAt: string;
+  readMinutes?: number;
   body: ReactNode;
 }


### PR DESCRIPTION
## Summary

Replace the flat post-list on `/blog` with a magazine layout — single featured-post split (cover + meta + dek + author row) plus a subscribe block beneath. Reads editorially with one post and welcomes more posts when we ship them.

Subscribe form is wired to a new `/api/subscribe` route that writes to a Resend Audience via the SDK's `contacts.create`.

## Subscribe flow
1. Form posts `{ email, address }` to `/api/subscribe` (`address` = honeypot)
2. Optional Upstash rate limit (5/hour per IP, namespaced as `subscribe:`) — gated on `UPSTASH_REDIS_REST_URL`
3. Honeypot short-circuit returns success without writing
4. Zod-validated email, 503 if `RESEND_AUDIENCE_ID` is unset so a misconfig is visible
5. Calls `resend.contacts.create({ email, audienceId, unsubscribed: false })`

## Copy update
Old: "Long-form thinking from the team building it." (kept as the H1)
New subscribe block: **"Notes from building Salency · Customer interviews, product calls, *pilot results.*"**

## Env additions
```
RESEND_AUDIENCE_ID=...   # required for /api/subscribe
```
Documented in CLAUDE.md.

## Test plan
- [ ] `/blog`: featured-post card layout reads editorially, hover dims to .85
- [ ] `/blog` <800 width: split collapses to single column, cover stacks on top
- [ ] Subscribe form: bad email shows inline error, valid email + missing `RESEND_AUDIENCE_ID` returns 503 with copy
- [ ] Subscribe form success state replaces the form with "You're on the list."
- [ ] Honeypot: filled `address` field returns success without API call (verify in network tab)

## Setup before shipping
Create a Resend Audience at https://resend.com/audiences and add `RESEND_AUDIENCE_ID` to Vercel env (Production + Preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)