### PR TITLE
content(investors): strip insider voice + drop nav exposure (#166)

### DIFF
--- a/components/MarketingHeader.tsx
+++ b/components/MarketingHeader.tsx
@@ -17,7 +17,6 @@ const links: NavLink[] = [
   { label: 'Memory', href: '/memory' },
   { label: 'Our story', href: '/our-story' },
   { label: 'Blog', href: '/blog' },
-  { label: 'Investors', href: '/investors' },
   { label: 'Pricing', href: '/pricing' },
 ];
 

--- a/components/sections/InvestorsSection.tsx
+++ b/components/sections/InvestorsSection.tsx
@@ -170,8 +170,7 @@ export function InvestorsSection() {
                   2025), Account Console (Feb 2026). Doesn&rsquo;t ship pain
                   &rarr; product matching against a customer-maintained
                   catalog (no Vault primitive) or cross-call contradiction
-                  detection. Historical base rate ~38% per 12-month window
-                  for competitor-parity ships.
+                  detection.
                 </span>
               </div>
               <div className="compete-row">
@@ -182,9 +181,8 @@ export function InvestorsSection() {
                 <span className="c-why">
                   <strong>12 month window.</strong> Frame AI acquisition (Dec
                   2024) and Smart Deal Progression (Apr 2026) put them ~12
-                  months from packaging the matching engine. The architecture-
-                  flat moat argument is retracted post-Frame AI. 200K
-                  customers, freemium.
+                  months from packaging the matching engine. 200K customers,
+                  freemium.
                 </span>
               </div>
               <div className="compete-row">
@@ -196,8 +194,7 @@ export function InvestorsSection() {
                   <strong>18&ndash;24 month window.</strong> Account Research
                   Agent (Dreamforce 2025), Data 360 customer graph, Agentforce
                   360. Recipe published in Architect docs but not packaged as
-                  a SKU. 150K customers. One Spring 2027 release-note bullet
-                  erases the wedge for that base.
+                  a SKU. 150K customers.
                 </span>
               </div>
               <div className="compete-row">


### PR DESCRIPTION
## Summary

Two related issues on `/investors`, shipped together:

1. **Compete-table contained insider/analyst-memo language** that only makes sense to someone who'd read prior internal docs. Three sentences dropped, capability substance kept.
2. **`/investors` removed from primary nav.** Page stays at `/investors`, still reachable from deck links, still in the footer.

## Changes

### Compete-table copy (`InvestorsSection.tsx`)

| Row | Dropped sentence | What stays |
|---|---|---|
| Gong | "Historical base rate ~38% per 12-month window for competitor-parity ships." | 12–18 month window + capability gap (no Vault primitive, no cross-call contradiction detection) |
| HubSpot | "The architecture-flat moat argument is retracted post-Frame AI." | 12 month window + Frame AI + Smart Deal Progression timing + 200K customers, freemium |
| Salesforce | "One Spring 2027 release-note bullet erases the wedge for that base." | 18–24 month window + Account Research Agent / Data 360 / Agentforce 360 + recipe/SKU distinction + 150K customers |

AskElephant + Clari/Salesloft rows already read clean — left alone.

### Global nav (`MarketingHeader.tsx`)

Dropped `{ label: 'Investors', href: '/investors' }` from the `links` array. Header nav goes from 7 items to 6. The same array drives the mobile panel, so one edit covers both surfaces.

## Acceptance

- ✅ No occurrence of "architecture-flat moat," "base rate," or "erases the wedge" anywhere in `components/sections/InvestorsSection.tsx`
- ✅ `/investors` no longer in `MarketingHeader` (desktop + mobile)
- ✅ Direct nav to `/investors` still renders the page (route still exists)
- ✅ `npm run build` + `npm run lint` clean

## Out of scope (per #166)

- Footer link to `/investors` — issue scoped footer audit out, leaving alone
- Broader voice rewrite of the platform/TAM/thesis sections of `/investors` — separate concern
- Removing the page itself or its metadata

Closes #166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)