### PR TITLE
fix: 308 apex→www redirect (promote to prod)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,12 @@ const nextConfig: NextConfig = {
   async redirects() {
     return [
       {
+        source: '/:path*',
+        has: [{ type: 'host', value: 'salency.ai' }],
+        destination: 'https://www.salency.ai/:path*',
+        permanent: true,
+      },
+      {
         source: '/investor',
         destination: '/#investors',
         permanent: true,


### PR DESCRIPTION
## Summary
Promotes `fix/gh-212/apex-permanent-redirect` from `test` (merged in #213) to `main`.

Fixes the GSC "Page with redirect" indexing failure by overriding Vercel's default 307 with a Next.js `permanent: true` redirect (308). Apex `salency.ai` → `www.salency.ai` now consolidates link equity properly and Google can index the canonical URLs.

Closes #212.

## Test plan
- [x] `npm run build` succeeds.
- [x] Verified on staging.
- [ ] After production deploy: `curl -sI https://salency.ai/` returns `HTTP/2 308` (not 307).
- [ ] Re-submit sitemap + register change-of-address in GSC.
- [ ] Request indexation on 3 top URLs.
- [ ] "Page with redirect" count drops to zero on next crawl (1-3 days).

🤖 Generated with [Claude Code](https://claude.com/claude-code)