### PR TITLE
content(investors): copy hygiene + roadmap section removal

### DIFF
--- a/components/sections/HeroSection.tsx
+++ b/components/sections/HeroSection.tsx
@@ -39,7 +39,7 @@ export function HeroSection() {
 
           <div className="hero-meta">
             <span className="hero-meta-item">Gong, Fireflies, Otter, Granola, Fathom, or any raw transcript</span>
-            <span className="hero-meta-item">Early access · <span className="num">Q2 2026</span></span>
+            <span className="hero-meta-item">Now accepting pilot applications</span>
           </div>
         </div>
 

--- a/components/sections/InvestorsSection.tsx
+++ b/components/sections/InvestorsSection.tsx
@@ -248,63 +248,6 @@ export function InvestorsSection() {
             </Link>
           </section>
 
-          <section className="roadmap" id="roadmap">
-            <div className="eb">Roadmap</div>
-            <h2>
-              What ships <em>next.</em>
-            </h2>
-            <div className="horizon-list">
-              <div className="horizon">
-                <div className="horizon-head">
-                  <span className="pill">V1.5 · Q2–Q3 2026</span>
-                  <span className="label">Capture, without the upload step</span>
-                </div>
-                <ul className="horizon-body">
-                  <li>
-                    Recall.ai meeting bot, joining Zoom, Meet, Teams
-                    directly. Extraction runs without a transcript upload step.
-                  </li>
-                </ul>
-              </div>
-              <div className="horizon">
-                <div className="horizon-head">
-                  <span className="pill">Following · 2026 H2</span>
-                  <span className="label">Workflow depth</span>
-                </div>
-                <ul className="horizon-body">
-                  <li>
-                    Embedding pain-product mapping into product-management
-                    tools (Productboard, Aha, Jira), where the customer pain
-                    graph and the product roadmap converge. Pulled forward
-                    from 2027 after competitive-window analysis tightened the
-                    high-threat tier from 18 months to 12.
-                  </li>
-                  <li>
-                    Native integrations with the CRMs revenue teams already
-                    live in, scoped once each one ships a stable contract,
-                    not before.
-                  </li>
-                </ul>
-              </div>
-              <div className="horizon">
-                <div className="horizon-head">
-                  <span className="pill">Further out</span>
-                  <span className="label">Enterprise readiness + vertical expansion</span>
-                </div>
-                <ul className="horizon-body">
-                  <li>
-                    Security posture for regulated-vertical buyers (SOC 2 Type
-                    II audit kickoff post-bridge).
-                  </li>
-                  <li>
-                    Vertical expansion. First vertical: B2B SaaS. Next:
-                    FinTech.
-                  </li>
-                </ul>
-              </div>
-            </div>
-          </section>
-
           <section className="thesis" id="thesis">
             <div className="thesis-card">
               <div className="eb">Why now</div>

--- a/components/sections/InvestorsSection.tsx
+++ b/components/sections/InvestorsSection.tsx
@@ -62,11 +62,11 @@ export function InvestorsSection() {
             <p className="platform-moat-bridge">
               Vs CRM, the wedge is the shape of the data. Contradiction pairs,
               pain evolution over time, confidence-ranked pain → product
-              matches, cross-account pattern graphs. None of these fit a CRM
-              row. Flatten any of them into a field and you kill the thing
-              that makes Salency uncopyable. That&rsquo;s why we sit on top
-              of your stack, not inside it. Reps live in CRM
-              for pipeline stages. Reps live in Salency for the qualitative
+              matches, cross-account pattern graphs. CRM rows hold one value
+              per field; the graph holds rankings, timestamped citations, and
+              cross-call comparisons. Two layers, distinct shapes of data. We
+              sit on top of your stack, not inside it. Reps live in CRM for
+              pipeline stages. Reps live in Salency for the qualitative
               layer, what the customer actually said, what contradicts what,
               which pains map to which products.
             </p>
@@ -328,9 +328,9 @@ export function InvestorsSection() {
                 Every LLM commoditizes extraction. What doesn&rsquo;t
                 commoditize is the customer-built graph of pains, products,
                 and contradictions, and that graph compounds per account,
-                with every call. The moat is the specific join, pain →
-                product → contradiction across time, wired into the PM tools
-                where roadmaps already live.
+                with every call. The defensibility is the specific join, pain
+                → product → contradiction across time, wired into the PM
+                tools where roadmaps already live.
               </p>
               <div className="thesis-close">
                 Salency is building that layer. The longer a team runs it,

--- a/components/sections/NotDoSection.tsx
+++ b/components/sections/NotDoSection.tsx
@@ -34,8 +34,12 @@ export function NotDoSection() {
             <span className="check" aria-label="What it does">✓</span>
             <div className="subtitle">
               The pain-product graph, contradictions, and account memory live
-              on Salency by design. Flatten them into CRM rows and the moat
-              dissolves the same day.
+              on Salency. Each pain carries N ranked product matches with
+              confidences, two timestamped citations comparing what the
+              customer said in March vs June, and the verbatim quote behind
+              every signal. Pipeline stages, forecasts, and account assignments
+              stay where they belong — in your CRM. Two layers, distinct
+              shapes of data.
             </div>
           </div>
           <div className="notdo-item">


### PR DESCRIPTION
**Production PR.** Same diff as #215 (which already merged to `test`). Promotes those changes to production.

## Summary

Two changes on `/investors` + `/` (home):

### Change 1: Copy hygiene (3 sections)

Per memory rule (*"no captivity / lock-in framings on public site"*).

- **`NotDoSection.tsx`** — *"the moat dissolves the same day"* → descriptive coexistence framing (rankings + timestamped citations + cross-call comparisons).
- **`InvestorsSection.tsx`** — *"the thing that makes Salency uncopyable"* + *"the moat is the specific join"* → coexistence framing + *"defensibility"*.
- **`HeroSection.tsx`** — *"Early access · Q2 2026"* (stale, today is in Q2) → *"Now accepting pilot applications"*.

### Change 2: Remove `/investors` roadmap section

Stale (SOC 2 *"post-bridge"* references a retired bridge), wrong surface (detailed dated roadmap is deck territory not website territory), maintenance burden (strategy iterates weekly, section can't keep up). Detailed rationale on #215.

Other `/investors` sections (Platform & moat, Market, Competitive, Team, Thesis) carry the story without dated commitments.

## Test plan

- [ ] Already verified on staging via #215
- [ ] Production smoke after merge: `/`, `/investors`, hero meta render
- [ ] No 404s on `#roadmap` anchor (audit confirmed only the section itself referenced it)

## Related
- Staging PR (merged): #215
- Strategy context: `Project-Cerebro/context` repo, `company-context.md` §20.27 + §18

🤖 Generated with [Claude Code](https://claude.com/claude-code)