### PR TITLE
fix(our-story): remote-team factual accuracy

### DIFF
--- a/components/sections/OurStorySection.tsx
+++ b/components/sections/OurStorySection.tsx
@@ -55,9 +55,9 @@ export function OurStorySection() {
               First onboarding call for a new web3 game-studio customer at
               Sequence. By minute 15 the customer had said some version of{' '}
               <em>&ldquo;I already told your colleague this&rdquo;</em> three
-              times. The rep who closed the deal was two desks away. Nobody
-              had asked him to do a handover. The CRM had a stage field and a
-              one-line note.
+              times. The rep who closed the deal was one Slack message away.
+              Nobody had asked him to do a handover. The CRM had a stage field
+              and a one-line note.
             </p>
             <p>
               Howard had stopped thinking of that as a behavior problem months


### PR DESCRIPTION
## Summary

One-line factual fix: Sequence was a 100% remote company, so "the rep who closed the deal was two desks away" was wrong. Updated to "one Slack message away" to match the ProvenanceCard line on `/`.

Logged as a follow-up TODO during the PR #221 grilling — closing it out now since both surfaces should tell the same story.

## Test plan

- [ ] /our-story renders the new line
- [ ] Sentence flows naturally ("…three times. The rep who closed the deal was one Slack message away. Nobody had asked him to do a handover.")
- [ ] No layout regressions