### PR TITLE
content(pricing): explain redirect to pilot application

### DIFF
--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -15,6 +15,20 @@ export default function PricingPage() {
   return (
     <div className="page">
       <MarketingHeader />
+      {/* Reuses .inv-intro visual pattern (eyebrow + h1 + paragraph) — see globals.css:1882 */}
+      <div className="inv-intro">
+        <div className="inv-intro-inner">
+          <span className="eb">Pricing</span>
+          <h1>Per engagement, while we calibrate.</h1>
+          <p>
+            We&rsquo;re not publishing list prices yet. Pricing is set per
+            engagement while we calibrate with the Spring 2026 pilot cohort.
+            Apply for the pilot below and we&rsquo;ll share current terms in
+            the first conversation. Pilots run 4&ndash;6 weeks; pricing
+            post-pilot is set with you, based on what your team got out of it.
+          </p>
+        </div>
+      </div>
       <ScrollReveal><PilotApplication /></ScrollReveal>
       <SiteFooter />
     </div>


### PR DESCRIPTION
## Summary

`/pricing` was rendering `<PilotApplication />` directly with no context. User clicks "Pricing" expecting numbers or tiers, gets a form. Bait-and-switch feel.

Adds an intro block above the form explaining the redirect:
- No list prices yet
- Pricing set per engagement while we calibrate with the Spring 2026 pilot cohort
- Terms shared in first conversation
- 4–6 week pilots
- Post-pilot pricing set with the customer

Reuses existing `.inv-intro` CSS pattern (no new styles needed). Code comment documents the class reuse for future readers.

## Test plan

- [ ] `npm run dev` and navigate to `/pricing`
- [ ] Verify intro renders with eyebrow "Pricing" + h1 "Per engagement, while we calibrate." + paragraph
- [ ] Verify `<PilotApplication />` form renders below the intro, unchanged
- [ ] Mobile: intro doesn't push form off-screen, typography reflows correctly
- [ ] `/pilot` route is unchanged (we did not modify `<PilotApplication />` itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)