### PR TITLE
Pull unbuilt cross-account search claim from /memory

### DIFF
--- a/components/sections/MemorySection.tsx
+++ b/components/sections/MemorySection.tsx
@@ -34,12 +34,6 @@ const COMPARE_ROWS = [
     crm: 'One value per field, no ranking',
     salency: 'Confidence-ranked, top-N per pain',
   },
-  {
-    signal: 'Pattern across accounts',
-    crm: 'CSV export to a spreadsheet',
-    salency:
-      'Search \u201csettlement delay\u201d, every account that flagged it surfaces',
-  },
 ];
 
 export function MemorySection() {


### PR DESCRIPTION
## What
Removes the 'Pattern across accounts' row from the /memory CRM-compare table.

## Why
The row claimed Salency lets you search a signal ("settlement delay") and surface every account that flagged it. **Cross-account signal search is not built** and is deferred Post-V1 in the product. It was the loudest capability claim on the page and the one most likely to be tested in a pilot, so it read as oversell.

The three remaining rows (customer pain, contradiction between calls, pain to product fit) all trace to shipped behavior, restoring the file's own stated honesty boundary ("every artifact below traces to … No fictional names").

## Follow-ups (separate)
- cerebro-frontend#508 tracks building cross-account search (backend index + FE surface). When it ships, the row can come back, true.
- 'Change delta' signal (in DiffPairViewer + memory-signal-schema) is also not yet built — leaving it on the page; filing a build issue to make it true rather than gut the interactive demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)