### PR TITLE
fix(modal): portal TranscriptSnippetModal to body

### DIFF
--- a/components/TranscriptSnippetModal.tsx
+++ b/components/TranscriptSnippetModal.tsx
@@ -6,6 +6,7 @@
 // crossing the lib boundary.
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
 import {
   HUDSON_TERRACE_ARC,
@@ -116,7 +117,12 @@ export default function TranscriptSnippetModal() {
   const highlightLineIndex =
     detail.lineIdx ?? call.snippet.highlightLineIndex;
 
-  return (
+  // Portal to <body> so the fixed-position backdrop escapes any layout
+  // containers ancestors. The page wrapper has a `.page > *:not(header)
+  // { position:relative; z-index:1 }` rule (used to layer sections over
+  // the bg-noise/bg-mesh) that would otherwise pin this dialog into
+  // normal document flow once it became a direct child of .page in PR 1.
+  return createPortal(
     <div
       role="dialog"
       aria-modal="true"
@@ -205,6 +211,7 @@ export default function TranscriptSnippetModal() {
           </section>
         )}
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }


### PR DESCRIPTION
## Symptom

Clicking **"See the mapping engine →"** in MapStage (or any **"See full transcript →"** trigger inside HeroBrief) caused the transcript card to render at the **bottom of the page**, in normal document flow after the footer, instead of opening as a viewport-centered modal overlay.

## Root cause

`app/globals.css:200` has this layering rule:

```css
.page > *:not(header) { position: relative; z-index: 1 }
```

…which exists so every direct child of the page wrapper sits above the `bg-noise` / `bg-mesh` background layers.

PR #220 moved `<TranscriptSnippetModalLazy />` from `app/layout.tsx` into `<div className="page">` for page-scoping (closing autoplan finding E-1). That made the modal backdrop **a direct child of `.page`**, so the layering rule overrode its CSS:

| | Authored | Computed |
|---|---|---|
| `position` | `fixed` | `relative` |
| `z-index` | `100` | `1` |

`position: relative` means the dialog laid out in normal flow, after every other section, including `<SiteFooter />`. The viewport overlay never happened.

## Fix

Wrap the modal return in `createPortal(<dialog/>, document.body)`. The backdrop now mounts as a body child, escaping the `.page` selector entirely. Robust against any future containing-block creators (`transform`, `filter`, `contain`, `backdrop-filter`) on `.page` or its ancestors.

```tsx
// before
return (
  <div role="dialog" className="hero-artifact-modal-backdrop" ...>
    ...
  </div>
);

// after
return createPortal(
  <div role="dialog" className="hero-artifact-modal-backdrop" ...>
    ...
  </div>,
  document.body,
);
```

Modals canonically portal out of layout containers anyway. This should have been the original pattern.

## Verified

| Surface | Behavior |
|---|---|
| MapStage `See the mapping engine →` CTA | ✅ opens modal centered with pain → matches |
| HeroBrief citation pill → `See full transcript →` | ✅ opens modal with surrounding lines + matches |
| Esc key | ✅ closes |
| Backdrop click | ✅ closes |
| Focus return on close | ✅ works |

Computed style after fix: `position: fixed`, `z-index: 100`, `parentElement: BODY`, fills 1440×900 viewport.

Same fix benefits `/memory`, which mounts the same lazy modal under the same `.page` wrapper (same bug class).

## Test plan

- [ ] On `/`, click "See the mapping engine →" — modal opens centered, transcript visible
- [ ] On `/`, click any citation pill in HeroBrief, then click "See full transcript →" — modal opens
- [ ] Esc closes the modal
- [ ] Click outside the panel closes the modal
- [ ] On `/memory`, click any HeroArtifact card — modal opens correctly
- [ ] No console errors / no hydration warnings on any route