### PR TITLE
design(home): differentiate the three Request-a-pilot CTAs (#192)

### DIFF
--- a/components/sections/CtaSection.tsx
+++ b/components/sections/CtaSection.tsx
@@ -22,7 +22,7 @@ export function CtaSection() {
             className="btn btn-primary"
             onClick={() => openPilotModal()}
           >
-            Request pilot access →
+            Apply to the Spring 2026 cohort →
           </button>
           <Link href="/investors#thesis" className="btn btn-ghost">
             Read our memory thesis

--- a/components/sections/HeroSection.tsx
+++ b/components/sections/HeroSection.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { openPilotModal } from '@/components/PilotModal';
 import { HeroArtifact } from '@/components/HeroArtifact';
 
@@ -31,7 +32,9 @@ export function HeroSection() {
             >
               Request a pilot →
             </button>
-            <button className="btn btn-ghost">Watch 90-second tour</button>
+            <Link href="/memory" className="btn btn-ghost">
+              See the memory layer →
+            </Link>
           </div>
 
           <div className="hero-meta">


### PR DESCRIPTION
## Summary

"Request a pilot" was firing 3 times on `/` within ~4000px of scroll — header CTA, hero primary, and closing CtaSection primary all using the same copy. Three identical CTAs without differentiation reduce the meaning of each one.

## What changes

| Surface | Before | After |
|---|---|---|
| Header CTA | Request a pilot → | Request a pilot → *(unchanged — gateway)* |
| Hero primary | Request a pilot → | Request a pilot → *(unchanged — high intent)* |
| Hero secondary | Watch 90-second tour | **See the memory layer →** *(Link to /memory)* |
| Closing primary | Request pilot access → | **Apply to the Spring 2026 cohort →** |

## Why these specific moves
- **"Watch 90-second tour" → "See the memory layer →"**: there's no actual tour video, and `/memory` is the highest-leverage explore destination from the hero. Trades a phantom CTA for a real one.
- **"Request pilot access" → "Apply to the Spring 2026 cohort"**: cohort-application framing differentiates the closing CTA from the gateway header/hero CTA — same destination (the pilot modal), different commitment register.

Header + hero primary intentionally still match — that's the standard gateway pattern (nav CTA + hero CTA aligned to keep scent). The win is removing one phantom CTA and reframing the closing.

Closes #192.

## Test plan
- [ ] `/` hero: secondary CTA is now a Link to `/memory` (not a button), reads "See the memory layer →"
- [ ] `/` closing CtaSection: primary button reads "Apply to the Spring 2026 cohort →" and still opens the pilot modal
- [ ] Header CTA unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)