### PR TITLE
design(home): promote a product artifact into the hero (#188)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -815,10 +815,22 @@ html {
     position:relative;z-index:1;
   }
 
-  /* ═══════════ Hero ═══════════ */
+  /* ═══════════ Hero ═══════════
+     Single column on mobile/tablet; split copy + product artifact at
+     >=1024 so the page reads as a product, not a thesis essay. */
   .hero{
     max-width:var(--page-max);margin:0 auto;
     padding:96px 40px 72px;
+    display:block;
+  }
+  .hero-copy{display:block}
+  @media (min-width: 1024px){
+    .hero{
+      display:grid;
+      grid-template-columns:minmax(0, 1.05fr) minmax(0, 1fr);
+      gap:64px;
+      align-items:center;
+    }
   }
   @media (max-width: 768px) {
     .hero { padding: 56px 22px 48px; }
@@ -826,6 +838,108 @@ html {
        text-wrap: balance can split "Institutional memory for revenue
        teams." cleanly without orphaning the orange <em>. */
     .h1 .soft { display: block; margin-top: .25em; }
+  }
+
+  /* Hero artifact — illustrative "memory accumulating" stack of
+     extracted call notes. No real backend. Cards stagger-fade in on
+     load; prefers-reduced-motion collapses the animation to instant. */
+  .hero-artifact{
+    margin-top:48px;
+    padding:0;
+    perspective:1200px;
+  }
+  @media (min-width: 1024px){
+    .hero-artifact{margin-top:0}
+  }
+  .hero-artifact-frame{
+    position:relative;
+    background:linear-gradient(180deg, var(--bg-2) 0%, var(--bg-3) 100%);
+    border:1px solid var(--hair-2);
+    border-radius:14px;
+    padding:24px;
+    box-shadow:
+      0 1px 0 rgba(255,255,255,.04) inset,
+      0 24px 60px -28px rgba(0,0,0,.5);
+    overflow:hidden;
+  }
+  .hero-artifact-frame::before{
+    content:"";position:absolute;
+    top:0;left:24px;right:24px;height:1px;
+    background:linear-gradient(90deg, var(--copper) 0%, var(--copper-a08) 30%, transparent 100%);
+  }
+  .hero-artifact-head{
+    display:flex;align-items:center;justify-content:space-between;
+    margin-bottom:18px;
+    font-family:'Geist Mono', SFMono-Regular, Consolas, monospace;
+    font-size:10.5px;letter-spacing:.16em;
+    text-transform:uppercase;
+  }
+  .hero-artifact-eb{color:var(--copper)}
+  .hero-artifact-pulse{
+    color:var(--ink-3);
+    display:inline-flex;align-items:center;gap:6px;
+  }
+  .hero-artifact-pulse::before{
+    content:"";width:6px;height:6px;border-radius:999px;
+    background:var(--copper);
+    box-shadow:0 0 0 4px var(--copper-a18);
+  }
+
+  .hero-artifact-stack{
+    list-style:none;margin:0;padding:0;
+    display:flex;flex-direction:column;gap:10px;
+  }
+  .hero-artifact-card{
+    background:rgba(255,255,255,.02);
+    border:1px solid var(--hair);
+    border-radius:10px;
+    padding:14px 16px;
+    transform-origin:top left;
+    opacity:0;
+    transform:translateY(8px);
+    animation:hero-artifact-in .55s ease-out forwards;
+    animation-delay:calc(.18s + var(--i, 0) * .14s);
+  }
+  .hero-artifact.is-reduced .hero-artifact-card{
+    animation:none;opacity:1;transform:none;
+  }
+  @keyframes hero-artifact-in{
+    to{opacity:1;transform:translateY(0)}
+  }
+  .hero-artifact-meta{
+    display:flex;gap:8px;align-items:center;flex-wrap:wrap;
+    font-family:'Geist Mono', SFMono-Regular, Consolas, monospace;
+    font-size:10.5px;letter-spacing:.14em;text-transform:uppercase;
+    color:var(--ink-3);
+    margin-bottom:8px;
+  }
+  .hero-artifact-meta .date{color:var(--copper)}
+  .hero-artifact-meta .sep{opacity:.5}
+  .hero-artifact-meta .conf{color:var(--ink-2)}
+  .hero-artifact-pain{
+    font-family:var(--font-display), 'Instrument Serif', serif;
+    font-size:15px;line-height:1.45;
+    color:var(--ink);font-style:italic;
+    margin:0 0 6px;
+  }
+  .hero-artifact-cite{
+    font-family:'Geist Mono', SFMono-Regular, Consolas, monospace;
+    font-size:11px;letter-spacing:.06em;
+    color:var(--ink-3);margin:0;
+  }
+
+  .hero-artifact-foot{
+    margin-top:18px;padding-top:14px;
+    border-top:1px solid var(--hair);
+    display:flex;align-items:center;gap:10px;
+    font-family:'Geist Mono', SFMono-Regular, Consolas, monospace;
+    font-size:10.5px;letter-spacing:.14em;text-transform:uppercase;
+    color:var(--ink-3);
+  }
+  .hero-artifact-foot .dot{
+    width:5px;height:5px;border-radius:999px;
+    background:var(--copper);
+    box-shadow:0 0 0 3px var(--copper-a18);
   }
   .hero-hairline{
     max-width:var(--page-max);margin:0 auto;

--- a/components/HeroArtifact.tsx
+++ b/components/HeroArtifact.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+interface CallNote {
+  id: string;
+  date: string;
+  kind: string;
+  pain: string;
+  cite: string;
+  conf?: string;
+}
+
+const CALLS: CallNote[] = [
+  {
+    id: 'apr-21',
+    date: 'Apr 21',
+    kind: 'Renewal',
+    pain: '"AE-to-CSM handoff lost the pricing context — third re-ask."',
+    cite: 'Priya Shah, VP Sales · 14:08',
+    conf: '0.92',
+  },
+  {
+    id: 'apr-14',
+    date: 'Apr 14',
+    kind: 'Discovery',
+    pain: '"Budget\u2019s tight, maybe twenty." (contradicts Apr 07)',
+    cite: 'Marcus Chen, Sales Ops · 27:04',
+    conf: '0.87',
+  },
+  {
+    id: 'apr-07',
+    date: 'Apr 07',
+    kind: 'Pre-call',
+    pain: '"Budget is fifty. Need it live by Q3."',
+    cite: 'Priya Shah, VP Sales · 18:02',
+    conf: '0.94',
+  },
+];
+
+function subscribeReducedMotion(callback: () => void) {
+  const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+  mq.addEventListener('change', callback);
+  return () => mq.removeEventListener('change', callback);
+}
+function getReducedMotion() {
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+export function HeroArtifact() {
+  const reduced = useSyncExternalStore(
+    subscribeReducedMotion,
+    getReducedMotion,
+    () => true,
+  );
+
+  return (
+    <div
+      className={`hero-artifact${reduced ? ' is-reduced' : ''}`}
+      aria-hidden="true"
+    >
+      <div className="hero-artifact-frame">
+        <div className="hero-artifact-head">
+          <span className="hero-artifact-eb">Acme Corp · live memory</span>
+          <span className="hero-artifact-pulse">3 calls indexed</span>
+        </div>
+        <ol className="hero-artifact-stack">
+          {CALLS.map((call, i) => (
+            <li
+              key={call.id}
+              className="hero-artifact-card"
+              style={{ ['--i' as string]: i }}
+            >
+              <div className="hero-artifact-meta">
+                <span className="date">{call.date}</span>
+                <span className="sep">·</span>
+                <span className="kind">{call.kind}</span>
+                {call.conf && (
+                  <>
+                    <span className="sep">·</span>
+                    <span className="conf">conf {call.conf}</span>
+                  </>
+                )}
+              </div>
+              <p className="hero-artifact-pain">{call.pain}</p>
+              <p className="hero-artifact-cite">{call.cite}</p>
+            </li>
+          ))}
+        </ol>
+        <div className="hero-artifact-foot">
+          <span className="dot" />
+          <span>Memory compounds with every call</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/sections/HeroSection.tsx
+++ b/components/sections/HeroSection.tsx
@@ -1,41 +1,46 @@
 'use client';
 
 import { openPilotModal } from '@/components/PilotModal';
+import { HeroArtifact } from '@/components/HeroArtifact';
 
 export function HeroSection() {
   return (
     <>
       <section className="hero">
-        <h1 className="h1">
-          Institutional memory for <em>revenue</em> teams.{' '}
-          <span className="soft">Not another call recorder.</span>
-        </h1>
+        <div className="hero-copy">
+          <h1 className="h1">
+            Institutional memory for <em>revenue</em> teams.{' '}
+            <span className="soft">Not another call recorder.</span>
+          </h1>
 
-        <p className="sub">
-          AI notetakers record what was said. Salency{' '}
-          <em style={{ fontStyle: 'normal', color: 'var(--copper)' }}>
-            remembers what it meant
-          </em>
-          , structuring every conversation into pains, objections, competitors
-          and commitments, then keeping that context alive as reps rotate and
-          accounts hand off.
-        </p>
+          <p className="sub">
+            AI notetakers record what was said. Salency{' '}
+            <em style={{ fontStyle: 'normal', color: 'var(--copper)' }}>
+              remembers what it meant
+            </em>
+            , structuring every conversation into pains, objections, competitors
+            and commitments, then keeping that context alive as reps rotate and
+            accounts hand off.
+          </p>
 
-        <div className="cta-row">
-          <button
-            type="button"
-            className="btn btn-primary"
-            onClick={() => openPilotModal()}
-          >
-            Request a pilot →
-          </button>
-          <button className="btn btn-ghost">Watch 90-second tour</button>
+          <div className="cta-row">
+            <button
+              type="button"
+              className="btn btn-primary"
+              onClick={() => openPilotModal()}
+            >
+              Request a pilot →
+            </button>
+            <button className="btn btn-ghost">Watch 90-second tour</button>
+          </div>
+
+          <div className="hero-meta">
+            <span className="hero-meta-item">Gong, Fireflies, Otter, Granola, Fathom, or any raw transcript</span>
+            <span className="hero-meta-item">Early access · <span className="num">Q2 2026</span></span>
+          </div>
         </div>
 
-        <div className="hero-meta">
-          <span className="hero-meta-item">Gong, Fireflies, Otter, Granola, Fathom, or any raw transcript</span>
-          <span className="hero-meta-item">Early access · <span className="num">Q2 2026</span></span>
-        </div>
+        <HeroArtifact />
       </section>
 
       <div className="hero-hairline" aria-hidden="true"></div>


### PR DESCRIPTION
## Summary

The `/` hero was text-only above the fold — Stripe-grade homepages pair hero copy with a tangible artifact, otherwise the page reads as a thesis essay rather than a product. Land an illustrative **"memory accumulating"** stack on the right at desktop ≥1024.

## What lands

**`HeroArtifact`** — illustrative card stack, no real backend.
- Top eyebrow: `ACME CORP · LIVE MEMORY` + pulsing `3 calls indexed`
- 3 stacked call-extraction cards, oldest at the bottom, newest on top:
  - Mono-caps meta row: `Apr 21 · Renewal · conf 0.92` (date in copper)
  - Italic verbatim pain quote (Instrument Serif)
  - Mono citation: `Priya Shah, VP Sales · 14:08`
- Footer line: `▪ Memory compounds with every call`

**Stagger fade-in animation** with `.14s` spacing (cards translate from `translateY(8px)` + opacity 0 → in-place + opacity 1).

**`prefers-reduced-motion` respected** via `useSyncExternalStore` (no `useEffect` setState — clean lint pass). When the user has reduce set, the `.is-reduced` modifier on the wrapper disables the animation entirely (no fade, no transform).

## Layout
- `<1024`: single column. Artifact stacks beneath copy with `margin-top: 48px`. Still appears at the top of the fold on tablet.
- `>=1024`: hero becomes a `1.05fr / 1fr` grid with `64px` gap, copy left, artifact right.

## Constraints met (from #188)
- ✅ `prefers-reduced-motion` respected
- ✅ No animation under reduced motion
- ✅ Doesn't double the hero scroll height (artifact lives in the same row at desktop, stacks beneath at tablet/mobile)
- ✅ No real product backend — illustrative card data is in `CALLS` constant inside the component

Closes #188.

## Test plan
- [ ] `/` at >=1024: hero is split, artifact renders right of the copy, vertical alignment center
- [ ] `/` at <1024: artifact stacks below copy
- [ ] Cards fade in with stagger on first paint, animation lasts ~.55s per card
- [ ] OS-level reduced motion: cards appear instantly, no fade
- [ ] Pulse dot on `3 calls indexed` and the foot dot render correctly with copper glow

🤖 Generated with [Claude Code](https://claude.com/claude-code)