### PR TITLE
fix(why-salency): bulletproof CRM vs Salency comparisons (7 fixes)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4665,7 +4665,9 @@ header button:focus:not(:focus-visible){
   50%      { box-shadow: 0 0 0 4px rgba(255, 90, 90, 0.12); }
 }
 
-/* 11. Lost-in-overwrite reveal panel ───────────────────────────────── */
+/* 11. CRM-gap reveal panel — three failure modes (overwrite/no-link/no-field).
+   All share base layout. Strikethrough fires only for overwrite, since
+   no-link/no-field aren't destructive — they're CRM limitations.        */
 .crm-overwrite {
   margin-top: 8px;
   padding: 9px 11px;
@@ -4690,12 +4692,25 @@ header button:focus:not(:focus-visible){
   color: #E89A8E;
   margin-bottom: 6px;
 }
+.crm-overwrite .lost-row {
+  margin-bottom: 6px;
+}
+.crm-overwrite .lost-row:last-of-type {
+  margin-bottom: 0;
+}
+.crm-overwrite .lost-row + .lost-row {
+  padding-top: 6px;
+  border-top: 1px dashed rgba(255, 90, 90, 0.14);
+}
 .crm-overwrite .lost-line {
   font-family: var(--font-body), 'Instrument Sans', system-ui, sans-serif;
   font-style: italic;
   color: #E89A8E;
   font-size: 12px;
   margin: 0 0 3px;
+}
+/* Strikethrough only on the overwrite kind — the line is genuinely erased. */
+.crm-overwrite.is-overwrite .lost-line {
   text-decoration: line-through;
   text-decoration-color: rgba(255, 90, 90, 0.5);
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -4746,15 +4746,30 @@ header button:focus:not(:focus-visible){
 }
 .crm-overwrite .lost-line {
   font-family: var(--font-body), 'Instrument Sans', system-ui, sans-serif;
-  font-style: italic;
-  color: #E89A8E;
   font-size: 12px;
   margin: 0 0 3px;
 }
-/* Strikethrough only on the overwrite kind — the line is genuinely erased. */
+/* Overwrite + no-link kinds are showing actual customer speech that
+   either got erased or stored without relationships. Italic-red reads
+   as "verbatim quote with a problem." */
+.crm-overwrite.is-overwrite .lost-line,
+.crm-overwrite.is-no-link .lost-line {
+  font-style: italic;
+  color: #E89A8E;
+}
+/* Overwrite kind also gets strikethrough — the line is genuinely erased. */
 .crm-overwrite.is-overwrite .lost-line {
   text-decoration: line-through;
   text-decoration-color: rgba(255, 90, 90, 0.5);
+}
+/* No-field kind is showing structured pain records (categories, not
+   speech). Style as labels, not quotes — non-italic, ink-2 color, with
+   a subtle copper tint on the data category to call out the structure. */
+.crm-overwrite.is-no-field .lost-line {
+  font-style: normal;
+  color: var(--ink);
+  font-weight: 500;
+  letter-spacing: -0.005em;
 }
 .crm-overwrite .lost-meta {
   font-size: 9.5px;

--- a/app/globals.css
+++ b/app/globals.css
@@ -4699,26 +4699,40 @@ header button:focus:not(:focus-visible){
   border-radius: 2px;
   display: inline-block;
 }
-/* Brief flash on the eyebrow when the reveal expands so the new content is
-   noticed even when the auto-scroll only nudges the pane a few pixels. */
+/* Punchy flash on the eyebrow + reveal-panel border on expand so the new
+   content is noticed even when auto-scroll only nudges a few pixels. The
+   key prop on .crm-overwrite (in DiffPairViewer.tsx) forces React to remount
+   on state transitions, guaranteeing the keyframe restarts cleanly. */
 .crm-overwrite.is-shown .lost-eb {
-  animation: lost-eb-flash 600ms ease-out;
+  animation: lost-eb-flash 800ms ease-out;
 }
 @keyframes lost-eb-flash {
   0% {
-    background: rgba(255, 90, 90, 0.22);
-    color: #FFC7BD;
+    background: rgba(255, 90, 90, 0.40);
+    color: #FFE4DC;
+    box-shadow: 0 0 0 0 rgba(255, 90, 90, 0.5);
   }
-  60% {
-    background: rgba(255, 90, 90, 0.10);
+  30% {
+    background: rgba(255, 90, 90, 0.32);
+    color: #FFD2C5;
+    box-shadow: 0 0 0 4px rgba(255, 90, 90, 0.18);
   }
   100% {
     background: transparent;
     color: #E89A8E;
+    box-shadow: 0 0 0 0 rgba(255, 90, 90, 0);
   }
 }
+.crm-overwrite.is-shown {
+  animation: signal-in 240ms ease-out, gap-reveal-glow 800ms ease-out;
+}
+@keyframes gap-reveal-glow {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(255, 90, 90, 0); }
+  35%      { box-shadow: 0 0 18px -2px rgba(255, 90, 90, 0.32); }
+}
 @media (prefers-reduced-motion: reduce) {
-  .crm-overwrite.is-shown .lost-eb { animation: none; }
+  .crm-overwrite.is-shown .lost-eb,
+  .crm-overwrite.is-shown { animation: none; }
 }
 .crm-overwrite .lost-row {
   margin-bottom: 6px;

--- a/app/globals.css
+++ b/app/globals.css
@@ -4694,7 +4694,31 @@ header button:focus:not(:focus-visible){
   letter-spacing: 0.16em;
   text-transform: uppercase;
   color: #E89A8E;
-  margin-bottom: 6px;
+  margin: 0 -4px 6px;
+  padding: 2px 4px;
+  border-radius: 2px;
+  display: inline-block;
+}
+/* Brief flash on the eyebrow when the reveal expands so the new content is
+   noticed even when the auto-scroll only nudges the pane a few pixels. */
+.crm-overwrite.is-shown .lost-eb {
+  animation: lost-eb-flash 600ms ease-out;
+}
+@keyframes lost-eb-flash {
+  0% {
+    background: rgba(255, 90, 90, 0.22);
+    color: #FFC7BD;
+  }
+  60% {
+    background: rgba(255, 90, 90, 0.10);
+  }
+  100% {
+    background: transparent;
+    color: #E89A8E;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .crm-overwrite.is-shown .lost-eb { animation: none; }
 }
 .crm-overwrite .lost-row {
   margin-bottom: 6px;

--- a/app/globals.css
+++ b/app/globals.css
@@ -4276,7 +4276,11 @@ header button:focus:not(:focus-visible){
 .diff-stage {
   max-width: var(--page-max);
   margin: 0 auto;
-  padding: 18px 40px 56px;
+  /* 20px horizontal so the artifact (max-width 1240) can fill 1280 - 40
+     and preserve the locked 1.72:1 aspect ratio at 720 height. The rest
+     of the page stays on the 40px rail; the artifact intentionally
+     breaks out by 20px each side as the hero. */
+  padding: 18px 20px 56px;
 }
 @media (max-width: 768px) {
   .diff-stage { padding: 12px 22px 40px; }
@@ -4293,14 +4297,14 @@ header button:focus:not(:focus-visible){
   overflow: hidden;
   position: relative;
   width: 100%;
-  max-width: 1100px;
+  max-width: 1240px;
   height: 720px;
   max-height: calc(100vh - 140px);
   margin: 0 auto;
   display: flex;
   flex-direction: column;
 }
-@media (max-width: 1140px) {
+@media (max-width: 1280px) {
   .window-chrome { max-width: 100%; }
 }
 @media (max-width: 880px) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -4294,8 +4294,8 @@ header button:focus:not(:focus-visible){
   position: relative;
   width: 100%;
   max-width: 1100px;
-  height: 640px;
-  max-height: calc(100vh - 180px);
+  height: 720px;
+  max-height: calc(100vh - 140px);
   margin: 0 auto;
   display: flex;
   flex-direction: column;

--- a/components/sections/DiffPairViewer.tsx
+++ b/components/sections/DiffPairViewer.tsx
@@ -119,25 +119,66 @@ interface CrmFoot {
   text?: string;
 }
 
-interface OverwritePayload {
-  lostLine: string;
-  lostMeta: string;
+// CRM fails in three distinct ways across the arc. Each state declares which
+// failure mode it demonstrates; the badge, the reveal label, and the visual
+// treatment (strikethrough vs not) all key off this.
+type GapKind = 'overwrite' | 'no-link' | 'no-field';
+
+interface GapRow {
+  line: string;
+  meta: string;
+}
+
+interface CrmGapPayload {
+  kind: GapKind;
+  rows: GapRow[];
   comment: string;
 }
 
 interface DiffState {
   crmNotes: string;
   crmFoot: CrmFoot;
-  overwrite: OverwritePayload | null;
+  gap: CrmGapPayload | null;
   signals: SignalCardSpec[];
 }
 
+const GAP_BADGE: Record<GapKind, string> = {
+  'overwrite': `${CROSS} overwrites`,
+  'no-link': '\u26A0 no link',
+  'no-field': '\u26A0 no field',
+};
+
+const GAP_LABEL: Record<GapKind, string> = {
+  'overwrite': 'Lost in this overwrite',
+  'no-link': 'What CRM can\u2019t connect',
+  'no-field': 'What CRM has no field for',
+};
+
+const GAP_CUE: Record<GapKind, { closed: string; open: string }> = {
+  'overwrite': {
+    closed: `${ARROW_DOWN} Click to see what was overwritten`,
+    open: `${ARROW_UP} Click to collapse`,
+  },
+  'no-link': {
+    closed: `${ARROW_DOWN} Click to see what isn\u2019t linked`,
+    open: `${ARROW_UP} Click to collapse`,
+  },
+  'no-field': {
+    closed: `${ARROW_DOWN} Click to see what has no schema home`,
+    open: `${ARROW_UP} Click to collapse`,
+  },
+};
+
 const STATES: Record<number, DiffState> = {
-  // 0: Maya framing question (no extraction)
+  // 0: Maya framing question. CRM still carries the stale March note from
+  // before the pricing call started. Salency stays quiet.
   0: {
-    crmNotes: '"Where are we on the commercial side?"',
-    crmFoot: { hidden: true },
-    overwrite: null,
+    crmNotes: '"3-5s settlement delays during vol windows. follow up commercial."',
+    crmFoot: {
+      hidden: false,
+      text: `Mar 09 entry ${MIDDOT} not yet updated this call.`,
+    },
+    gap: null,
     signals: [
       {
         name: 'Context only',
@@ -149,14 +190,21 @@ const STATES: Record<number, DiffState> = {
       },
     ],
   },
-  // 1: DEFAULT, the contradiction line
+  // 1: DEFAULT, the contradiction line. CRM gets overwritten in place,
+  // erasing the original March pain. Salency keeps both citations and
+  // flags the delta.
   1: {
     crmNotes: '"gotten used to it. not main thing anymore."',
     crmFoot: { hidden: false, text: `${CROSS} Mar 09 pain overwritten Apr 06.` },
-    overwrite: {
-      lostLine:
-        '"3 to 5 second settlement delays, killing us during volatility windows."',
-      lostMeta: `Daniel Voss ${MIDDOT} Mar 09 ${MIDDOT} 00:01:28 ${MIDDOT} stored in this same notes field`,
+    gap: {
+      kind: 'overwrite',
+      rows: [
+        {
+          line:
+            '"three to five seconds of settlement delay on our internal transfers, and that\u2019s killing us during volatility windows."',
+          meta: `Daniel Voss ${MIDDOT} Mar 09 ${MIDDOT} 00:01:28 ${MIDDOT} this same notes field`,
+        },
+      ],
       comment:
         'The pain that drove the deal in March is gone from this CRM record. Salency keeps it cited and contradicted, not erased.',
     },
@@ -212,7 +260,7 @@ const STATES: Record<number, DiffState> = {
       },
       {
         name: `Pain ${ARROW} product`,
-        status: 'still queued',
+        status: 'still ranked',
         flagged: false,
         title: (
           <>
@@ -227,13 +275,13 @@ const STATES: Record<number, DiffState> = {
             label: 'match',
             body: (
               <>
-                {`3-5s settlement delays ${MIDDOT} primary ${MIDDOT} confidence `}
-                <span className="copper">high</span>
+                {`3-5s settlement delays ${MIDDOT} primary ${MIDDOT} `}
+                <span className="copper">0.96 confidence</span>
               </>
             ),
           },
         ],
-        foot: 'Pain doesn\u2019t disappear when the rep adapts. The match stays queued.',
+        foot: 'Pain doesn\u2019t disappear when the rep adapts. The match stays ranked.',
         detail: {
           ctx: [
             {
@@ -246,11 +294,15 @@ const STATES: Record<number, DiffState> = {
       },
     ],
   },
-  // 2: Maya followup probe
+  // 2: Maya followup probe. CRM unchanged from state 1 (questions don't
+  // trigger CRM updates). Salency stays quiet on follow-up prompts.
   2: {
-    crmNotes: '"Interesting. What changed?"',
-    crmFoot: { hidden: true },
-    overwrite: null,
+    crmNotes: '"gotten used to it. not main thing anymore."',
+    crmFoot: {
+      hidden: false,
+      text: `Apr 06 entry ${MIDDOT} unchanged from previous line.`,
+    },
+    gap: null,
     signals: [
       {
         name: 'Context only',
@@ -262,18 +314,30 @@ const STATES: Record<number, DiffState> = {
       },
     ],
   },
-  // 3: Trader workflow adjustment
+  // 3: Trader workflow adjustment. CRM stores the new line but cannot
+  // connect it to the underlying pain (call-001) or to the trader as a
+  // stakeholder. The failure mode is "no link", not "overwrite".
   3: {
     crmNotes: '"trader workflow adjusted, pre-positions margin"',
     crmFoot: {
       hidden: false,
-      text: `${CROSS} Note doesn\u2019t link to the original pain or to the trader stakeholder.`,
+      text: `${CROSS} New line stored. No link to the related pain or stakeholder.`,
     },
-    overwrite: {
-      lostLine: '"trader workflow adjusted, pre-positions margin"',
-      lostMeta: `Apr 06 entry ${MIDDOT} 88 chars`,
+    gap: {
+      kind: 'no-link',
+      rows: [
+        {
+          line:
+            '"three to five seconds of settlement delay on our internal transfers..."',
+          meta: `related pain ${MIDDOT} call-001 ${MIDDOT} 00:01:28 ${MIDDOT} stored as separate note, no relation`,
+        },
+        {
+          line: '"They yell at me. Not joking."',
+          meta: `head trader ${MIDDOT} call-001 ${MIDDOT} 00:01:56 ${MIDDOT} no stakeholder field, no relation`,
+        },
+      ],
       comment:
-        'CRM stores the line. It can\u2019t link this to the underlying pain or to the trader stakeholder. Two related signals, no relationship.',
+        'Three related facts across two calls. CRM stores them as flat strings with no relationship. Salency links the workaround to the pain it compensates for and to the person who drove it.',
     },
     signals: [
       {
@@ -315,25 +379,39 @@ const STATES: Record<number, DiffState> = {
         rows: [
           {
             label: 'role',
-            body: `Daniel Voss\u2019s direct report ${MIDDOT} referenced 4 times across calls`,
+            body: `Daniel Voss\u2019s direct report ${MIDDOT} mentioned across both calls`,
           },
         ],
         foot: 'Salency tracks people Daniel mentions, not just attendees of the call.',
       },
     ],
   },
-  // 4: Pain ranking
+  // 4: Pain ranking. Daniel's "list" statement implies an ordered priority
+  // across the account's pains. CRM has no priority/ranking field type, so
+  // even if the rep typed it, there's no schema home for the order. The
+  // failure mode is "no field", not "overwrite". The rebalance only cites
+  // pains that actually appear in the arc (latency from call-001 and MAS
+  // Singapore from call-002).
   4: {
     crmNotes: '"latency on the list but not the top"',
     crmFoot: {
       hidden: false,
-      text: `${CROSS} "List" is referenced. CRM has no list field.`,
+      text: `${CROSS} "List" is referenced. CRM has no priority field.`,
     },
-    overwrite: {
-      lostLine: '"latency on the list but not the top"',
-      lostMeta: `Apr 06 ${MIDDOT} references a "list" CRM has no field for`,
+    gap: {
+      kind: 'no-field',
+      rows: [
+        {
+          line: 'Latency · 3-5s settlement delays',
+          meta: `call-001 ${MIDDOT} Mar 09 ${MIDDOT} stored as a pain with no rank`,
+        },
+        {
+          line: 'MAS Singapore · Q4 deadline',
+          meta: `call-002 ${MIDDOT} Mar 23 ${MIDDOT} stored as an objection with no rank`,
+        },
+      ],
       comment:
-        'Daniel\u2019s ranking statement implies a 3-pain priority list. CRM has no representation; Salency rebalances the account\u2019s pain weights.',
+        'Two pains tracked across the arc. Daniel\u2019s "list" statement reorders them: MAS now urgent, latency demoted. CRM has no priority field, so the order has no place to live. Salency stores ranked weights as first-class data.',
     },
     signals: [
       {
@@ -344,14 +422,14 @@ const STATES: Record<number, DiffState> = {
         rows: [
           {
             label: 'before',
-            body: `Latency #1 (Mar 09) ${MIDDOT} Reconciliation #2 ${MIDDOT} MAS #3`,
+            body: `Latency #1 (Mar 09) ${MIDDOT} MAS Singapore #2 (Mar 23)`,
           },
           {
             label: 'after',
-            body: `Reconciliation #1 ${MIDDOT} MAS #2 ${MIDDOT} Latency #3`,
+            body: `MAS Singapore #1 ${MIDDOT} Latency #2`,
           },
         ],
-        foot: `Same pains, new weights ${MIDDOT} auto-rebalanced from explicit ranking statement.`,
+        foot: `Same two pains, new weights ${MIDDOT} rebalanced from Daniel\u2019s ranking statement.`,
       },
     ],
   },
@@ -431,7 +509,7 @@ export function DiffPairViewer() {
       setRenderState(STATES[idx]);
       setSwapKey((k) => k + 1);
       const next = STATES[idx];
-      if (next.overwrite) {
+      if (next.gap) {
         setPulseBadge(true);
         window.setTimeout(() => setPulseBadge(false), 1200);
       }
@@ -572,13 +650,13 @@ export function DiffPairViewer() {
                 </div>
                 <button
                   type="button"
-                  className={`crm-row notes${overwriteOpen ? ' is-expanded' : ''}${renderState.overwrite ? '' : ' is-quiet'}`}
+                  className={`crm-row notes${overwriteOpen ? ' is-expanded' : ''}${renderState.gap ? '' : ' is-quiet'}`}
                   onClick={() => {
-                    if (!renderState.overwrite) return;
+                    if (!renderState.gap) return;
                     setOverwriteOpen((v) => !v);
                   }}
                   aria-expanded={overwriteOpen}
-                  aria-disabled={renderState.overwrite ? 'false' : 'true'}
+                  aria-disabled={renderState.gap ? 'false' : 'true'}
                 >
                   <span className="crm-key">
                     notes
@@ -588,10 +666,12 @@ export function DiffPairViewer() {
                   </span>
                   <span className="crm-val-col">
                     <span
-                      className={`crm-overwrite-badge${renderState.overwrite ? '' : ' is-hidden'}${pulseBadge ? ' is-pulse' : ''}`}
-                      aria-hidden={renderState.overwrite ? 'false' : 'true'}
+                      className={`crm-overwrite-badge${renderState.gap ? ` is-${renderState.gap.kind}` : ' is-hidden'}${pulseBadge ? ' is-pulse' : ''}`}
+                      aria-hidden={renderState.gap ? 'false' : 'true'}
                     >
-                      {`${CROSS} overwrites`}
+                      {renderState.gap
+                        ? GAP_BADGE[renderState.gap.kind]
+                        : ''}
                     </span>
                     <span
                       key={swapKey}
@@ -599,28 +679,30 @@ export function DiffPairViewer() {
                     >
                       {renderState.crmNotes}
                     </span>
-                    {renderState.overwrite ? (
+                    {renderState.gap ? (
                       <span className="crm-expand-cue" aria-hidden="true">
                         {overwriteOpen
-                          ? '\u2191 Click to collapse'
-                          : '\u2193 Click to see what was overwritten'}
+                          ? GAP_CUE[renderState.gap.kind].open
+                          : GAP_CUE[renderState.gap.kind].closed}
                       </span>
                     ) : null}
                   </span>
                 </button>
               </div>
-              {renderState.overwrite ? (
+              {renderState.gap ? (
                 <div
-                  className={`crm-overwrite${overwriteOpen ? ' is-shown' : ''}`}
+                  className={`crm-overwrite is-${renderState.gap.kind}${overwriteOpen ? ' is-shown' : ''}`}
                   role="region"
-                  aria-label="Lost in this overwrite"
+                  aria-label={GAP_LABEL[renderState.gap.kind]}
                 >
-                  <div className="lost-eb">Lost in this overwrite</div>
-                  <p className="lost-line">{renderState.overwrite.lostLine}</p>
-                  <p className="lost-meta">{renderState.overwrite.lostMeta}</p>
-                  <div className="lost-comment">
-                    {renderState.overwrite.comment}
-                  </div>
+                  <div className="lost-eb">{GAP_LABEL[renderState.gap.kind]}</div>
+                  {renderState.gap.rows.map((r, ri) => (
+                    <div className="lost-row" key={ri}>
+                      <p className="lost-line">{r.line}</p>
+                      <p className="lost-meta">{r.meta}</p>
+                    </div>
+                  ))}
+                  <div className="lost-comment">{renderState.gap.comment}</div>
                 </div>
               ) : null}
               {!renderState.crmFoot.hidden ? (

--- a/components/sections/DiffPairViewer.tsx
+++ b/components/sections/DiffPairViewer.tsx
@@ -739,6 +739,11 @@ export function DiffPairViewer() {
               </div>
               {renderState.gap ? (
                 <div
+                  // Key includes activeIdx + overwriteOpen so React remounts
+                  // when the user re-expands on a new state. Forces the flash
+                  // animation to restart cleanly instead of being preserved
+                  // mid-progress across state-to-state transitions.
+                  key={`gap-${activeIdx}-${overwriteOpen}`}
                   ref={overwriteRef}
                   className={`crm-overwrite is-${renderState.gap.kind}${overwriteOpen ? ' is-shown' : ''}`}
                   role="region"

--- a/components/sections/DiffPairViewer.tsx
+++ b/components/sections/DiffPairViewer.tsx
@@ -488,11 +488,27 @@ export function DiffPairViewer() {
   // page) by walking up to the nearest .pane ancestor.
   const overwriteRef = useRef<HTMLDivElement | null>(null);
   const cardRefs = useRef<Array<HTMLElement | null>>([]);
+  // Refs for both the CRM pane and the Salency pane. When the user changes
+  // transcript state, we reset both panes' scrollTop so each new expand
+  // starts from a known (top) position. Without this, the pane retains the
+  // prior state's scroll, which makes the auto-scroll math conclude "already
+  // in view" on the next expand and skip the visual cue.
+  const crmPaneRef = useRef<HTMLDivElement | null>(null);
+  const salencyPaneRef = useRef<HTMLDivElement | null>(null);
 
   const totalCallsLine = useMemo(
     () => `Tracked across ${HUDSON_TERRACE_ARC.length} calls`,
     [],
   );
+
+  // Reset both panes' scrollTop on every transcript state change so each new
+  // expand on the new state starts from a known top position. Without this,
+  // a prior-state auto-scroll leaves scrollTop > 0, and the next expand's
+  // math concludes "already in view" and skips the visual cue.
+  useEffect(() => {
+    if (crmPaneRef.current) crmPaneRef.current.scrollTop = 0;
+    if (salencyPaneRef.current) salencyPaneRef.current.scrollTop = 0;
+  }, [activeIdx]);
 
   // Scroll the parent pane (not the page) so an expanded element is visible.
   // Uses scrollTop math instead of scrollIntoView to avoid the document also
@@ -666,7 +682,7 @@ export function DiffPairViewer() {
             </div>
 
             {/* CRM pane */}
-            <div className="pane crm-pane">
+            <div ref={crmPaneRef} className="pane crm-pane">
               <div className="pane-eb">
                 {`CRM record `}
                 <span className="meta">{` ${MIDDOT} #4128`}</span>
@@ -765,7 +781,7 @@ export function DiffPairViewer() {
             </div>
 
             {/* Salency pane */}
-            <div className="pane salency-pane">
+            <div ref={salencyPaneRef} className="pane salency-pane">
               <div className="pane-eb">
                 {`Memory layer`}
                 <span className="meta">

--- a/components/sections/DiffPairViewer.tsx
+++ b/components/sections/DiffPairViewer.tsx
@@ -28,7 +28,7 @@
 //     anchored to call-001 (the Mar 09 Discovery where the pain was raised)
 //     and passes call-001's matches array as-is.
 
-import { useMemo, useRef, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import {
   HUDSON_TERRACE_ARC,
   getCallById,
@@ -482,11 +482,59 @@ export function DiffPairViewer() {
   // pre-swap window. CSS transitions on .is-outgoing handle the fade.
   const [outgoing, setOutgoing] = useState(false);
   const tlineRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  // Refs for the CRM gap reveal panel and the Salency signal cards. When the
+  // user expands either, we scroll the parent pane so the new content is in
+  // view without forcing a manual scroll. Only scrolls the pane (not the
+  // page) by walking up to the nearest .pane ancestor.
+  const overwriteRef = useRef<HTMLDivElement | null>(null);
+  const cardRefs = useRef<Array<HTMLElement | null>>([]);
 
   const totalCallsLine = useMemo(
     () => `Tracked across ${HUDSON_TERRACE_ARC.length} calls`,
     [],
   );
+
+  // Scroll the parent pane (not the page) so an expanded element is visible.
+  // Uses scrollTop math instead of scrollIntoView to avoid the document also
+  // scrolling when the artifact itself is partially below the fold.
+  useEffect(() => {
+    if (!overwriteOpen || !overwriteRef.current) return;
+    const el = overwriteRef.current;
+    const pane = el.closest('.pane') as HTMLElement | null;
+    if (!pane) return;
+    const reduceMotion = window.matchMedia(
+      '(prefers-reduced-motion: reduce)',
+    ).matches;
+    const elBottom = el.offsetTop + el.offsetHeight;
+    const paneBottom = pane.scrollTop + pane.clientHeight;
+    if (elBottom > paneBottom) {
+      pane.scrollTo({
+        top: elBottom - pane.clientHeight + 16,
+        behavior: reduceMotion ? 'auto' : 'smooth',
+      });
+    }
+  }, [overwriteOpen]);
+
+  useEffect(() => {
+    if (expanded.size === 0) return;
+    const reduceMotion = window.matchMedia(
+      '(prefers-reduced-motion: reduce)',
+    ).matches;
+    expanded.forEach((idx) => {
+      const el = cardRefs.current[idx];
+      if (!el) return;
+      const pane = el.closest('.pane') as HTMLElement | null;
+      if (!pane) return;
+      const elBottom = el.offsetTop + el.offsetHeight;
+      const paneBottom = pane.scrollTop + pane.clientHeight;
+      if (elBottom > paneBottom) {
+        pane.scrollTo({
+          top: elBottom - pane.clientHeight + 16,
+          behavior: reduceMotion ? 'auto' : 'smooth',
+        });
+      }
+    });
+  }, [expanded]);
 
   const onSelectLine = (idx: number) => {
     if (idx === activeIdx) return;
@@ -691,6 +739,7 @@ export function DiffPairViewer() {
               </div>
               {renderState.gap ? (
                 <div
+                  ref={overwriteRef}
                   className={`crm-overwrite is-${renderState.gap.kind}${overwriteOpen ? ' is-shown' : ''}`}
                   role="region"
                   aria-label={GAP_LABEL[renderState.gap.kind]}
@@ -727,6 +776,9 @@ export function DiffPairViewer() {
                   return (
                     <article
                       key={`${swapKey}-${i}`}
+                      ref={(el) => {
+                        cardRefs.current[i] = el;
+                      }}
                       className={`signal-card is-new${sig.flagged ? ' is-flagged' : ''}${isExpanded ? ' is-expanded' : ''}`}
                       style={{ animationDelay: `${i * 60}ms` }}
                     >

--- a/components/sections/DiffPairViewer.tsx
+++ b/components/sections/DiffPairViewer.tsx
@@ -510,25 +510,22 @@ export function DiffPairViewer() {
     if (salencyPaneRef.current) salencyPaneRef.current.scrollTop = 0;
   }, [activeIdx]);
 
-  // Scroll the parent pane (not the page) so an expanded element is visible.
-  // Uses scrollTop math instead of scrollIntoView to avoid the document also
-  // scrolling when the artifact itself is partially below the fold.
+  // On expand: scroll the parent pane to its very bottom so the reveal
+  // (and the crm-foot beneath it) are guaranteed visible. Simpler than
+  // computing minimum-required scroll, and produces the same generous
+  // downward motion across every state — no math edge cases. Only scrolls
+  // the pane (not the page) by walking up to the nearest .pane ancestor.
   useEffect(() => {
     if (!overwriteOpen || !overwriteRef.current) return;
-    const el = overwriteRef.current;
-    const pane = el.closest('.pane') as HTMLElement | null;
+    const pane = overwriteRef.current.closest('.pane') as HTMLElement | null;
     if (!pane) return;
     const reduceMotion = window.matchMedia(
       '(prefers-reduced-motion: reduce)',
     ).matches;
-    const elBottom = el.offsetTop + el.offsetHeight;
-    const paneBottom = pane.scrollTop + pane.clientHeight;
-    if (elBottom > paneBottom) {
-      pane.scrollTo({
-        top: elBottom - pane.clientHeight + 16,
-        behavior: reduceMotion ? 'auto' : 'smooth',
-      });
-    }
+    pane.scrollTo({
+      top: pane.scrollHeight,
+      behavior: reduceMotion ? 'auto' : 'smooth',
+    });
   }, [overwriteOpen]);
 
   useEffect(() => {
@@ -541,14 +538,10 @@ export function DiffPairViewer() {
       if (!el) return;
       const pane = el.closest('.pane') as HTMLElement | null;
       if (!pane) return;
-      const elBottom = el.offsetTop + el.offsetHeight;
-      const paneBottom = pane.scrollTop + pane.clientHeight;
-      if (elBottom > paneBottom) {
-        pane.scrollTo({
-          top: elBottom - pane.clientHeight + 16,
-          behavior: reduceMotion ? 'auto' : 'smooth',
-        });
-      }
+      pane.scrollTo({
+        top: pane.scrollHeight,
+        behavior: reduceMotion ? 'auto' : 'smooth',
+      });
     });
   }, [expanded]);
 


### PR DESCRIPTION
## Summary

Deep audit of the diff-pair viewer surfaced 7 issues where the CRM vs Salency comparisons either weren't airtight, contained a fabricated pain, paraphrased while in quotes, or used one badge for three different CRM failure modes. All fixed.

## Audit findings + fixes

| # | Issue | Fix |
|---|-------|-----|
| A | One ✕ OVERWRITES badge fired for three distinct CRM failure modes (overwrite, no-link, no-field) | Three badges keyed off `gap.kind`. Reveal label + click cue + strikethrough swap accordingly |
| B | State 4 cited "Reconciliation #2" pain that doesn't exist in arc.ts (honesty-boundary violation) | Drop fabricated pain. Use only latency (call-001) and MAS Singapore (call-002) — the two pains that trace |
| C | States 0/2 showed Maya's questions as CRM notes (made CRM look like a notetaker) | Replace with stale carry-over from Mar 09 note (state 0) and unchanged-from-prev-line (state 2) |
| D | State 1 lostLine was paraphrased but in quote marks | Verbatim from `lib/synthetic-arc/arc.ts` call-001 line 1 |
| E | Stakeholder card claimed "referenced 4 times" — arc has 3 references | Drop the count, frame as "mentioned across both calls" |
| F | States 3/4 reveal panel was showing the same line as crmNotes (no real diff) | Per-kind reveal panels: no-link shows the related pain + stakeholder that exist in OTHER call records with no relationship to this one; no-field shows the two ranked pains and their lack of priority field |
| G | Pain → Product card said "confidence high" instead of citing arc.ts's explicit 0.96 | Cite 0.96 verbatim |

## Schema change

Replaced `OverwritePayload` (overwrite-only) with `CrmGapPayload` (kind discriminator + multi-row support). All three failure modes share base styling; only `is-overwrite` gets strikethrough on the lost line. New CRM-failure mode = one entry in three module-scope constants (`GAP_BADGE`, `GAP_LABEL`, `GAP_CUE`), not three scattered conditionals.

## Test plan
- [x] State 0: badge hidden, CRM shows Mar 09 carry-over, Salency = "Context only"
- [x] State 1: ✕ overwrites, "Lost in this overwrite" panel, verbatim arc quote, strikethrough on
- [x] State 2: badge hidden, CRM unchanged from state 1, Salency = "Context only"
- [x] State 3: ⚠ no link, "What CRM can't connect" panel, 2 rows (pain + stakeholder), no strikethrough
- [x] State 4: ⚠ no field, "What CRM has no field for" panel, 2 ranked pains (latency + MAS), no strikethrough
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [ ] Manual click-through on Vercel preview after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)