### PR TITLE
design(blog): full magazine-grade post shell

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -4,6 +4,9 @@ import { notFound } from 'next/navigation';
 import { MarketingHeader } from '@/components/MarketingHeader';
 import { SiteFooter } from '@/components/sections/SiteFooter';
 import { JsonLd } from '@/components/JsonLd';
+import { FounderAvatar } from '@/components/FounderAvatar';
+import { PostToc } from '@/components/PostToc';
+import { ShareButtons } from '@/components/ShareButtons';
 import { FOUNDERS } from '@/lib/founders';
 import { getAllPostSlugs, getPostBySlug } from '@/content/posts';
 
@@ -61,6 +64,7 @@ export default async function BlogPostPage({
 
   const author = FOUNDERS.find((f) => f.id === post.authorId);
   const authorName = author?.name ?? 'Salency';
+  const postUrl = `https://www.salency.ai/blog/${post.slug}`;
 
   const articleSchema = {
     '@context': 'https://schema.org',
@@ -81,35 +85,78 @@ export default async function BlogPostPage({
         url: 'https://www.salency.ai/salency-mark.svg',
       },
     },
-    mainEntityOfPage: `https://www.salency.ai/blog/${post.slug}`,
+    mainEntityOfPage: postUrl,
   };
 
   return (
     <div className="page">
       <JsonLd data={articleSchema} />
       <MarketingHeader />
-      <main className="post-page">
-        <article className="post-article">
-          <div className="post-meta-top">
-            <Link href="/blog" className="post-back">
-              ← Build log
-            </Link>
-            <span className="post-date">
-              {formatDate(post.publishedAt)} · By {authorName}
-            </span>
+
+      <header className="post-hero">
+        <div className="post-hero-inner">
+          <div className="post-breadcrumb">
+            <Link href="/blog">← Salency build log</Link>
           </div>
-          <h1>{post.title}</h1>
+          <div className="post-meta-row">
+            {post.category && <span className="cat">{post.category}</span>}
+            {post.category && <span className="sep">·</span>}
+            <span>{formatDate(post.publishedAt)}</span>
+            <span className="sep">·</span>
+            <span>{post.readMinutes ?? 5} min read</span>
+          </div>
+          <h1 className="post-title">{post.title}</h1>
           <p className="post-dek">{post.dek}</p>
+        </div>
+      </header>
+
+      <main className="post-layout">
+        <article className="post-article">
           <div className="post-body">{post.body}</div>
-          <div className="post-footer">
-            <p>
-              Salency is institutional memory for B2B sales teams.{' '}
-              <Link href="/why-salency">Read why Salency</Link>, or{' '}
-              <Link href="/pilot">join the Spring 2026 pilot cohort</Link>.
-            </p>
-          </div>
+          <ShareButtons url={postUrl} title={post.title} />
         </article>
+
+        {post.headings && post.headings.length > 0 && (
+          <aside className="post-toc-rail">
+            <PostToc sections={post.headings} />
+          </aside>
+        )}
       </main>
+
+      {author && (
+        <aside className="post-author-card">
+          <div className="post-author-inner">
+            <FounderAvatar founder={author} size={96} />
+            <div className="post-author-meta">
+              <span className="eb">— Author</span>
+              <h3>{author.name}</h3>
+              <span className="role">{author.role}, Salency</span>
+              <p>{author.longBio}</p>
+              <div className="post-author-links">
+                {author.linkedin && (
+                  <a
+                    href={author.linkedin}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    LinkedIn ↗
+                  </a>
+                )}
+                <a href="mailto:hello@salency.ai">Reach out →</a>
+              </div>
+            </div>
+          </div>
+        </aside>
+      )}
+
+      <div className="post-page-footer">
+        <p>
+          Salency is institutional memory for B2B sales teams.{' '}
+          <Link href="/why-salency">Read why Salency</Link>, or{' '}
+          <Link href="/pilot">join the Spring 2026 pilot cohort</Link>.
+        </p>
+      </div>
+
       <SiteFooter />
     </div>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -2328,67 +2328,249 @@ header button:focus:not(:focus-visible){
   .subscribe-form{min-width:0;width:100%}
 }
 
-/* ═══════════ Blog post (article body) ═══════════ */
-.post-page{max-width:780px;margin:0 auto;padding:80px 32px 96px}
-.post-meta-top{
-  display:flex;justify-content:space-between;align-items:center;
-  margin-bottom:48px;gap:24px;flex-wrap:wrap;
-  font-family:'Geist Mono','SFMono-Regular',Consolas,monospace;
-  font-size:11px;font-weight:500;letter-spacing:.12em;text-transform:uppercase;
+/* ═══════════ Blog post — magazine-grade shell ═══════════
+   Hero (full-bleed pull-quote treatment) → 2-col body with sticky
+   right-rail TOC at >=1024 → share buttons → author card → footer. */
+.post-hero{
+  position:relative;
+  padding:96px 40px 72px;
+  border-bottom:1px solid var(--hair-2);
+  background:
+    radial-gradient(ellipse at 30% 30%, var(--copper-a08) 0%, transparent 50%),
+    radial-gradient(ellipse at 80% 70%, rgba(107,78,255,.06) 0%, transparent 60%),
+    var(--bg);
+  overflow:hidden;
 }
-.post-back{color:var(--copper);text-decoration:none}
-.post-back:hover{text-decoration:underline}
-.post-date{color:var(--ink-3)}
-
-.post-article h1{
-  font-family:var(--font-display), 'Instrument Sans', system-ui, sans-serif;
-  font-weight:500;font-size:clamp(34px,4.4vw,52px);line-height:1.08;
-  letter-spacing:-.025em;color:var(--ink);margin:0 0 20px;text-wrap:balance;
+.post-hero::before{
+  content:"";position:absolute;left:50%;top:0;bottom:0;
+  width:1px;
+  background:linear-gradient(180deg, transparent, var(--copper-a30) 30%, var(--copper-a18) 70%, transparent);
+  transform:translateX(-50%);opacity:.5;
+}
+.post-hero-inner{
+  max-width:880px;margin:0 auto;position:relative;
+}
+.post-breadcrumb{
+  font-family:'Geist Mono', SFMono-Regular, Consolas, monospace;
+  font-size:11px;letter-spacing:.12em;
+  text-transform:uppercase;color:var(--ink-3);
+  margin-bottom:36px;
+}
+.post-breadcrumb a{color:var(--copper);text-decoration:none}
+.post-breadcrumb a:hover{color:var(--ink)}
+.post-meta-row{
+  display:flex;gap:14px;align-items:baseline;flex-wrap:wrap;
+  font-family:'Geist Mono', SFMono-Regular, Consolas, monospace;
+  font-size:11px;color:var(--ink-3);
+  letter-spacing:.14em;text-transform:uppercase;
+  margin-bottom:22px;
+}
+.post-meta-row .cat{color:var(--copper)}
+.post-meta-row .sep{color:var(--ink-3);opacity:.5}
+.post-title{
+  font-family:var(--font-display), 'Instrument Serif', serif;
+  font-size:clamp(38px, 4.6vw, 60px);
+  font-weight:500;line-height:1.1;
+  letter-spacing:-.02em;
+  margin:0 0 24px;color:var(--ink);
+  max-width:22ch;text-wrap:balance;
 }
 .post-dek{
-  font-size:20px;line-height:1.5;color:var(--ink-3);
-  margin:0 0 56px;font-weight:400;text-wrap:pretty;
+  font-family:var(--font-display), 'Instrument Serif', serif;
+  font-style:italic;font-size:22px;line-height:1.5;
+  color:var(--ink-2);margin:0;max-width:56ch;
 }
-.post-body{font-size:18px;line-height:1.65;color:var(--ink-2)}
-.post-body h2{
-  font-family:var(--font-display), 'Instrument Sans', system-ui, sans-serif;
-  font-weight:500;font-size:clamp(24px,2.6vw,32px);line-height:1.2;
-  letter-spacing:-.015em;color:var(--ink);margin:56px 0 20px;
+.post-dek em{color:var(--copper)}
+
+.post-layout{
+  max-width:1080px;margin:0 auto;
+  padding:56px 40px 72px;
+  display:block;
+}
+.post-article{max-width:720px;margin:0 auto}
+.post-body{
+  font-size:18px;line-height:1.7;color:var(--ink);font-weight:300;
 }
 .post-body p{margin:0 0 22px}
-.post-body p strong{color:var(--ink);font-weight:600}
+.post-body p strong{font-weight:500;color:var(--ink)}
 .post-body p em{color:var(--copper);font-style:italic}
-.post-body a{color:var(--copper);text-decoration:none;border-bottom:1px solid rgba(232,146,90,0.4)}
+.post-body a{
+  color:var(--copper);text-decoration:none;
+  border-bottom:1px solid var(--copper-a30);
+  transition:border-color .18s ease;
+}
 .post-body a:hover{border-bottom-color:var(--copper)}
+.post-body h2{
+  font-family:var(--font-display), 'Instrument Sans', system-ui, sans-serif;
+  font-size:28px;font-weight:500;line-height:1.25;
+  letter-spacing:-.015em;color:var(--ink);
+  margin:56px 0 18px;text-wrap:balance;
+  scroll-margin-top:96px;
+}
 .post-body ul{margin:0 0 22px;padding-left:20px}
 .post-body ul li{margin-bottom:8px}
 .post-body blockquote{
   margin:28px 0;padding:6px 0 6px 22px;
   border-left:2px solid var(--copper);
+  font-family:var(--font-display), 'Instrument Serif', serif;
   font-size:21px;color:var(--ink);font-style:italic;line-height:1.45;
 }
 .post-body table{
   width:100%;border-collapse:collapse;margin:28px 0;font-size:16px;
 }
-.post-body table th,.post-body table td{
+.post-body table th, .post-body table td{
   text-align:left;padding:14px 16px;border-bottom:1px solid var(--hair);
 }
 .post-body table th{
   color:var(--copper);
-  font-family:'Geist Mono','SFMono-Regular',Consolas,monospace;
+  font-family:'Geist Mono', SFMono-Regular, Consolas, monospace;
   font-size:11px;letter-spacing:.12em;text-transform:uppercase;font-weight:500;
 }
 .post-body table td{color:var(--ink-2)}
 .post-pullquote{
   margin:32px 0;padding:24px 0;
   border-top:1px solid var(--hair);border-bottom:1px solid var(--hair);
+  font-family:var(--font-display), 'Instrument Serif', serif;
   font-size:22px;line-height:1.4;color:var(--ink);font-weight:500;
 }
-.post-footer{
-  margin-top:64px;padding-top:32px;border-top:1px solid var(--hair);
-  font-size:16px;color:var(--ink-3);
+
+/* Share buttons — sit beneath the body, before the author card. */
+.post-share{
+  margin:48px 0 0;
+  padding:24px 0 0;
+  border-top:1px solid var(--hair-2);
+  display:flex;gap:14px;align-items:center;flex-wrap:wrap;
 }
-.post-footer a{color:var(--copper);text-decoration:none;border-bottom:1px solid rgba(232,146,90,0.4)}
+.post-share-label{
+  font-family:'Geist Mono', SFMono-Regular, Consolas, monospace;
+  font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;
+  color:var(--ink-3);margin-right:4px;
+}
+.post-share-btn{
+  background:transparent;border:0;cursor:pointer;
+  font-family:'Geist Mono', SFMono-Regular, Consolas, monospace;
+  font-size:12px;letter-spacing:.08em;
+  color:var(--copper);text-decoration:none;
+  border-bottom:1px solid var(--copper-a30);
+  padding:0 0 2px;
+  transition:color .18s, border-color .18s;
+}
+.post-share-btn:hover{color:var(--ink);border-bottom-color:var(--ink)}
+
+/* Sticky right-rail TOC at >=1024. Below that, hidden — keeps the
+   reading column un-distracted on mobile/tablet. */
+.post-toc-rail{display:none}
+@media (min-width: 1024px){
+  .post-layout{
+    display:grid;
+    grid-template-columns:minmax(0,1fr) 220px;
+    gap:64px;
+    align-items:start;
+    max-width:1080px;
+  }
+  .post-article{max-width:none;margin:0}
+  .post-toc-rail{display:block}
+  .post-toc{
+    position:sticky;top:96px;
+    font-family:'Geist Mono', SFMono-Regular, Consolas, monospace;
+    font-size:12px;line-height:1.5;
+  }
+  .post-toc-eb{
+    display:block;
+    font-size:10.5px;font-weight:500;letter-spacing:.18em;
+    text-transform:uppercase;color:var(--copper);
+    margin-bottom:14px;
+  }
+  .post-toc ol{
+    list-style:none;margin:0;padding:0;
+    border-left:1px solid var(--hair-2);
+  }
+  .post-toc li{margin:0;padding:0}
+  .post-toc a{
+    display:block;padding:6px 14px;
+    color:var(--ink-3);text-decoration:none;
+    border-left:1px solid transparent;margin-left:-1px;
+    transition:color .18s ease, border-color .18s ease;
+  }
+  .post-toc a:hover{color:var(--ink-2)}
+  .post-toc li.is-active a{
+    color:var(--copper);border-left-color:var(--copper);
+  }
+}
+
+/* Author footer card — photo + bio + LinkedIn/email. */
+.post-author-card{
+  max-width:720px;margin:0 auto 72px;padding:0 40px;
+}
+.post-author-inner{
+  display:grid;grid-template-columns:96px 1fr;gap:28px;align-items:start;
+  padding:32px;background:var(--bg-2);
+  border:1px solid var(--hair-2);border-radius:14px;
+  position:relative;
+}
+.post-author-inner::before{
+  content:"";position:absolute;
+  top:0;left:32px;right:32px;height:1px;
+  background:linear-gradient(90deg, var(--copper) 0%, var(--copper-a08) 30%, transparent 100%);
+}
+.post-author-card .photo{
+  width:96px;height:96px;border-radius:12px;
+  border:1px solid var(--hair-2);overflow:hidden;
+}
+.post-author-card .photo img{width:100%;height:100%;object-fit:cover;display:block}
+.post-author-meta .eb{
+  font-family:'Geist Mono', SFMono-Regular, Consolas, monospace;
+  font-size:10.5px;letter-spacing:.2em;text-transform:uppercase;
+  color:var(--copper);display:block;margin-bottom:8px;
+}
+.post-author-meta h3{
+  font-family:var(--font-display), 'Instrument Serif', serif;
+  font-size:22px;font-weight:500;color:var(--ink);
+  margin:0 0 4px;line-height:1.2;
+}
+.post-author-meta .role{
+  font-family:'Geist Mono', SFMono-Regular, Consolas, monospace;
+  font-size:11px;letter-spacing:.16em;text-transform:uppercase;
+  color:var(--ink-3);margin-bottom:14px;display:block;
+}
+.post-author-meta p{
+  font-size:14.5px;line-height:1.6;color:var(--ink-2);
+  margin:0 0 16px;font-weight:300;
+}
+.post-author-meta p em{color:var(--copper);font-style:italic}
+.post-author-links{display:flex;gap:16px;align-items:center;flex-wrap:wrap}
+.post-author-links a{
+  font-family:'Geist Mono', SFMono-Regular, Consolas, monospace;
+  font-size:12px;letter-spacing:.08em;
+  color:var(--copper);text-decoration:none;
+  border-bottom:1px solid var(--copper-a30);
+  padding-bottom:2px;
+  transition:border-color .18s, color .18s;
+}
+.post-author-links a:hover{color:var(--ink);border-bottom-color:var(--ink)}
+
+.post-page-footer{
+  max-width:720px;margin:0 auto 96px;padding:32px 40px 0;
+  border-top:1px solid var(--hair);
+  font-size:15px;color:var(--ink-3);
+}
+.post-page-footer a{
+  color:var(--copper);text-decoration:none;
+  border-bottom:1px solid var(--copper-a30);
+}
+.post-page-footer a:hover{border-bottom-color:var(--copper)}
+
+@media (max-width: 700px){
+  .post-hero{padding:64px 24px 48px}
+  .post-layout{padding:40px 24px 56px}
+  .post-body{font-size:17px}
+  .post-author-card{padding:0 24px}
+  .post-author-inner{grid-template-columns:72px 1fr;gap:20px;padding:24px}
+  .post-author-card .photo{width:72px;height:72px}
+  .post-title{font-size:clamp(30px,7vw,44px)}
+  .post-dek{font-size:18px}
+  .post-page-footer{padding:32px 24px 0}
+}
 
 /* ═══════════ A11y utilities ═══════════ */
 .sr-only{

--- a/components/PostToc.tsx
+++ b/components/PostToc.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export interface PostTocSection {
+  id: string;
+  title: string;
+}
+
+interface Props {
+  sections: PostTocSection[];
+}
+
+export function PostToc({ sections }: Props) {
+  const [activeId, setActiveId] = useState<string | null>(sections[0]?.id ?? null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || sections.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible[0]) setActiveId(visible[0].target.id);
+      },
+      { rootMargin: '-20% 0px -65% 0px', threshold: 0 },
+    );
+
+    sections.forEach(({ id }) => {
+      const el = document.getElementById(id);
+      if (el) observer.observe(el);
+    });
+
+    return () => observer.disconnect();
+  }, [sections]);
+
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>, id: string) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    e.preventDefault();
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    el.scrollIntoView({ behavior: reduced ? 'auto' : 'smooth', block: 'start' });
+    history.replaceState(null, '', `#${id}`);
+  };
+
+  return (
+    <nav className="post-toc" aria-label="On this page">
+      <span className="post-toc-eb">On this page</span>
+      <ol>
+        {sections.map(({ id, title }) => (
+          <li key={id} className={activeId === id ? 'is-active' : undefined}>
+            <a href={`#${id}`} onClick={(e) => handleClick(e, id)}>
+              {title}
+            </a>
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}

--- a/components/ShareButtons.tsx
+++ b/components/ShareButtons.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState } from 'react';
+
+interface Props {
+  url: string;
+  title: string;
+}
+
+export function ShareButtons({ url, title }: Props) {
+  const [copied, setCopied] = useState(false);
+
+  const encodedUrl = encodeURIComponent(url);
+  const encodedTitle = encodeURIComponent(title);
+  const twitterHref = `https://twitter.com/intent/tweet?text=${encodedTitle}&url=${encodedUrl}`;
+  const linkedinHref = `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`;
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  return (
+    <div className="post-share" aria-label="Share">
+      <span className="post-share-label">Share</span>
+      <a
+        className="post-share-btn"
+        href={twitterHref}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Twitter ↗
+      </a>
+      <a
+        className="post-share-btn"
+        href={linkedinHref}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        LinkedIn ↗
+      </a>
+      <button
+        type="button"
+        className="post-share-btn"
+        onClick={handleCopy}
+        aria-live="polite"
+      >
+        {copied ? 'Copied' : 'Copy link'}
+      </button>
+    </div>
+  );
+}

--- a/content/posts/institutional-memory-ai-bottleneck.tsx
+++ b/content/posts/institutional-memory-ai-bottleneck.tsx
@@ -9,6 +9,17 @@ export const post: Post = {
     'The augment-vs-replace debate is brain-rot. The right question for revenue leaders is which knowledge layer AI is uniquely suited to own. The answer is institutional memory.',
   authorId: 'howard',
   publishedAt: '2026-04-26',
+  readMinutes: 5,
+  category: 'Strategy',
+  headings: [
+    { id: 'the-wrong-question', title: 'The wrong question' },
+    { id: 'what-humans-do', title: "What humans do that AI can't" },
+    { id: 'what-ai-does', title: "What AI does that humans can't" },
+    { id: 'the-right-model', title: 'The right model' },
+    { id: 'what-changes', title: 'What changes when AI owns the memory layer' },
+    { id: 'what-were-building', title: "This is what we're building" },
+    { id: 'the-actual-reframe', title: 'The actual reframe' },
+  ],
   body: (
     <>
       <p>Your top AE quit Friday.</p>
@@ -35,7 +46,7 @@ export const post: Post = {
 
       <p>This is also what every &ldquo;AI in sales&rdquo; think piece is missing.</p>
 
-      <h2>The wrong question</h2>
+      <h2 id="the-wrong-question">The wrong question</h2>
 
       <p>The augment-vs-replace debate is brain-rot.</p>
 
@@ -59,7 +70,7 @@ export const post: Post = {
         &ldquo;AI sales tools&rdquo; are doing.
       </p>
 
-      <h2>What humans do that AI can&rsquo;t</h2>
+      <h2 id="what-humans-do">What humans do that AI can&rsquo;t</h2>
 
       <ul>
         <li>Read the room.</li>
@@ -79,7 +90,7 @@ export const post: Post = {
 
       <p>Stop trying to replace this layer.</p>
 
-      <h2>What AI does that humans can&rsquo;t</h2>
+      <h2 id="what-ai-does">What AI does that humans can&rsquo;t</h2>
 
       <p>Remember.</p>
 
@@ -112,7 +123,7 @@ export const post: Post = {
 
       <p>That&rsquo;s not memory. That&rsquo;s a graveyard with full-text search.</p>
 
-      <h2>The right model</h2>
+      <h2 id="the-right-model">The right model</h2>
 
       <table>
         <thead>
@@ -151,7 +162,7 @@ export const post: Post = {
         4:55pm on a Friday.
       </p>
 
-      <h2>What changes when AI owns the memory layer</h2>
+      <h2 id="what-changes">What changes when AI owns the memory layer</h2>
 
       <p>
         The new AE doesn&rsquo;t read recordings. They inherit a Day-1 brief:
@@ -185,7 +196,7 @@ export const post: Post = {
         &ldquo;the new person reads notes and hopes.&rdquo;
       </p>
 
-      <h2>This is what we&rsquo;re building</h2>
+      <h2 id="what-were-building">This is what we&rsquo;re building</h2>
 
       <p>
         Salency is institutional memory for B2B sales. We turn every call into
@@ -201,7 +212,7 @@ export const post: Post = {
         <a href="/pilot">we&rsquo;d love to talk</a>.
       </p>
 
-      <h2>The actual reframe</h2>
+      <h2 id="the-actual-reframe">The actual reframe</h2>
 
       <p>AI doesn&rsquo;t replace humans in sales.</p>
 

--- a/content/posts/types.ts
+++ b/content/posts/types.ts
@@ -1,5 +1,10 @@
 import type { ReactNode } from 'react';
 
+export interface PostHeading {
+  id: string;
+  title: string;
+}
+
 export interface Post {
   slug: string;
   title: string;
@@ -8,5 +13,7 @@ export interface Post {
   authorId: string;
   publishedAt: string;
   readMinutes?: number;
+  category?: string;
+  headings?: PostHeading[];
   body: ReactNode;
 }


### PR DESCRIPTION
## Summary

Replace the flat blog post body with the full A-shell from the retroactive grill: hero treatment, sticky right-rail TOC, share buttons, and an author footer card. Drops the related-grid placeholders intentionally — we ship one post for now and the layout welcomes more without scaffolding.

## What lands

**Hero (`.post-hero`)**
- Full-bleed copper/violet radial gradient + vertical hairline accent
- Breadcrumb (← Salency build log)
- Mono-caps meta row (category · date · read time)
- Big Instrument Serif title at clamp(38px, 4.6vw, 60px)
- Italic Instrument Serif dek

**Body**
- Serif H2s with `scroll-margin-top: 96px` so anchor jumps don't disappear under the header
- Copper italic accents preserved
- Blockquote rendered in serif italic

**Sticky right-rail TOC at >=1024 (`.post-toc-rail`)**
- IntersectionObserver-driven active-section highlight (matches `LegalToc` pattern)
- `prefers-reduced-motion` respected on anchor click
- Hidden below 1024 to keep the reading column focused

**Share buttons (`.post-share`)**
- Twitter/X intent, LinkedIn intent, Copy link
- Clipboard API with 1.8s "Copied" feedback state

**Author card (`.post-author-card`)**
- Photo (96×96 / 72×72 mobile), name, role, `longBio` from FOUNDERS
- LinkedIn + mailto links
- Top-edge copper gradient hairline matches the hub-card visual register

## Type updates
Adds optional fields to `Post`:
- `readMinutes` (already used by /blog featured card)
- `category` (e.g. "Strategy")
- `headings: PostHeading[]` for the TOC

Adds `id="..."` attributes to each H2 in the existing institutional-memory post so the TOC anchor links land correctly.

## Test plan
- [ ] `/blog/institutional-memory-ai-bottleneck` at >=1024: TOC sticks at top:96px, current section highlighted on scroll, click smooth-scrolls to H2
- [ ] Mobile <700: hero padding compresses, author card stacks 72px photo
- [ ] Share buttons: Twitter/LinkedIn open intent in new tab, Copy link writes to clipboard and shows "Copied" for 1.8s
- [ ] `prefers-reduced-motion`: TOC anchor click jumps (no smooth scroll)
- [ ] Author card photo loads (Howard's `/founders/howard.png`)
- [ ] Body renders italic+copper accents, blockquote in serif italic with copper border-left

🤖 Generated with [Claude Code](https://claude.com/claude-code)