### PR TITLE
a11y(contrast): bump --ink-3 to clear WCAG AA on small mono text

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -158,7 +158,7 @@ html {
     --hair-2: rgba(232,230,227,0.14);
     --ink: #E8E6E3;
     --ink-2: #B6B4B0;
-    --ink-3: #7C7A77;
+    --ink-3: #8A8884;
     --ink-4: #4E4C4A;
     /* Salency warm ramp — from uploaded palette */
     --copper: #FE8531;          /* primary accent */


### PR DESCRIPTION
## Summary

Audited every text element <14px on `/` against its alpha-composited background. Found 16 unique violations all sharing the same root: `--ink-3` (`#7C7A77`, rgb 124,122,119) computed to **4.14–4.39:1** on bg-2 / bg-3 surfaces. WCAG AA body text needs **≥4.5:1**.

## Affected surfaces

| Class | Size | Surface | Ratio |
|---|---:|---|---:|
| `.hub-output-sub` | 11.5px | bg-3 | 4.14 |
| `.map-pain-cite` | 10px | bg-2/3 | 4.36–4.39 |
| `.map-match-score` | 10.5px | bg-2/3 | 4.36–4.39 |
| `.map-match-role` | 9.5px | bg-3 | 4.39 |
| `.recall-pair-cite` | 10.5px | bg-3 | 4.39 |

## Fix

Bump the token from `#7C7A77` to `#8A8884` (rgb 138,136,132). Lifts every fail above 4.5 — lowest now ~4.77 on bg-3, ~5.19 on bg-2. The token is shared across **93 callsites**; one-line change preserves visual hierarchy (still reads as "tertiary text" against `--ink` and `--ink-2`).

## Verified

- ✅ Re-audited the / homepage with the same alpha-composited contrast script: **0 fails** post-bump.
- ✅ Visual hierarchy preserved (screenshots compared on HeroBrief, MapStage, RecallStage).
- ✅ `npm run build` clean, `npm run lint` clean.

Builds on PR #224 which fixed heading hierarchy + accessible names. Backlog item closed for *"copper-on-tint contrast verification at 11px Geist Mono"*.